### PR TITLE
Write each language name in the target language

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -1582,7 +1582,7 @@ margin_left = 61.0
 margin_right = 142.0
 margin_bottom = 21.0
 text = "System Language"
-items = [ "System Language", null, false, 0, null, "German [de]", null, false, 1, null, "Greek [el]", null, false, 2, null, "English [en]", null, false, 3, null, "French [fr]", null, false, 4, null, "Polish [pl]", null, false, 5, null ]
+items = [ "System Language", null, false, 0, null, "Deutsch [de]", null, false, 1, null, "Ελληνικά [el]", null, false, 2, null, "English [en]", null, false, 3, null, "Français [fr]", null, false, 4, null, "Polski [pl]", null, false, 5, null ]
 selected = 0
 
 [node name="GridOptionsLabel" type="Label" parent="PreferencesDialog/VBoxContainer"]

--- a/Translations/#Translations.csv
+++ b/Translations/#Translations.csv
@@ -51,11 +51,6 @@ Grid options,Grid options,Επιλογές πλέγματος,Configuration de l
 Color:,Color:,Χρώμα:,Couleur :,Farbe:,Kolor:
 Language:,Language:,Γλώσσα:,Langue :,Sprache:,Język:
 System Language,System Language,Γλώσσα Συστήματος,Langue système,System Sprache,Język systemowy
-English [en],English [en],Αγγλικά [en],Anglais [en],Englisch [en],Angielski [en]
-German [de],German [de],Γερμανικά [de],allemand [de],Deutsch [de],Niemiecki [de]
-Greek [el],Greek [el],Ελληνικά [el],Grec [el],Griechisch [el],Grecki [el]
-French [fr],French [fr],Γαλλικά [fr],Français [fr],Französisch [fr],Francuski [fr]
-Polish [pl],Polish [pl],Πολωνικά [pl],Polonaise [pl],Polnische [pl],Polski [pl]
 About Pixelorama,About Pixelorama,Σχετικά με το Pixelorama,À propos de Pixelorama,Über Pixelorama,O Pixeloramie
 MADEBY_LABEL,Your Free and Open Source Sprite Editor!\nDeveloped by Orama Interactive\n,Το δωρεάν και ανοιχτού κώδικα πρόγραμμά σας!\nΦτιαγμένο από την Orama Interactive\n,Votre éditeur de sprites libre et open source\nDéveloppé par Orama Interactive\n,Ihr kostenloser und opensource Pixeleditor!\nEntwickelt von Orama Interactive\n,Twój darmowy edytor Sprite-ów na otwartej licencji!\nTworzony przez: Orama Interactive\n
 Website,Website,Ιστοσελίδα,Site Web,Website,Strona internetowa


### PR DESCRIPTION
In a language selection menu, languge names should be written in the target language so that they can be easily understood by those speaking the language.

This also removes the need for individual translations to supply their own strings for every language name.