### PR TITLE
Hide presets in ColorPickers

### DIFF
--- a/Scripts/Dialogs/OutlineDialog.gd
+++ b/Scripts/Dialogs/OutlineDialog.gd
@@ -1,5 +1,8 @@
 extends ConfirmationDialog
 
+func _ready() -> void:
+	$OptionsContainer/OutlineColor.get_picker().presets_visible = false
+
 func _on_OutlineDialog_confirmed() -> void:
 	var outline_color : Color = $OptionsContainer/OutlineColor.color
 	var thickness : int = $OptionsContainer/ThickValue.value

--- a/Scripts/Dialogs/PreferencesDialog.gd
+++ b/Scripts/Dialogs/PreferencesDialog.gd
@@ -82,6 +82,10 @@ func _ready() -> void:
 		Global.default_fill_color = fill_color
 		default_fill_color.color = Global.default_fill_color
 
+	$"HSplitContainer/ScrollContainer/VBoxContainer/Grid&Guides/GridOptions/GridColor".get_picker().presets_visible = false
+	$"HSplitContainer/ScrollContainer/VBoxContainer/Grid&Guides/GridOptions/GridColor".get_picker().presets_visible = false
+	$HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions/DefaultFillColor.get_picker().presets_visible = false
+
 func _on_PreferencesDialog_about_to_show(changed_language := false) -> void:
 	var root := tree.create_item()
 	var general_button := tree.create_item(root)

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -165,6 +165,9 @@ func _ready() -> void:
 
 	Import.import_brushes("Brushes")
 
+	$MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ColorButtonsVertical/ColorPickersCenter/ColorPickersHorizontal/LeftColorPickerButton.get_picker().presets_visible = false
+	$MenuAndUI/UI/ToolPanel/Tools/ColorAndToolOptions/ColorButtonsVertical/ColorPickersCenter/ColorPickersHorizontal/RightColorPickerButton.get_picker().presets_visible = false
+
 	if not Global.config_cache.has_section_key("preferences", "startup"):
 		Global.config_cache.set_value("preferences", "startup", true)
 	if not Global.config_cache.get_value("preferences", "startup"):

--- a/Scripts/Palette/EditPalettePopup.gd
+++ b/Scripts/Palette/EditPalettePopup.gd
@@ -11,6 +11,9 @@ onready var palette_grid = $VBoxContainer/HBoxContainer/Panel/ScrollContainer/Ed
 onready var color_name_edit = $VBoxContainer/PaletteOptions/EditPaletteColorNameLineEdit
 onready var palette_name_edit = $VBoxContainer/PaletteOptions/EditPaletteNameLineEdit
 
+func _ready() -> void:
+	$VBoxContainer/HBoxContainer/EditPaletteColorPicker.presets_visible = false
+
 func open(palette : String) -> void:
 	current_palette = palette
 	palette_name_edit.text = current_palette


### PR DESCRIPTION
As their presets aren't saved, and for the canvas itself there's the palette system for that, they being visible is mostly pointless and creates noise.

Note that the "Add" button will still be visible due to a bug in Godot itself. It will be fixed with https://github.com/godotengine/godot/pull/36235 in a later release.