### PR TITLE
Add palette import from a PNG file

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -1478,7 +1478,7 @@ visible = false
 [node name="NewPaletteDialog" parent="." instance=ExtResource( 52 )]
 
 [node name="PaletteImportFileDialog" parent="." instance=ExtResource( 53 )]
-filters = PoolStringArray( "*.json ; JavaScript Object Notation", "*.gpl ; Gimp Palette Library" )
+filters = PoolStringArray( "*.json ; JavaScript Object Notation", "*.gpl ; Gimp Palette Library", "*.png; Portable Network Graphics" )
 current_dir = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama"
 current_path = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama/"
 

--- a/Scripts/Import.gd
+++ b/Scripts/Import.gd
@@ -87,3 +87,33 @@ func import_gpl(path : String) -> Palette:
 		file.close()
 
 	return result
+
+func import_png_palette(path: String) -> Palette:
+	var result: Palette = null
+
+	var image := Image.new()
+	var err := image.load(path)
+	if err != OK: # An error occured
+		return null
+
+	var height: int = image.get_height()
+	var width: int = image.get_width()
+
+	result = Palette.new()
+
+	# Iterate all pixels and store unique colors to palete
+	image.lock()
+	for y in range(0, height):
+		for x in range(0, width):
+			var color: Color = image.get_pixel(x, y)
+			if not result.has_color(color):
+				result.add_color(color, "#" + color.to_html())
+	image.unlock()
+
+	var name_start = path.find_last('/') + 1
+	var name_end = path.find_last('.')
+	if name_end > name_start:
+		result.name = path.substr(name_start, name_end - name_start)
+
+	return result
+	pass

--- a/Scripts/Palette/Palette.gd
+++ b/Scripts/Palette/Palette.gd
@@ -50,6 +50,12 @@ func get_color_data(index : int) -> String:
 
 	return result
 
+func has_color(color: Color) -> bool:
+	for palette_color in colors:
+		if palette_color.color == color:
+			return true
+	return false
+
 func set_color_data(index : int, new_color : String) -> void:
 	if index < colors.size():
 		colors[index].data = new_color

--- a/Scripts/Palette/PaletteContainer.gd
+++ b/Scripts/Palette/PaletteContainer.gd
@@ -43,6 +43,8 @@ func on_palette_import_file_selected(path : String) -> void:
 		palette = Palette.new().load_from_file(path)
 	elif path.to_lower().ends_with("gpl"):
 		palette = Import.import_gpl(path)
+	elif path.to_lower().ends_with("png"):
+		palette = Import.import_png_palette(path)
 
 	if palette:
 		if not Global.palettes.has(palette.name):


### PR DESCRIPTION
Adds ability to import a palette from a PNG file. Some palettes are distributed as PNG files with each color spanning exactly one pixel. Or it can be used to "scan" any image and get it's color palette.