### PR TITLE
Add WarningDialog for unsaved Image before creating a new Image

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -1163,6 +1163,12 @@ visible = false
 
 [node name="AboutDialog" parent="." instance=ExtResource( 34 )]
 
+[node name="UnsavedCanvasDialog" type="ConfirmationDialog" parent="."]
+margin_right = 200.0
+margin_bottom = 70.0
+window_title = "Unsaved Image"
+dialog_text = "Are you sure want to proceed?"
+
 [node name="QuitDialog" type="ConfirmationDialog" parent="."]
 margin_right = 200.0
 margin_bottom = 70.0
@@ -1252,6 +1258,8 @@ visible = false
 [connection signal="popup_hide" from="PreferencesDialog" to="." method="_can_draw_true"]
 [connection signal="popup_hide" from="OutlineDialog" to="." method="_can_draw_true"]
 [connection signal="popup_hide" from="AboutDialog" to="." method="_can_draw_true"]
+[connection signal="confirmed" from="UnsavedCanvasDialog" to="." method="_on_UnsavedCanvasDialog_confirmed"]
+[connection signal="popup_hide" from="UnsavedCanvasDialog" to="." method="_can_draw_true"]
 [connection signal="confirmed" from="QuitDialog" to="." method="_on_QuitDialog_confirmed"]
 [connection signal="popup_hide" from="QuitDialog" to="." method="_can_draw_true"]
 [connection signal="confirmed" from="QuitAndSaveDialog" to="." method="_on_QuitDialog_confirmed"]

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -216,7 +216,10 @@ func _notification(what : int) -> void:
 func file_menu_id_pressed(id : int) -> void:
 	match id:
 		0: # New
-			$CreateNewImage.popup_centered()
+			if(!Global.saved):
+				$UnsavedCanvasDialog.popup_centered()
+			else:
+				$CreateNewImage.popup_centered()
 			Global.can_draw = false
 		1: # Open
 			$OpenSprite.popup_centered()
@@ -824,3 +827,6 @@ func _on_QuitDialog_confirmed() -> void:
 	modulate = Color(0.5, 0.5, 0.5)
 
 	get_tree().quit()
+
+func _on_UnsavedCanvasDialog_confirmed() -> void :
+	$CreateNewImage.popup_centered()


### PR DESCRIPTION
Temporary fix for #109 (Till tabs are implemented in v0.8)