### PR TITLE
Added selective animation tag export for Spritesheets

### DIFF
--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -167,6 +167,12 @@ msgstr ""
 msgid "Frame"
 msgstr ""
 
+msgid "Frames:"
+msgstr ""
+
+msgid "All Frames"
+msgstr ""
+
 msgid "Spritesheet"
 msgstr ""
 

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -10,6 +10,8 @@ var processed_images = [] # Image[]
 var frame_number := 0
 
 # Spritesheet options
+var frame_current_tag := 0 # Export only current frame tag
+var canvas_size := 0
 enum Orientation { ROWS = 0, COLUMNS = 1 }
 var orientation : int = Orientation.ROWS
 # How many rows/columns before new line is added
@@ -39,6 +41,7 @@ var file_exists_alert = "File %s already exists. Overwrite?"
 var was_exported : bool = false
 var exported_tab : int
 var exported_frame_number : int
+var exported_frame_current_tag : int
 var exported_orientation : int
 var exported_lines_count : int
 var exported_animation_type : int
@@ -94,8 +97,10 @@ func show_tab() -> void:
 				process_frame()
 			$VBoxContainer/FrameOptions.show()
 		ExportTab.SPRITESHEET:
+			create_frame_tag_list()
 			file_format = FileFormat.PNG
 			$VBoxContainer/File/FileFormat.selected = FileFormat.PNG
+			$VBoxContainer/SpritesheetOptions/Frames/Frames.select(frame_current_tag)
 			$FrameTimer.stop()
 			if not was_exported:
 				orientation = Orientation.ROWS
@@ -139,6 +144,18 @@ func process_frame() -> void:
 
 
 func process_spritesheet() -> void:
+	# Range of frames determined by tags
+	var frames := []
+	if frame_current_tag > 0:
+		var frame_start = Global.animation_tags[frame_current_tag - 1][2]
+		var frame_end = Global.animation_tags[frame_current_tag - 1][3]
+		frames = Global.canvases.slice(frame_start-1, frame_end-1, 1, true)
+	else:
+		frames = Global.canvases
+
+	# Then store the size of frames for other functions
+	canvas_size = frames.size()
+
 	# If rows mode selected calculate columns count and vice versa
 	var spritesheet_columns = lines_count if orientation == Orientation.ROWS else frames_divided_by_spritesheet_lines()
 	var spritesheet_rows = lines_count if orientation == Orientation.COLUMNS else frames_divided_by_spritesheet_lines()
@@ -152,7 +169,8 @@ func process_spritesheet() -> void:
 	var origin := Vector2.ZERO
 	var hh := 0
 	var vv := 0
-	for canvas in Global.canvases:
+
+	for canvas in frames:
 		if orientation == Orientation.ROWS:
 			if vv < spritesheet_columns:
 				origin.x = canvas.size.x * vv
@@ -398,7 +416,7 @@ func create_export_path(multifile: bool, frame: int = 0) -> String:
 
 
 func frames_divided_by_spritesheet_lines() -> int:
-	return int(ceil(Global.canvases.size() / float(lines_count)))
+	return int(ceil(canvas_size / float(lines_count)))
 
 
 func file_format_string(format_enum : int) -> String:
@@ -428,9 +446,21 @@ func set_file_format_selector() -> void:
 			$VBoxContainer/AnimationOptions/AnimatedOptions.show()
 
 
+func create_frame_tag_list() -> void:
+	var frame_container := $VBoxContainer/SpritesheetOptions/Frames/Frames
+	# Clear existing tag list from entry if it exists
+	frame_container.clear()
+	frame_container.add_item("All Frames", 0) # Re-add removed 'All Frames' item
+
+	# Repopulate list with current tag list
+	for item in Global.animation_tags:
+		frame_container.add_item(item[0])
+
+
 func store_export_settings() -> void:
 	exported_tab = current_tab
 	exported_frame_number = frame_number
+	exported_frame_current_tag = frame_current_tag
 	exported_orientation = orientation
 	exported_lines_count = lines_count
 	exported_animation_type = animation_type
@@ -447,6 +477,7 @@ func store_export_settings() -> void:
 func restore_previous_export_settings() -> void:
 	current_tab = exported_tab
 	frame_number = exported_frame_number if exported_frame_number <= Global.canvases.size() else Global.canvases.size()
+	frame_current_tag = exported_frame_current_tag if exported_frame_current_tag <= Global.animation_tags.size() else 0
 	orientation = exported_orientation
 	lines_count = exported_lines_count
 	animation_type = exported_animation_type
@@ -630,3 +661,9 @@ func _on_ExportDialog_popup_hide() -> void:
 
 func _on_MultipleAnimationsDirectories_toggled(button_pressed : bool) -> void:
 	new_dir_for_each_frame_tag = button_pressed
+
+
+func _on_Frames_item_selected(id : int) -> void:
+	frame_current_tag = id
+	process_spritesheet()
+	set_preview()

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -11,7 +11,7 @@ var frame_number := 0
 
 # Spritesheet options
 var frame_current_tag := 0 # Export only current frame tag
-var canvas_size := 0
+var canvas_size := 1
 enum Orientation { ROWS = 0, COLUMNS = 1 }
 var orientation : int = Orientation.ROWS
 # How many rows/columns before new line is added
@@ -99,17 +99,17 @@ func show_tab() -> void:
 		ExportTab.SPRITESHEET:
 			create_frame_tag_list()
 			file_format = FileFormat.PNG
+			if not was_exported:
+				orientation = Orientation.ROWS
+				lines_count = int(ceil(sqrt(canvas_size)))
+			process_spritesheet()
 			$VBoxContainer/File/FileFormat.selected = FileFormat.PNG
 			$VBoxContainer/SpritesheetOptions/Frames/Frames.select(frame_current_tag)
 			$FrameTimer.stop()
-			if not was_exported:
-				orientation = Orientation.ROWS
-				lines_count = int(ceil(sqrt(Global.canvases.size())))
 			$VBoxContainer/SpritesheetOptions/Orientation/Orientation.selected = orientation
-			$VBoxContainer/SpritesheetOptions/Orientation/LinesCount.max_value = Global.canvases.size()
+			$VBoxContainer/SpritesheetOptions/Orientation/LinesCount.max_value = canvas_size
 			$VBoxContainer/SpritesheetOptions/Orientation/LinesCount.value = lines_count
 			$VBoxContainer/SpritesheetOptions/Orientation/LinesCountLabel.text = "Columns:"
-			process_spritesheet()
 			$VBoxContainer/SpritesheetOptions.show()
 		ExportTab.ANIMATION:
 			set_file_format_selector()
@@ -667,3 +667,5 @@ func _on_Frames_item_selected(id : int) -> void:
 	frame_current_tag = id
 	process_spritesheet()
 	set_preview()
+	$VBoxContainer/SpritesheetOptions/Orientation/LinesCount.max_value = canvas_size
+	$VBoxContainer/SpritesheetOptions/Orientation/LinesCount.value = lines_count

--- a/src/UI/Dialogs/ExportDialog.tscn
+++ b/src/UI/Dialogs/ExportDialog.tscn
@@ -4,6 +4,7 @@
 [ext_resource path="res://addons/godot-gifexporter/src/GifExporter.gd" type="Script" id=2]
 
 [node name="ExportDialog" type="AcceptDialog"]
+visible = true
 margin_right = 532.0
 margin_bottom = 530.0
 rect_min_size = Vector2( 456, 530 )
@@ -45,18 +46,19 @@ text = "Preview:"
 [node name="PreviewScroll" type="ScrollContainer" parent="VBoxContainer"]
 margin_top = 54.0
 margin_right = 516.0
-margin_bottom = 274.0
+margin_bottom = 278.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Previews" type="GridContainer" parent="VBoxContainer/PreviewScroll"]
 margin_right = 516.0
-margin_bottom = 220.0
+margin_bottom = 224.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 3
 
 [node name="FrameOptions" type="VBoxContainer" parent="VBoxContainer"]
+visible = false
 margin_top = 278.0
 margin_right = 516.0
 margin_bottom = 302.0
@@ -85,13 +87,35 @@ rounded = true
 align = 2
 
 [node name="SpritesheetOptions" type="VBoxContainer" parent="VBoxContainer"]
-margin_top = 306.0
+margin_top = 282.0
 margin_right = 516.0
 margin_bottom = 330.0
 
-[node name="Orientation" type="HBoxContainer" parent="VBoxContainer/SpritesheetOptions"]
+[node name="Frames" type="HBoxContainer" parent="VBoxContainer/SpritesheetOptions"]
 margin_right = 516.0
-margin_bottom = 24.0
+margin_bottom = 20.0
+
+[node name="FramesLabel" type="Label" parent="VBoxContainer/SpritesheetOptions/Frames"]
+margin_top = 3.0
+margin_right = 51.0
+margin_bottom = 17.0
+text = "Frames:"
+
+[node name="Frames" type="OptionButton" parent="VBoxContainer/SpritesheetOptions/Frames"]
+anchor_left = 0.00193798
+anchor_right = 0.00193798
+margin_left = 55.0
+margin_right = 516.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+text = "All Frames"
+items = [ "All Frames", null, false, 0, null ]
+selected = 0
+
+[node name="Orientation" type="HBoxContainer" parent="VBoxContainer/SpritesheetOptions"]
+margin_top = 24.0
+margin_right = 516.0
+margin_bottom = 48.0
 alignment = 1
 
 [node name="OrientationLabel" type="Label" parent="VBoxContainer/SpritesheetOptions/Orientation"]
@@ -323,8 +347,8 @@ window_title = "Open a Directory"
 resizable = true
 mode = 2
 access = 2
-current_dir = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama"
-current_path = "C:/Users/Overloaded/Dropbox/Orama Founding Members/εταιρικα αρχεια/Godot Projects/Pixelorama/"
+current_dir = "/home/wishdream/Pixelorama"
+current_path = "/home/wishdream/Pixelorama/"
 
 [node name="PathValidationAlert" type="AcceptDialog" parent="Popups"]
 margin_left = 8.0
@@ -370,6 +394,7 @@ __meta__ = {
 [connection signal="popup_hide" from="." to="." method="_on_ExportDialog_popup_hide"]
 [connection signal="tab_clicked" from="VBoxContainer/Tabs" to="." method="_on_Tabs_tab_clicked"]
 [connection signal="value_changed" from="VBoxContainer/FrameOptions/FrameNumber/FrameNumber" to="." method="_on_Frame_value_changed"]
+[connection signal="item_selected" from="VBoxContainer/SpritesheetOptions/Frames/Frames" to="." method="_on_Frames_item_selected"]
 [connection signal="item_selected" from="VBoxContainer/SpritesheetOptions/Orientation/Orientation" to="." method="_on_Orientation_item_selected"]
 [connection signal="value_changed" from="VBoxContainer/SpritesheetOptions/Orientation/LinesCount" to="." method="_on_LinesCount_value_changed"]
 [connection signal="item_selected" from="VBoxContainer/AnimationOptions/AnimationType" to="." method="_on_AnimationType_item_selected"]


### PR DESCRIPTION
This lets people export **a single tag** or **all frames** in spritesheet export tab:

![image](https://user-images.githubusercontent.com/4660711/81450000-1626be00-91b4-11ea-8025-b170d24116bf.png)

![image](https://user-images.githubusercontent.com/4660711/81450086-440c0280-91b4-11ea-9aa8-cd93bb70c7e6.png)

In the future, I want to work on this more to also carry this over to Animation as well and also the `Create new directory for each frame tag` over to the Spritesheet export.