### PR TITLE
Changed line tool so it activates by pressing shift after last draw

### DIFF
--- a/Scripts/SelectionRectangle.gd
+++ b/Scripts/SelectionRectangle.gd
@@ -61,6 +61,10 @@ func _process(delta : float) -> void:
 				Global.canvas.update_texture(Global.canvas.current_layer_index)
 			tex.create_from_image(img, 0)
 			update()
+			
+			# Makes line2d invisible
+			if weakref(Global.canvas.line_2d).get_ref():	# Checks to see if line_2d object still exists
+				Global.canvas.line_2d.default_color = Color(0, 0, 0, 0)
 	else:
 		get_parent().get_parent().mouse_default_cursor_shape = Input.CURSOR_ARROW
 
@@ -98,6 +102,10 @@ func _process(delta : float) -> void:
 					Global.selected_pixels.append(Vector2(xx, yy))
 
 			Global.canvas.handle_redo("Rectangle Select") #Redo
+			
+			# Makes line2d visible
+			if weakref(Global.canvas.line_2d).get_ref():	# Checks to see if line_2d object still exists
+				Global.canvas.line_2d.default_color = Color.darkgray
 
 	#Handle copy
 	if Input.is_action_just_pressed("copy") && Global.selected_pixels.size() > 0:


### PR DESCRIPTION
Made it so the line tool works like how it does in GIMP. This is how I personally prefer the line tool, and I'm making this pull request in case it would be preferred by others as well.

Now, instead of holding shift before drawing, you hold shift at any time after you draw and it will show the line. From here it works like normal, where you click and it will draw in the line. The position the line is drawn from is updated every time you draw.

I also made it so the line is invisible while dragging a selection.

NOTE: I am not too familiar with the undo and redo system. So this version of the line tool currently does not revert to being drawn from previous positions when undoing.