### PR TITLE
Pixel Perfect mode for brush, eraser and lighten/darken

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -637,6 +637,23 @@ value = 1.0
 allow_greater = true
 ticks_on_borders = true
 
+[node name="LeftBrushPixelPerfectMode" type="VBoxContainer" parent="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions"]
+margin_top = 71.0
+margin_right = 160.0
+margin_bottom = 87.0
+alignment = 1
+
+[node name="LeftPixelPerfectMode" type="CheckBox" parent="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushPixelPerfectMode"]
+margin_left = 36.0
+margin_right = 123.0
+margin_bottom = 16.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+pressed = true
+text = "Pixel Perfect"
+align = 1
+
 [node name="LeftColorInterpolation" type="VBoxContainer" parent="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions"]
 visible = false
 margin_top = 75.0
@@ -1030,6 +1047,23 @@ min_value = 1.0
 value = 1.0
 allow_greater = true
 ticks_on_borders = true
+
+[node name="RightBrushPixelPerfectMode" type="VBoxContainer" parent="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions"]
+margin_top = 71.0
+margin_right = 160.0
+margin_bottom = 87.0
+alignment = 1
+
+[node name="RightPixelPerfectMode" type="CheckBox" parent="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushPixelPerfectMode"]
+margin_left = 36.0
+margin_right = 123.0
+margin_bottom = 16.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+pressed = true
+text = "Pixel Perfect"
+align = 1
 
 [node name="RightColorInterpolation" type="VBoxContainer" parent="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions"]
 visible = false
@@ -1658,6 +1692,7 @@ visible = false
 [connection signal="pressed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushType/LeftBrushTypeButton" to="." method="_on_LeftBrushTypeButton_pressed"]
 [connection signal="value_changed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushType/LeftBrushSizeEdit" to="." method="_on_LeftBrushSizeEdit_value_changed"]
 [connection signal="value_changed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushSizeSlider" to="." method="_on_LeftBrushSizeEdit_value_changed"]
+[connection signal="toggled" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftBrushPixelPerfectMode/LeftPixelPerfectMode" to="." method="_on_LeftPixelPerfectMode_toggled"]
 [connection signal="value_changed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftColorInterpolation/LeftInterpolateFactor" to="." method="_on_LeftInterpolateFactor_value_changed"]
 [connection signal="value_changed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftColorInterpolation/LeftInterpolateSlider" to="." method="_on_LeftInterpolateFactor_value_changed"]
 [connection signal="item_selected" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/LeftToolOptions/LeftFillArea/LeftFillAreaOptions" to="." method="_on_LeftFillAreaOptions_item_selected"]
@@ -1677,6 +1712,7 @@ visible = false
 [connection signal="pressed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushType/RightBrushTypeButton" to="." method="_on_RightBrushTypeButton_pressed"]
 [connection signal="value_changed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushType/RightBrushSizeEdit" to="." method="_on_RightBrushSizeEdit_value_changed"]
 [connection signal="value_changed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushSizeSlider" to="." method="_on_RightBrushSizeEdit_value_changed"]
+[connection signal="toggled" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightBrushPixelPerfectMode/RightPixelPerfectMode" to="." method="_on_RightPixelPerfectMode_toggled"]
 [connection signal="value_changed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightColorInterpolation/RightInterpolateFactor" to="." method="_on_RightInterpolateFactor_value_changed"]
 [connection signal="value_changed" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightColorInterpolation/RightInterpolateSlider" to="." method="_on_RightInterpolateFactor_value_changed"]
 [connection signal="item_selected" from="MenuAndUI/UI/RightPanel/PreviewAndPalettes/ToolAndPaletteVSplit/ColorAndToolOptions/ScrollContainer/ToolOptions/RightToolOptions/RightFillArea/RightFillAreaOptions" to="." method="_on_RightFillAreaOptions_item_selected"]

--- a/Scripts/Drawers.gd
+++ b/Scripts/Drawers.gd
@@ -1,0 +1,37 @@
+class Drawer:
+	func reset() -> void:
+		pass
+
+	func set_pixel(sprite: Image, pos: Vector2, new_color: Color) -> void:
+		pass
+
+
+class SimpleDrawer extends Drawer:
+	func reset() -> void:
+		pass
+
+	func set_pixel(sprite: Image, pos: Vector2, new_color: Color) -> void:
+		sprite.set_pixel(pos.x, pos.y, new_color)
+
+
+class PixelPerfectDrawer extends Drawer:
+	const neighbours = [Vector2(0, 1), Vector2(1, 0), Vector2(-1, 0), Vector2(0, -1)]
+	const corners = [Vector2(1, 1), Vector2(-1, -1), Vector2(-1, 1), Vector2(1, -1)]
+	var last_pixels = [null, null]
+
+	func reset():
+		last_pixels = [null, null]
+
+	func set_pixel(sprite: Image, pos: Vector2, new_color: Color) -> void:
+		last_pixels.push_back([pos, sprite.get_pixel(pos.x, pos.y)])
+		sprite.set_pixel(pos.x, pos.y, new_color)
+
+		var corner = last_pixels.pop_front()
+		var neighbour = last_pixels[0]
+
+		if corner == null or neighbour == null:
+			return
+
+		if pos - corner[0] in corners and pos - neighbour[0] in neighbours:
+			sprite.set_pixel(neighbour[0].x, neighbour[0].y, neighbour[1])
+			last_pixels[0] = corner

--- a/Scripts/Global.gd
+++ b/Scripts/Global.gd
@@ -105,6 +105,9 @@ var left_vertical_mirror := false
 var right_horizontal_mirror := false
 var right_vertical_mirror := false
 
+var left_pixel_perfect := true
+var right_pixel_perfect := true
+
 # View menu options
 var tile_mode := false
 var draw_grid := false

--- a/Scripts/Global.gd
+++ b/Scripts/Global.gd
@@ -198,6 +198,9 @@ var left_brush_size_slider : HSlider
 var right_brush_size_edit : SpinBox
 var right_brush_size_slider : HSlider
 
+var left_pixel_perfect_container : VBoxContainer
+var right_pixel_perfect_container : VBoxContainer
+
 var left_color_interpolation_container : Container
 var right_color_interpolation_container : Container
 var left_interpolate_spinbox : SpinBox
@@ -326,6 +329,9 @@ func _ready() -> void:
 	left_brush_size_slider = find_node_by_name(root, "LeftBrushSizeSlider")
 	right_brush_size_edit = find_node_by_name(root, "RightBrushSizeEdit")
 	right_brush_size_slider = find_node_by_name(root, "RightBrushSizeSlider")
+
+	left_pixel_perfect_container = find_node_by_name(root, "LeftBrushPixelPerfectMode")
+	right_pixel_perfect_container = find_node_by_name(root, "RightBrushPixelPerfectMode")
 
 	left_color_interpolation_container = find_node_by_name(root, "LeftColorInterpolation")
 	right_color_interpolation_container = find_node_by_name(root, "RightColorInterpolation")

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -495,12 +495,14 @@ func _on_Tool_pressed(tool_pressed : BaseButton, mouse_press := true, key_for_le
 		if current_action == "Pencil":
 			Global.left_brush_type_container.visible = true
 			Global.left_brush_size_slider.visible = true
+			Global.left_pixel_perfect_container.visible = true
 			Global.left_mirror_container.visible = true
 			if Global.current_left_brush_type == Global.Brush_Types.FILE or Global.current_left_brush_type == Global.Brush_Types.CUSTOM or Global.current_left_brush_type == Global.Brush_Types.RANDOM_FILE:
 				Global.left_color_interpolation_container.visible = true
 		elif current_action == "Eraser":
 			Global.left_brush_type_container.visible = true
 			Global.left_brush_size_slider.visible = true
+			Global.left_pixel_perfect_container.visible = true
 			Global.left_mirror_container.visible = true
 		elif current_action == "Bucket":
 			Global.left_fill_area_container.visible = true
@@ -508,6 +510,7 @@ func _on_Tool_pressed(tool_pressed : BaseButton, mouse_press := true, key_for_le
 		elif current_action == "LightenDarken":
 			Global.left_brush_type_container.visible = true
 			Global.left_brush_size_slider.visible = true
+			Global.left_pixel_perfect_container.visible = true
 			Global.left_ld_container.visible = true
 			Global.left_mirror_container.visible = true
 		elif current_action == "ColorPicker":
@@ -527,12 +530,14 @@ func _on_Tool_pressed(tool_pressed : BaseButton, mouse_press := true, key_for_le
 		if current_action == "Pencil":
 			Global.right_brush_type_container.visible = true
 			Global.right_brush_size_slider.visible = true
+			Global.right_pixel_perfect_container.visible = true
 			Global.right_mirror_container.visible = true
 			if Global.current_right_brush_type == Global.Brush_Types.FILE or Global.current_right_brush_type == Global.Brush_Types.CUSTOM or Global.current_right_brush_type == Global.Brush_Types.RANDOM_FILE:
 				Global.right_color_interpolation_container.visible = true
 		elif current_action == "Eraser":
 			Global.right_brush_type_container.visible = true
 			Global.right_brush_size_slider.visible = true
+			Global.right_pixel_perfect_container.visible = true
 			Global.right_mirror_container.visible = true
 		elif current_action == "Bucket":
 			Global.right_fill_area_container.visible = true
@@ -540,6 +545,7 @@ func _on_Tool_pressed(tool_pressed : BaseButton, mouse_press := true, key_for_le
 		elif current_action == "LightenDarken":
 			Global.right_brush_type_container.visible = true
 			Global.right_brush_size_slider.visible = true
+			Global.right_pixel_perfect_container.visible = true
 			Global.right_ld_container.visible = true
 			Global.right_mirror_container.visible = true
 		elif current_action == "ColorPicker":

--- a/Scripts/Main.gd
+++ b/Scripts/Main.gd
@@ -784,3 +784,11 @@ func _on_QuitDialog_confirmed() -> void:
 	modulate = Color(0.5, 0.5, 0.5)
 
 	get_tree().quit()
+
+
+func _on_LeftPixelPerfectMode_toggled(button_pressed) -> void:
+	Global.left_pixel_perfect = button_pressed
+
+
+func _on_RightPixelPerfectMode_toggled(button_pressed) -> void:
+	Global.right_pixel_perfect = button_pressed


### PR DESCRIPTION

![Screenshot from 2020-04-26 12-18-36](https://user-images.githubusercontent.com/902408/80305045-9879b000-87ba-11ea-88b1-8e3ec6bcdc6b.png)

Added a pixel perfect mode for the pencil and similar brush-like tools

See issue: https://github.com/Orama-Interactive/Pixelorama/issues/192

Unrelated question: I see that you have nice variable names and the code is quite readable. Still, I feel that some methods are too long and there is a lot of repetition. Would you accept refactor-only pull requests?

