### PR TITLE
added option to hide tool icons next to cursor

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -269,7 +269,6 @@ text = "[64×64]"
 align = 2
 
 [node name="UI" type="HBoxContainer" parent="MenuAndUI"]
-editor/display_folded = true
 margin_top = 28.0
 margin_right = 1152.0
 margin_bottom = 648.0
@@ -278,7 +277,6 @@ size_flags_vertical = 3
 custom_constants/separation = 0
 
 [node name="ToolPanel" type="Panel" parent="MenuAndUI/UI"]
-editor/display_folded = true
 margin_right = 224.0
 margin_bottom = 620.0
 rect_min_size = Vector2( 224, 0 )
@@ -420,7 +418,6 @@ button_mask = 3
 texture_normal = ExtResource( 9 )
 
 [node name="ColorAndToolOptions" type="VBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools"]
-editor/display_folded = true
 margin_top = 159.0
 margin_right = 208.0
 margin_bottom = 612.0
@@ -510,13 +507,12 @@ size_flags_vertical = 3
 
 [node name="ToolOptions" type="VBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer"]
 margin_right = 208.0
-margin_bottom = 312.0
+margin_bottom = 352.0
 size_flags_horizontal = 3
 
 [node name="LeftToolOptions" type="VBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions"]
-editor/display_folded = true
 margin_right = 208.0
-margin_bottom = 150.0
+margin_bottom = 170.0
 
 [node name="LeftLabel" type="Label" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions"]
 margin_right = 208.0
@@ -533,11 +529,17 @@ mouse_default_cursor_shape = 2
 pressed = true
 text = "Left pixel indicator"
 
-[node name="LeftBrushType" type="HBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions"]
-editor/display_folded = true
+[node name="LeftToolIconCheckbox" type="CheckBox" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions"]
 margin_top = 39.0
 margin_right = 208.0
-margin_bottom = 71.0
+margin_bottom = 55.0
+text = "Show tool icon"
+
+[node name="LeftBrushType" type="HBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions"]
+editor/display_folded = true
+margin_top = 59.0
+margin_right = 208.0
+margin_bottom = 91.0
 
 [node name="LeftBrushTypeButton" type="TextureButton" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushType"]
 margin_right = 36.0
@@ -564,9 +566,9 @@ text = "Brush: Pixel"
 
 [node name="LeftBrushSize" type="VBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions"]
 editor/display_folded = true
-margin_top = 75.0
+margin_top = 95.0
 margin_right = 208.0
-margin_bottom = 111.0
+margin_bottom = 131.0
 
 [node name="BrushSizeLabel" type="Label" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushSize"]
 margin_right = 208.0
@@ -725,9 +727,9 @@ selected = 0
 
 [node name="LeftMirroring" type="VBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions"]
 editor/display_folded = true
-margin_top = 115.0
+margin_top = 135.0
 margin_right = 208.0
-margin_bottom = 150.0
+margin_bottom = 170.0
 
 [node name="Label" type="Label" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftMirroring"]
 margin_right = 208.0
@@ -755,15 +757,14 @@ mouse_default_cursor_shape = 2
 text = "Vertical"
 
 [node name="HSeparator" type="HSeparator" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions"]
-margin_top = 154.0
+margin_top = 174.0
 margin_right = 208.0
-margin_bottom = 158.0
+margin_bottom = 178.0
 
 [node name="RightToolOptions" type="VBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions"]
-editor/display_folded = true
-margin_top = 162.0
+margin_top = 182.0
 margin_right = 208.0
-margin_bottom = 312.0
+margin_bottom = 352.0
 
 [node name="RightLabel" type="Label" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions"]
 margin_right = 208.0
@@ -779,11 +780,17 @@ hint_tooltip = "RIGHT_INDIC_HT"
 mouse_default_cursor_shape = 2
 text = "Right pixel indicator"
 
-[node name="RightBrushType" type="HBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions"]
-editor/display_folded = true
+[node name="RightToolIconCheckbox" type="CheckBox" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions"]
 margin_top = 39.0
 margin_right = 208.0
-margin_bottom = 71.0
+margin_bottom = 55.0
+text = "Show tool icon"
+
+[node name="RightBrushType" type="HBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions"]
+editor/display_folded = true
+margin_top = 59.0
+margin_right = 208.0
+margin_bottom = 91.0
 
 [node name="RightBrushTypeButton" type="TextureButton" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushType"]
 margin_right = 36.0
@@ -810,9 +817,9 @@ text = "Brush: Pixel"
 
 [node name="RightBrushSize" type="VBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions"]
 editor/display_folded = true
-margin_top = 75.0
+margin_top = 95.0
 margin_right = 208.0
-margin_bottom = 111.0
+margin_bottom = 131.0
 
 [node name="BrushSizeLabel" type="Label" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushSize"]
 margin_right = 208.0
@@ -972,9 +979,9 @@ selected = 1
 
 [node name="RightMirroring" type="VBoxContainer" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions"]
 editor/display_folded = true
-margin_top = 115.0
+margin_top = 135.0
 margin_right = 208.0
-margin_bottom = 150.0
+margin_bottom = 170.0
 
 [node name="Label" type="Label" parent="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightMirroring"]
 margin_right = 208.0
@@ -1010,6 +1017,7 @@ size_flags_horizontal = 3
 custom_constants/separation = 0
 
 [node name="HViewportContainer" type="HBoxContainer" parent="MenuAndUI/UI/CanvasAndTimeline"]
+editor/display_folded = true
 margin_right = 704.0
 margin_bottom = 478.0
 size_flags_horizontal = 3
@@ -1067,6 +1075,7 @@ enabled_focus_mode = 0
 script = ExtResource( 15 )
 
 [node name="ViewportContainer" type="ViewportContainer" parent="MenuAndUI/UI/CanvasAndTimeline/HViewportContainer/ViewportAndRulers/HSplitContainer/ViewportandVerticalRuler"]
+editor/display_folded = true
 margin_left = 16.0
 margin_right = 692.0
 margin_bottom = 462.0
@@ -1740,8 +1749,8 @@ resizable = true
 mode = 0
 access = 2
 filters = PoolStringArray( "*.pxo ; Pixelorama Project" )
-current_dir = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama"
-current_path = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama/"
+current_dir = "/home/henlo-birb/Documents/godot/Pixelorama"
+current_path = "/home/henlo-birb/Documents/godot/Pixelorama/"
 
 [node name="SaveSprite" type="FileDialog" parent="."]
 anchor_left = 0.5
@@ -1756,12 +1765,16 @@ window_title = "Save Sprite as .pxo"
 resizable = true
 access = 2
 filters = PoolStringArray( "*.pxo ; Pixelorama Project" )
-current_dir = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama"
-current_path = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama/"
+current_dir = "/home/henlo-birb/Documents/godot/Pixelorama"
+current_path = "/home/henlo-birb/Documents/godot/Pixelorama/"
 
 [node name="ImportSprites" parent="." instance=ExtResource( 61 )]
+current_dir = "/home/henlo-birb/Documents/godot/Pixelorama"
+current_path = "/home/henlo-birb/Documents/godot/Pixelorama/"
 
 [node name="ExportSprites" parent="." instance=ExtResource( 62 )]
+current_dir = "/home/henlo-birb/Documents/godot/Pixelorama"
+current_path = "/home/henlo-birb/Documents/godot/Pixelorama/"
 
 [node name="ScaleImage" parent="." instance=ExtResource( 63 )]
 
@@ -1791,8 +1804,8 @@ visible = false
 
 [node name="PaletteImportFileDialog" parent="." instance=ExtResource( 69 )]
 filters = PoolStringArray( "*.json ; JavaScript Object Notation", "*.gpl ; Gimp Palette Library" )
-current_dir = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama"
-current_path = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama/"
+current_dir = "/home/henlo-birb/Documents/godot/Pixelorama"
+current_path = "/home/henlo-birb/Documents/godot/Pixelorama/"
 
 [node name="AnimationTimer" type="Timer" parent="."]
 
@@ -1810,6 +1823,7 @@ visible = false
 [connection signal="pressed" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ColorButtonsVertical/ColorPickersCenter/ColorPickersHorizontal/RightColorPickerButton" to="." method="_can_draw_false"]
 [connection signal="pressed" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ColorButtonsVertical/ColorDefaultsCenter/ColorDefaults" to="." method="_on_ColorDefaults_pressed"]
 [connection signal="toggled" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftIndicatorCheckbox" to="." method="_on_LeftIndicatorCheckbox_toggled"]
+[connection signal="toggled" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftToolIconCheckbox" to="." method="_on_LeftToolIconCheckbox_toggled"]
 [connection signal="pressed" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushType/LeftBrushTypeButton" to="." method="_on_LeftBrushTypeButton_pressed"]
 [connection signal="value_changed" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushSize/HBoxContainer/LeftBrushSizeSlider" to="." method="_on_LeftBrushSizeEdit_value_changed"]
 [connection signal="value_changed" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushSize/HBoxContainer/LeftBrushSizeEdit" to="." method="_on_LeftBrushSizeEdit_value_changed"]
@@ -1823,6 +1837,7 @@ visible = false
 [connection signal="toggled" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftMirroring/LeftMirrorButtons/LeftHorizontalMirroring" to="." method="_on_LeftHorizontalMirroring_toggled"]
 [connection signal="toggled" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftMirroring/LeftMirrorButtons/LeftVerticalMirroring" to="." method="_on_LeftVerticalMirroring_toggled"]
 [connection signal="toggled" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightIndicatorCheckbox" to="." method="_on_RightIndicatorCheckbox_toggled"]
+[connection signal="toggled" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightToolIconCheckbox" to="." method="_on_RightToolIconCheckbox_toggled"]
 [connection signal="pressed" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushType/RightBrushTypeButton" to="." method="_on_RightBrushTypeButton_pressed"]
 [connection signal="value_changed" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushSize/HBoxContainer/RightBrushSizeSlider" to="." method="_on_RightBrushSizeEdit_value_changed"]
 [connection signal="value_changed" from="MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushSize/HBoxContainer/RightBrushSizeEdit" to="." method="_on_RightBrushSizeEdit_value_changed"]

--- a/Scripts/Canvas.gd
+++ b/Scripts/Canvas.gd
@@ -153,8 +153,10 @@ func _input(event : InputEvent) -> void:
 			if !cursor_inside_canvas:
 				cursor_inside_canvas = true
 				Input.set_custom_mouse_cursor(load("res://Assets/Graphics/Cursor.png"), 0, Vector2(15, 15))
-				Global.left_cursor.visible = true
-				Global.right_cursor.visible = true
+				if Global.show_left_tool_icon:
+					Global.left_cursor.visible = true
+				if Global.show_right_tool_icon:
+					Global.right_cursor.visible = true
 		else:
 			if !Input.is_mouse_button_pressed(BUTTON_LEFT) && !Input.is_mouse_button_pressed(BUTTON_RIGHT):
 				if mouse_inside_canvas:

--- a/Scripts/Global.gd
+++ b/Scripts/Global.gd
@@ -46,6 +46,10 @@ var current_left_tool := "Pencil"
 # warning-ignore:unused_class_variable
 var current_right_tool := "Eraser"
 # warning-ignore:unused_class_variable
+var show_left_tool_icon := false
+# warning-ignore:unused_class_variable
+var show_right_tool_icon := false
+# warning-ignore:unused_class_variable
 var left_square_indicator_visible := true
 # warning-ignore:unused_class_variable
 var right_square_indicator_visible := false

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -622,6 +622,12 @@ func _on_LeftIndicatorCheckbox_toggled(button_pressed) -> void:
 func _on_RightIndicatorCheckbox_toggled(button_pressed) -> void:
 	Global.right_square_indicator_visible = button_pressed
 
+func _on_LeftToolIconCheckbox_toggled(button_pressed) -> void:
+	Global.show_left_tool_icon = button_pressed
+
+func _on_RightToolIconCheckbox_toggled(button_pressed) -> void:
+	Global.show_right_tool_icon = button_pressed
+
 func _on_LeftBrushTypeButton_pressed() -> void:
 	Global.brushes_popup.popup(Rect2(Global.left_brush_type_button.rect_global_position, Vector2(226, 72)))
 	Global.brush_type_window_position = "left"

--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -346,6 +346,9 @@ msgstr ""
 msgid "RIGHT_INDIC_HT"
 msgstr ""
 
+msgid "Show tool icon"
+msgstr ""
+
 msgid "Right pixel indicator"
 msgstr ""
 

--- a/Translations/de.po
+++ b/Translations/de.po
@@ -388,6 +388,9 @@ msgstr "Rechte Werkzeugoptionen"
 msgid "Left pixel indicator"
 msgstr "Linke Pixelanzeige"
 
+msgid "Show tool icon"
+msgstr "Werkzeugsymbol anzeigen"
+
 msgid "LEFT_INDIC_HT"
 msgstr ""
 "Zeige linkes Mausicon oder Pinsel auf der Leinwand wenn gezeichnet wird"

--- a/Translations/el.po
+++ b/Translations/el.po
@@ -385,6 +385,9 @@ msgstr "Επιλογές δεξιού εργαλείου"
 msgid "Left pixel indicator"
 msgstr "Δείκτης αριστερού πιξελ"
 
+msgid "Show tool icon"
+msgstr "Εμφάνιση εικονιδίου εργαλείου"
+
 msgid "LEFT_INDIC_HT"
 msgstr ""
 "Εμφάνιση δείκτη για το εικονοστοιχείο ή το πινέλο πάνω στον καμβά που "

--- a/Translations/en.po
+++ b/Translations/en.po
@@ -381,6 +381,9 @@ msgstr "Right tool options"
 msgid "Left pixel indicator"
 msgstr "Left pixel indicator"
 
+msgid "Show tool icon"
+msgstr "Show tool icon"
+
 msgid "LEFT_INDIC_HT"
 msgstr "Show left mouse pixel indicator or brush on the canvas when drawing"
 

--- a/Translations/fr.po
+++ b/Translations/fr.po
@@ -399,6 +399,9 @@ msgstr "Options de l'outil droit"
 msgid "Left pixel indicator"
 msgstr "Indicateur de pixel gauche"
 
+msgid "Show tool icon"
+msgstr "Afficher l'icône de l'outil"
+
 msgid "LEFT_INDIC_HT"
 msgstr ""
 "Affiche un indicateur de pixel ou de brosse pour l'outil gauche lorsque vous "

--- a/Translations/it.po
+++ b/Translations/it.po
@@ -382,6 +382,9 @@ msgstr "Opzioni dello strumento destro"
 msgid "Left pixel indicator"
 msgstr "Indicatore pixel strumento sinistro"
 
+msgid "Show tool icon"
+msgstr "Mostra icona strumento"
+
 msgid "LEFT_INDIC_HT"
 msgstr ""
 "Mostra l'indicatore pixel del mouse sinistro o il pennello sul canvas quando "

--- a/Translations/pl.po
+++ b/Translations/pl.po
@@ -393,6 +393,9 @@ msgstr "Opcje prawego narzędzia"
 msgid "Left pixel indicator"
 msgstr "Wskaźnik lewego pędzla"
 
+msgid "Show tool icon"
+msgstr "Pokaż ikonę narzędzia"
+
 msgid "LEFT_INDIC_HT"
 msgstr "Wyświetl wskaźnik lewego narzędzia lub pędzla podczas rysowania"
 

--- a/Translations/pt_BR.po
+++ b/Translations/pt_BR.po
@@ -386,6 +386,9 @@ msgstr "Opções da ferramente direita"
 msgid "Left pixel indicator"
 msgstr "Pixel indicador esquerdo"
 
+msgid "Show tool icon"
+msgstr "Mostrar ícone da ferramenta"
+
 msgid "LEFT_INDIC_HT"
 msgstr ""
 "Mostrar o indicador pixel do mouse esquerdo ou o pincel na tela quando "

--- a/Translations/ru.po
+++ b/Translations/ru.po
@@ -393,6 +393,9 @@ msgstr "Настройки правого инструмента"
 msgid "Left pixel indicator"
 msgstr "Цвет для ЛКМ"
 
+msgid "Show tool icon"
+msgstr "Показать значок инструмента"
+
 msgid "LEFT_INDIC_HT"
 msgstr "Отображать цвет кисти для ЛКМ во время рисования"
 

--- a/Translations/zh_TW.po
+++ b/Translations/zh_TW.po
@@ -380,6 +380,9 @@ msgstr "右鍵工具選項"
 msgid "Left pixel indicator"
 msgstr "左鍵工具準心"
 
+msgid "Show tool icon"
+msgstr "顯示工具圖標"
+
 msgid "LEFT_INDIC_HT"
 msgstr "在畫布上顯示左鍵工具"
 


### PR DESCRIPTION

Fixes #122 

implemented using checkboxes  in the the left and right tool options panels

![image](https://user-images.githubusercontent.com/10779186/72229563-9c702200-357d-11ea-9137-392bd7f4210c.png)


translations are done using google translate, so they should be checked by translators