### PR TITLE
Use the `2D` framebuffer allocation

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -223,5 +223,7 @@ locale_filter=[ 0, [  ] ]
 [rendering]
 
 quality/driver/driver_name="GLES2"
+quality/intended_usage/framebuffer_allocation=0
+quality/intended_usage/framebuffer_allocation.mobile=0
 vram_compression/import_etc=true
 vram_compression/import_etc2=false


### PR DESCRIPTION
This results in slightly increased performance and decreased CPU/GPU usage.

This also prevents the "Directional shadow buffer status invalid" error message from appearing in the console output when using a very old graphics card.