### PR TITLE
Refactoring perferences dialog

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -68,6 +68,9 @@ var checker_size := 10
 var checker_color_1 := Color(0.47, 0.47, 0.47, 1)
 var checker_color_2 := Color(0.34, 0.35, 0.34, 1)
 
+var autosave_interval := 5.0
+var enable_autosave := true
+
 # Tools & options
 var current_left_tool := "Pencil"
 var current_right_tool := "Eraser"

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -3,7 +3,6 @@ extends Node
 var current_save_path := ""
 # Stores a filename of a backup file in user:// until user saves manually
 var backup_save_path = ""
-var default_autosave_interval := 5 # Minutes
 
 onready var autosave_timer : Timer
 
@@ -14,8 +13,7 @@ func _ready() -> void:
 	autosave_timer.process_mode = Timer.TIMER_PROCESS_IDLE
 	autosave_timer.connect("timeout", self, "_on_Autosave_timeout")
 	add_child(autosave_timer)
-	set_autosave_interval(default_autosave_interval)
-	toggle_autosave(true) # Gets started from preferences dialog
+	update_autosave()
 
 
 func open_pxo_file(path : String, untitled_backup : bool = false) -> void:
@@ -271,16 +269,11 @@ func save_pxo_file(path : String, autosave : bool) -> void:
 		Global.notification_label("File failed to save")
 
 
-func toggle_autosave(enable : bool) -> void:
-	if enable:
+func update_autosave() -> void:
+	autosave_timer.stop()
+	autosave_timer.wait_time = Global.autosave_interval * 60 # Interval parameter is in minutes, wait_time is seconds
+	if Global.enable_autosave:
 		autosave_timer.start()
-	else:
-		autosave_timer.stop()
-
-
-func set_autosave_interval(interval : float) -> void:
-	autosave_timer.wait_time = interval * 60 # Interval parameter is in minutes, wait_time is seconds
-	autosave_timer.start()
 
 
 func _on_Autosave_timeout() -> void:

--- a/src/Preferences/HandleLanguages.gd
+++ b/src/Preferences/HandleLanguages.gd
@@ -25,25 +25,18 @@ func _ready() -> void:
 
 	for child in get_children():
 		if child is Button:
-			child.connect("pressed", self, "_on_Language_pressed", [child])
+			child.connect("pressed", self, "_on_Language_pressed", [child.get_index()])
 			child.hint_tooltip = child.name
 
 
-func _on_Language_pressed(button : Button) -> void:
-	var index := 0
-	var i := -1
+func _on_Language_pressed(index : int) -> void:
 	for child in get_children():
 		if child is Button:
-			if child == button:
-				button.pressed = true
-				index = i
-			else:
-				child.pressed = false
-			i += 1
-	if index == -1:
+			child.pressed = child.get_index() == index
+	if index == 0:
 		TranslationServer.set_locale(OS.get_locale())
 	else:
-		TranslationServer.set_locale(Global.loaded_locales[index])
+		TranslationServer.set_locale(Global.loaded_locales[index - 1])
 
 	if "zh" in TranslationServer.get_locale():
 		Global.control.theme.default_font = preload("res://assets/fonts/CJK/NotoSansCJKtc-Regular.tres")

--- a/src/Preferences/HandleThemes.gd
+++ b/src/Preferences/HandleThemes.gd
@@ -4,7 +4,7 @@ extends Node
 func _ready() -> void:
 	for child in get_children():
 		if child is Button:
-			child.connect("pressed", self, "_on_Theme_pressed", [child])
+			child.connect("pressed", self, "_on_Theme_pressed", [child.get_index()])
 
 	if Global.config_cache.has_section_key("preferences", "theme"):
 		var theme_id = Global.config_cache.get_value("preferences", "theme")
@@ -15,18 +15,10 @@ func _ready() -> void:
 		get_child(0).pressed = true
 
 
-func _on_Theme_pressed(button : Button) -> void:
-	var index := 0
-	var i := 0
+func _on_Theme_pressed(index : int) -> void:
 	for child in get_children():
 		if child is Button:
-			if child == button:
-				button.pressed = true
-				index = i
-			else:
-				child.pressed = false
-			i += 1
-
+			child.pressed = child.get_index() == index
 	change_theme(index)
 
 	Global.config_cache.set_value("preferences", "theme", index)

--- a/src/Preferences/PreferencesDialog.gd
+++ b/src/Preferences/PreferencesDialog.gd
@@ -1,292 +1,124 @@
 extends AcceptDialog
 
-onready var tree : Tree = $HSplitContainer/Tree
+onready var list : ItemList = $HSplitContainer/List
 onready var right_side : VBoxContainer = $HSplitContainer/ScrollContainer/VBoxContainer
 onready var general = $HSplitContainer/ScrollContainer/VBoxContainer/General
-onready var languages = $HSplitContainer/ScrollContainer/VBoxContainer/Languages
-onready var themes = $HSplitContainer/ScrollContainer/VBoxContainer/Themes
-onready var canvas = $HSplitContainer/ScrollContainer/VBoxContainer/Canvas
-onready var image = $HSplitContainer/ScrollContainer/VBoxContainer/Image
-onready var shortcuts = $HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts
 
-onready var open_last_project_button = $HSplitContainer/ScrollContainer/VBoxContainer/General/OpenLastProject
-onready var smooth_zoom_button = $HSplitContainer/ScrollContainer/VBoxContainer/General/SmoothZoom
-onready var sensitivity_option = $HSplitContainer/ScrollContainer/VBoxContainer/General/PressureSentivity/PressureSensitivityOptionButton
-onready var left_tool_icon = $HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer/LeftToolIconCheckbox
-onready var right_tool_icon = $HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer/RightToolIconCheckbox
-
-onready var default_width_value = $HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions/ImageDefaultWidth
-onready var default_height_value = $HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions/ImageDefaultHeight
-onready var default_fill_color = $HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions/DefaultFillColor
-
-onready var grid_width_value = $HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions/GridWidthValue
-onready var grid_height_value = $HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions/GridHeightValue
-onready var grid_color = $HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions/GridColor
-onready var guide_color = $HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GuideOptions/GuideColor
-
-onready var checker_size_value = $HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions/CheckerSizeValue
-onready var checker_color_1 = $HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions/CheckerColor1
-onready var checker_color_2 = $HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions/CheckerColor2
-
+# Preferences table: [Prop name in Global, relative node path, value type]
+var preferences = [
+	["open_last_project", "General/OpenLastProject", "pressed"],
+	["smooth_zoom", "General/SmoothZoom", "pressed"],
+	["pressure_sensitivity_mode", "General/PressureSentivity/PressureSensitivityOptionButton", "selected"],
+	["show_left_tool_icon", "General/GridContainer/LeftToolIconCheckbox", "pressed"],
+	["show_right_tool_icon", "General/GridContainer/RightToolIconCheckbox", "pressed"],
+	["left_square_indicator_visible", "General/GridContainer/LeftIndicatorCheckbox", "pressed"],
+	["right_square_indicator_visible", "General/GridContainer/RightIndicatorCheckbox", "pressed"],
+	["autosave_interval", "General/AutosaveInterval/AutosaveInterval", "value"],
+	["enable_autosave", "General/EnableAutosave", "pressed"],
+	
+	["default_image_width", "Image/ImageOptions/ImageDefaultWidth", "value"],
+	["default_image_height", "Image/ImageOptions/ImageDefaultHeight", "value"],
+	["default_fill_color", "Image/ImageOptions/DefaultFillColor", "color"],
+	
+	["grid_width", "Canvas/GridOptions/GridWidthValue", "value"],
+	["grid_height", "Canvas/GridOptions/GridHeightValue", "value"],
+	["grid_color", "Canvas/GridOptions/GridColor", "color"],
+	["guide_color", "Canvas/GuideOptions/GuideColor", "color"],
+	["checker_size", "Canvas/CheckerOptions/CheckerSizeValue", "value"],
+	["checker_color_1", "Canvas/CheckerOptions/CheckerColor1", "color"],
+	["checker_color_2", "Canvas/CheckerOptions/CheckerColor2", "color"],
+]
 
 func _ready() -> void:
 	# Replace OK with Close since preference changes are being applied immediately, not after OK confirmation
 	get_ok().text = tr("Close")
-
-	# Set default values for General options
-	if Global.config_cache.has_section_key("preferences", "open_last_project"):
-		Global.open_last_project = Global.config_cache.get_value("preferences", "open_last_project")
-		open_last_project_button.pressed = Global.open_last_project
-	if Global.config_cache.has_section_key("preferences", "smooth_zoom"):
-		Global.smooth_zoom = Global.config_cache.get_value("preferences", "smooth_zoom")
-		smooth_zoom_button.pressed = Global.smooth_zoom
-	if Global.config_cache.has_section_key("preferences", "pressure_sensitivity"):
-		Global.pressure_sensitivity_mode = Global.config_cache.get_value("preferences", "pressure_sensitivity")
-		sensitivity_option.selected = Global.pressure_sensitivity_mode
-
-	if Global.config_cache.has_section_key("preferences", "show_left_tool_icon"):
-		Global.show_left_tool_icon = Global.config_cache.get_value("preferences", "show_left_tool_icon")
-		left_tool_icon.pressed = Global.show_left_tool_icon
-	if Global.config_cache.has_section_key("preferences", "show_right_tool_icon"):
-		Global.show_right_tool_icon = Global.config_cache.get_value("preferences", "show_right_tool_icon")
-		right_tool_icon.pressed = Global.show_right_tool_icon
-
-	# Get autosave settings
-	if Global.config_cache.has_section_key("preferences", "autosave_interval"):
-		var autosave_interval = Global.config_cache.get_value("preferences", "autosave_interval")
-		OpenSave.set_autosave_interval(autosave_interval)
-		general.get_node("AutosaveInterval/AutosaveInterval").value = autosave_interval
-	if Global.config_cache.has_section_key("preferences", "enable_autosave"):
-		var enable_autosave = Global.config_cache.get_value("preferences", "enable_autosave")
-		OpenSave.toggle_autosave(enable_autosave)
-		general.get_node("EnableAutosave").pressed = enable_autosave
-
-	# Set default values for Canvas options
-	if Global.config_cache.has_section_key("preferences", "grid_size"):
-		var grid_size = Global.config_cache.get_value("preferences", "grid_size")
-		Global.grid_width = int(grid_size.x)
-		Global.grid_height = int(grid_size.y)
-		grid_width_value.value = grid_size.x
-		grid_height_value.value = grid_size.y
-
-	if Global.config_cache.has_section_key("preferences", "grid_color"):
-		Global.grid_color = Global.config_cache.get_value("preferences", "grid_color")
-		grid_color.color = Global.grid_color
-
-	if Global.config_cache.has_section_key("preferences", "checker_size"):
-		var checker_size = Global.config_cache.get_value("preferences", "checker_size")
-		Global.checker_size = int(checker_size)
-		checker_size_value.value = checker_size
-
-	if Global.config_cache.has_section_key("preferences", "checker_color_1"):
-		Global.checker_color_1 = Global.config_cache.get_value("preferences", "checker_color_1")
-		checker_color_1.color = Global.checker_color_1
-
-	if Global.config_cache.has_section_key("preferences", "checker_color_2"):
-		Global.checker_color_2 = Global.config_cache.get_value("preferences", "checker_color_2")
-		checker_color_2.color = Global.checker_color_2
+	
+	for pref in preferences:
+		var node = right_side.get_node(pref[1])
+		
+		if Global.config_cache.has_section_key("preferences", pref[0]):
+			var value = Global.config_cache.get_value("preferences", pref[0])
+			Global.set(pref[0], value)
+			node.set(pref[2], value)
+			
+		match pref[2]:
+			"pressed":
+				node.connect("toggled", self, "_on_Preference_toggled", [pref[0]])
+			"value":
+				node.connect("value_changed", self, "_on_Preference_value_changed", [pref[0]])
+			"color":
+				node.get_picker().presets_visible = false
+				node.connect("color_changed", self, "_on_Preference_color_changed", [pref[0]])
+			"selected":
+				node.connect("item_selected", self, "_on_Preference_item_selected", [pref[0]])
 
 	Global.transparent_checker._ready()
 
-	if Global.config_cache.has_section_key("preferences", "guide_color"):
-		Global.guide_color = Global.config_cache.get_value("preferences", "guide_color")
+	for canvas in Global.canvases:
+		for guide in canvas.get_children():
+			if guide is Guide:
+				guide.default_color = Global.guide_color
+
+
+func _on_Preference_toggled(button_pressed : bool, prop : String) -> void:
+	Global.set(prop, button_pressed)
+	Global.config_cache.set_value("preferences", prop, button_pressed)
+	preference_update(prop)
+
+
+func _on_Preference_value_changed(value : float, prop : String) -> void:
+	Global.set(prop, value)
+	Global.config_cache.set_value("preferences", prop, value)
+	preference_update(prop)
+
+
+func _on_Preference_color_changed(color : Color, prop : String) -> void:
+	Global.set(prop, color)
+	Global.config_cache.set_value("preferences", prop, color)
+	preference_update(prop)
+
+
+func _on_Preference_item_selected(id : int, prop : String) -> void:
+	Global.set(prop, id)
+	Global.config_cache.set_value("preferences", prop, id)
+	preference_update(prop)
+
+
+func preference_update(prop : String) -> void:
+	if prop in ["autosave_interval", "enable_autosave"]:
+		OpenSave.update_autosave()
+	
+	if prop in ["grid_width", "grid_height", "grid_color"]:
+		Global.canvas.update()
+	
+	if prop in ["checker_size", "checker_color_1", "checker_color_2"]:
+		Global.transparent_checker._ready()
+	
+	if prop in ["guide_color"]:
 		for canvas in Global.canvases:
 			for guide in canvas.get_children():
 				if guide is Guide:
 					guide.default_color = Global.guide_color
-		guide_color.color = Global.guide_color
-
-	# Set default values for Image
-	if Global.config_cache.has_section_key("preferences", "default_width"):
-		var default_width = Global.config_cache.get_value("preferences", "default_width")
-		Global.default_image_width = int(default_width)
-		default_width_value.value = Global.default_image_width
-
-	if Global.config_cache.has_section_key("preferences", "default_height"):
-		var default_height = Global.config_cache.get_value("preferences", "default_height")
-		Global.default_image_height = int(default_height)
-		default_height_value.value = Global.default_image_height
-
-	if Global.config_cache.has_section_key("preferences", "default_fill_color"):
-		var fill_color = Global.config_cache.get_value("preferences", "default_fill_color")
-		Global.default_fill_color = fill_color
-		default_fill_color.color = Global.default_fill_color
-
-	guide_color.get_picker().presets_visible = false
-	grid_color.get_picker().presets_visible = false
-	checker_color_1.get_picker().presets_visible = false
-	checker_color_2.get_picker().presets_visible = false
-	default_fill_color.get_picker().presets_visible = false
+				
+	Global.config_cache.save("user://cache.ini")
 
 
 func _on_PreferencesDialog_about_to_show(changed_language := false) -> void:
-	var root := tree.create_item()
-	var general_button := tree.create_item(root)
-	var language_button := tree.create_item(root)
-	var theme_button := tree.create_item(root)
-	var canvas_button := tree.create_item(root)
-	var image_button := tree.create_item(root)
-	var shortcuts_button := tree.create_item(root)
-
-	general_button.set_text(0, "  " + tr("General"))
-	# We use metadata to avoid being affected by translations
-	general_button.set_metadata(0, "General")
-	language_button.set_text(0, "  " + tr("Language"))
-	language_button.set_metadata(0, "Language")
-	theme_button.set_text(0, "  " + tr("Themes"))
-	theme_button.set_metadata(0, "Themes")
-	canvas_button.set_text(0, "  " + tr("Canvas"))
-	canvas_button.set_metadata(0, "Canvas")
-	image_button.set_text(0, "  " + tr("Image"))
-	image_button.set_metadata(0, "Image")
-	shortcuts_button.set_text(0, "  " + tr("Shortcuts"))
-	shortcuts_button.set_metadata(0, "Shortcuts")
-
-	if changed_language:
-		language_button.select(0)
-	else:
-		general_button.select(0)
-
+	list.add_item("  " + tr("General"))
+	list.add_item("  " + tr("Language"))
+	list.add_item("  " + tr("Themes"))
+	list.add_item("  " + tr("Canvas"))
+	list.add_item("  " + tr("Image"))
+	list.add_item("  " + tr("Shortcuts"))
+	
+	list.select(1 if changed_language else 0)
 	general.get_node("AutosaveInterval/AutosaveInterval").suffix = tr("minute(s)")
 
 
 func _on_PreferencesDialog_popup_hide() -> void:
-	tree.clear()
+	list.clear()
 
 
-func _on_Tree_item_selected() -> void:
+func _on_List_item_selected(index):
 	for child in right_side.get_children():
-		child.visible = false
-	var selected : String = tree.get_selected().get_metadata(0)
-	if "General" in selected:
-		general.visible = true
-	elif "Language" in selected:
-		languages.visible = true
-	elif "Themes" in selected:
-		themes.visible = true
-	elif "Canvas" in selected:
-		canvas.visible = true
-	elif "Image" in selected:
-		image.visible = true
-	elif "Shortcuts" in selected:
-		shortcuts.visible = true
-
-
-func _on_PressureSensitivityOptionButton_item_selected(id : int) -> void:
-	Global.pressure_sensitivity_mode = id
-	Global.config_cache.set_value("preferences", "pressure_sensitivity", id)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_SmoothZoom_pressed() -> void:
-	Global.smooth_zoom = !Global.smooth_zoom
-	Global.config_cache.set_value("preferences", "smooth_zoom", Global.smooth_zoom)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_GridWidthValue_value_changed(value : float) -> void:
-	Global.grid_width = value
-	Global.canvas.update()
-	Global.config_cache.set_value("preferences", "grid_size", Vector2(value, grid_height_value.value))
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_GridHeightValue_value_changed(value : float) -> void:
-	Global.grid_height = value
-	Global.canvas.update()
-	Global.config_cache.set_value("preferences", "grid_size", Vector2(grid_width_value.value, value))
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_GridColor_color_changed(color : Color) -> void:
-	Global.grid_color = color
-	Global.canvas.update()
-	Global.config_cache.set_value("preferences", "grid_color", color)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_CheckerSize_value_changed(value : float) -> void:
-	Global.checker_size = value
-	Global.transparent_checker._ready()
-	Global.config_cache.set_value("preferences", "checker_size", value)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_CheckerColor1_color_changed(color : Color) -> void:
-	Global.checker_color_1 = color
-	Global.transparent_checker._ready()
-	Global.config_cache.set_value("preferences", "checker_color_1", color)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_CheckerColor2_color_changed(color : Color) -> void:
-	Global.checker_color_2 = color
-	Global.transparent_checker._ready()
-	Global.config_cache.set_value("preferences", "checker_color_2", color)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_GuideColor_color_changed(color : Color) -> void:
-	Global.guide_color = color
-	for canvas in Global.canvases:
-		for guide in canvas.get_children():
-			if guide is Guide:
-				guide.default_color = color
-	Global.config_cache.set_value("preferences", "guide_color", color)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_ImageDefaultWidth_value_changed(value: float) -> void:
-	Global.default_image_width = value
-	Global.config_cache.set_value("preferences", "default_width", value)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_ImageDefaultHeight_value_changed(value: float) -> void:
-	Global.default_image_height = value
-	Global.config_cache.set_value("preferences", "default_height", value)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_DefaultBackground_color_changed(color: Color) -> void:
-	Global.default_fill_color = color
-	Global.config_cache.set_value("preferences", "default_fill_color", color)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_LeftIndicatorCheckbox_toggled(button_pressed : bool) -> void:
-	Global.left_square_indicator_visible = button_pressed
-
-
-func _on_RightIndicatorCheckbox_toggled(button_pressed : bool) -> void:
-	Global.right_square_indicator_visible = button_pressed
-
-
-func _on_LeftToolIconCheckbox_toggled(button_pressed : bool) -> void:
-	Global.show_left_tool_icon = button_pressed
-	Global.config_cache.set_value("preferences", "show_left_tool_icon", Global.show_left_tool_icon)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_RightToolIconCheckbox_toggled(button_pressed : bool) -> void:
-	Global.show_right_tool_icon = button_pressed
-	Global.config_cache.set_value("preferences", "show_right_tool_icon", Global.show_right_tool_icon)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_OpenLastProject_pressed() -> void:
-	Global.open_last_project = !Global.open_last_project
-	Global.config_cache.set_value("preferences", "open_last_project", Global.open_last_project)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_EnableAutosave_toggled(button_pressed : bool) -> void:
-	OpenSave.toggle_autosave(button_pressed)
-	Global.config_cache.set_value("preferences", "enable_autosave", button_pressed)
-	Global.config_cache.save("user://cache.ini")
-
-
-func _on_AutosaveInterval_value_changed(value : float) -> void:
-	OpenSave.set_autosave_interval(value)
-	Global.config_cache.set_value("preferences", "autosave_interval", value)
-	Global.config_cache.save("user://cache.ini")
+		child.visible = child.name == ["General", "Languages", "Themes", "Canvas", "Image", "Shortcuts"][index]

--- a/src/Preferences/PreferencesDialog.tscn
+++ b/src/Preferences/PreferencesDialog.tscn
@@ -36,12 +36,10 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Tree" type="Tree" parent="HSplitContainer"]
+[node name="List" type="ItemList" parent="HSplitContainer"]
 margin_right = 86.0
 margin_bottom = 1110.0
 rect_min_size = Vector2( 85, 0 )
-custom_constants/item_margin = -2
-hide_root = true
 
 [node name="ScrollContainer" type="ScrollContainer" parent="HSplitContainer"]
 margin_left = 98.0
@@ -52,15 +50,15 @@ size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer/ScrollContainer"]
 margin_right = 506.0
-margin_bottom = 1286.0
+margin_bottom = 180.0
 size_flags_horizontal = 3
 
 [node name="General" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 180.0
 
 [node name="SmoothZoom" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/General"]
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 24.0
 hint_tooltip = "Adds a smoother transition when zooming in or out"
 mouse_default_cursor_shape = 2
@@ -69,19 +67,19 @@ text = "Smooth Zoom"
 
 [node name="HSeparator2" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/General"]
 margin_top = 28.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 32.0
 
 [node name="GridContainer" type="GridContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/General"]
 margin_top = 36.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 88.0
 custom_constants/vseparation = 4
 custom_constants/hseparation = 4
 columns = 2
 
 [node name="LeftIndicatorCheckbox" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer"]
-margin_right = 245.0
+margin_right = 251.0
 margin_bottom = 24.0
 hint_tooltip = "Show left mouse pixel indicator or brush on the canvas when drawing"
 mouse_default_cursor_shape = 2
@@ -90,8 +88,8 @@ pressed = true
 text = "Left pixel indicator"
 
 [node name="RightIndicatorCheckbox" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer"]
-margin_left = 249.0
-margin_right = 494.0
+margin_left = 255.0
+margin_right = 506.0
 margin_bottom = 24.0
 hint_tooltip = "Show right mouse pixel indicator or brush on the canvas when drawing"
 mouse_default_cursor_shape = 2
@@ -100,7 +98,7 @@ text = "Right pixel indicator"
 
 [node name="LeftToolIconCheckbox" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer"]
 margin_top = 28.0
-margin_right = 245.0
+margin_right = 251.0
 margin_bottom = 52.0
 hint_tooltip = "Displays an icon of the selected left tool next to the cursor on the canvas"
 mouse_default_cursor_shape = 2
@@ -109,9 +107,9 @@ pressed = true
 text = "Show left tool icon"
 
 [node name="RightToolIconCheckbox" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer"]
-margin_left = 249.0
+margin_left = 255.0
 margin_top = 28.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 52.0
 hint_tooltip = "Displays an icon of the selected right tool next to the cursor on the canvas"
 mouse_default_cursor_shape = 2
@@ -121,14 +119,14 @@ text = "Show right tool icon"
 
 [node name="HSeparator3" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/General"]
 margin_top = 92.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 96.0
 
 [node name="PressureSentivity" type="HBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/General"]
 visible = false
-margin_top = 116.0
-margin_right = 334.0
-margin_bottom = 136.0
+margin_top = 100.0
+margin_right = 506.0
+margin_bottom = 120.0
 
 [node name="PressureSensitivityLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/General/PressureSentivity"]
 margin_top = 3.0
@@ -146,7 +144,7 @@ selected = 1
 
 [node name="OpenLastProject" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/General"]
 margin_top = 100.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 124.0
 hint_tooltip = "Opens last opened project on startup"
 mouse_default_cursor_shape = 2
@@ -154,7 +152,7 @@ text = "Open last project on startup"
 
 [node name="EnableAutosave" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/General"]
 margin_top = 128.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 152.0
 mouse_default_cursor_shape = 2
 pressed = true
@@ -165,7 +163,7 @@ __meta__ = {
 
 [node name="AutosaveInterval" type="HBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/General"]
 margin_top = 156.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 180.0
 __meta__ = {
 "_edit_use_anchors_": false
@@ -179,7 +177,7 @@ text = "Autosave interval:"
 
 [node name="AutosaveInterval" type="SpinBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/General/AutosaveInterval"]
 margin_left = 119.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 24.0
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 3
@@ -194,13 +192,14 @@ __meta__ = {
 }
 
 [node name="Languages" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
+visible = false
 margin_top = 184.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 632.0
 script = ExtResource( 4 )
 
 [node name="System Language" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 24.0
 mouse_default_cursor_shape = 2
 pressed = true
@@ -208,21 +207,21 @@ text = "System Language"
 
 [node name="Czech" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 28.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 52.0
 mouse_default_cursor_shape = 2
 text = "Czech [cs]"
 
 [node name="German" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 56.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 80.0
 mouse_default_cursor_shape = 2
 text = "Deutsch [de]"
 
 [node name="Greek" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 84.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 108.0
 mouse_default_cursor_shape = 2
 custom_fonts/font = ExtResource( 2 )
@@ -230,77 +229,77 @@ text = "Ελληνικά [el]"
 
 [node name="English" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 112.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 136.0
 mouse_default_cursor_shape = 2
 text = "English [en]"
 
 [node name="Esperanto" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 140.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 164.0
 mouse_default_cursor_shape = 2
 text = "Esperanto [eo]"
 
 [node name="Spanish" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 168.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 192.0
 mouse_default_cursor_shape = 2
 text = "Español [es]"
 
 [node name="French" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 196.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 220.0
 mouse_default_cursor_shape = 2
 text = "Français [fr]"
 
 [node name="Indonesian" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 224.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 248.0
 mouse_default_cursor_shape = 2
 text = "Indonesian [id]"
 
 [node name="Italian" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 252.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 276.0
 mouse_default_cursor_shape = 2
 text = "Italiano [it]"
 
 [node name="Latvian" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 280.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 304.0
 mouse_default_cursor_shape = 2
 text = "Latvian [lv]"
 
 [node name="Polish" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 308.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 332.0
 mouse_default_cursor_shape = 2
 text = "Polski [pl]"
 
 [node name="Brazilian Portuguese" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 336.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 360.0
 mouse_default_cursor_shape = 2
 text = "Português Brasileiro [pt_BR]"
 
 [node name="Russian" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 364.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 388.0
 mouse_default_cursor_shape = 2
 text = "Русский [ru]"
 
 [node name="Chinese Simplified" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 392.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 418.0
 mouse_default_cursor_shape = 2
 custom_fonts/font = ExtResource( 3 )
@@ -308,59 +307,60 @@ text = "简体中文 [zh_CN]"
 
 [node name="Chinese Traditional" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Languages"]
 margin_top = 422.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 448.0
 mouse_default_cursor_shape = 2
 custom_fonts/font = ExtResource( 3 )
 text = "繁體中文 [zh_TW]"
 
 [node name="Themes" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
-margin_top = 636.0
-margin_right = 494.0
-margin_bottom = 772.0
+visible = false
+margin_right = 506.0
+margin_bottom = 136.0
 script = ExtResource( 5 )
 
 [node name="Dark Theme" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Themes"]
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 24.0
 mouse_default_cursor_shape = 2
 text = "Dark"
 
 [node name="Gray Theme" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Themes"]
 margin_top = 28.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 52.0
 mouse_default_cursor_shape = 2
 text = "Gray"
 
 [node name="Blue Theme" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Themes"]
 margin_top = 56.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 80.0
 mouse_default_cursor_shape = 2
 text = "Blue"
 
 [node name="Caramel Theme" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Themes"]
 margin_top = 84.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 108.0
 mouse_default_cursor_shape = 2
 text = "Caramel"
 
 [node name="Light Theme" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Themes"]
 margin_top = 112.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 136.0
 mouse_default_cursor_shape = 2
 text = "Light"
 
 [node name="Canvas" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
-margin_top = 776.0
-margin_right = 494.0
-margin_bottom = 968.0
+visible = false
+margin_top = 184.0
+margin_right = 506.0
+margin_bottom = 376.0
 
 [node name="GuideOptions" type="GridContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas"]
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 20.0
 custom_constants/vseparation = 4
 custom_constants/hseparation = 4
@@ -377,7 +377,7 @@ text = "Guides color:"
 
 [node name="GuideColor" type="ColorPickerButton" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GuideOptions"]
 margin_left = 114.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 64, 20 )
 hint_tooltip = "A color of ruler guides displayed on the canvas"
@@ -387,12 +387,12 @@ color = Color( 0.63, 0.13, 0.94, 1 )
 
 [node name="HSeparator" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas"]
 margin_top = 24.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 28.0
 
 [node name="GridOptions" type="GridContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas"]
 margin_top = 32.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 108.0
 custom_constants/vseparation = 4
 custom_constants/hseparation = 4
@@ -409,13 +409,14 @@ text = "Grid width:"
 
 [node name="GridWidthValue" type="SpinBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions"]
 margin_left = 114.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 24.0
 hint_tooltip = "Sets how far apart are vertical lines of the grid"
 mouse_default_cursor_shape = 2
 min_value = 1.0
 max_value = 16384.0
 value = 1.0
+rounded = true
 align = 2
 suffix = "px"
 
@@ -430,7 +431,7 @@ text = "Grid height:"
 [node name="GridHeightValue" type="SpinBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions"]
 margin_left = 114.0
 margin_top = 28.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 52.0
 hint_tooltip = "Sets how far apart are horizontal lines of the grid"
 mouse_default_cursor_shape = 2
@@ -438,6 +439,7 @@ size_flags_horizontal = 3
 min_value = 1.0
 max_value = 16384.0
 value = 1.0
+rounded = true
 align = 2
 suffix = "px"
 
@@ -452,7 +454,7 @@ text = "Grid color:"
 [node name="GridColor" type="ColorPickerButton" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions"]
 margin_left = 114.0
 margin_top = 56.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 76.0
 rect_min_size = Vector2( 64, 20 )
 hint_tooltip = "A color of the grid"
@@ -460,12 +462,12 @@ mouse_default_cursor_shape = 2
 
 [node name="HSeparator2" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas"]
 margin_top = 112.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 116.0
 
 [node name="CheckerOptions" type="GridContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas"]
 margin_top = 120.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 192.0
 custom_constants/vseparation = 4
 custom_constants/hseparation = 4
@@ -482,13 +484,15 @@ text = "Checker size:"
 
 [node name="CheckerSizeValue" type="SpinBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions"]
 margin_left = 114.0
-margin_right = 188.0
+margin_right = 506.0
 margin_bottom = 24.0
 hint_tooltip = "Size of the transparent checker background"
 mouse_default_cursor_shape = 2
+size_flags_horizontal = 3
 min_value = 1.0
 max_value = 16384.0
 value = 10.0
+rounded = true
 align = 2
 suffix = "px"
 
@@ -503,7 +507,7 @@ text = "Checker color 1:"
 [node name="CheckerColor1" type="ColorPickerButton" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions"]
 margin_left = 114.0
 margin_top = 28.0
-margin_right = 188.0
+margin_right = 506.0
 margin_bottom = 48.0
 rect_min_size = Vector2( 64, 20 )
 hint_tooltip = "First color of the transparent checker background"
@@ -521,7 +525,7 @@ text = "Checker color 2:"
 [node name="CheckerColor2" type="ColorPickerButton" parent="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions"]
 margin_left = 114.0
 margin_top = 52.0
-margin_right = 188.0
+margin_right = 506.0
 margin_bottom = 72.0
 rect_min_size = Vector2( 64, 20 )
 hint_tooltip = "Second color of the transparent checker background"
@@ -529,12 +533,13 @@ mouse_default_cursor_shape = 2
 color = Color( 0.341176, 0.34902, 0.341176, 1 )
 
 [node name="Image" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
-margin_top = 972.0
-margin_right = 494.0
-margin_bottom = 1048.0
+visible = false
+margin_top = 184.0
+margin_right = 506.0
+margin_bottom = 260.0
 
 [node name="ImageOptions" type="GridContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Image"]
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 76.0
 custom_constants/vseparation = 4
 custom_constants/hseparation = 4
@@ -551,7 +556,7 @@ text = "Default width:"
 
 [node name="ImageDefaultWidth" type="SpinBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions"]
 margin_left = 114.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 24.0
 hint_tooltip = "A default width of a new image"
 mouse_default_cursor_shape = 2
@@ -559,6 +564,7 @@ size_flags_horizontal = 3
 min_value = 1.0
 max_value = 16384.0
 value = 64.0
+rounded = true
 align = 2
 suffix = "px"
 
@@ -573,13 +579,14 @@ text = "Default height:"
 [node name="ImageDefaultHeight" type="SpinBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions"]
 margin_left = 114.0
 margin_top = 28.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 52.0
 hint_tooltip = "A default height of a new image"
 mouse_default_cursor_shape = 2
 min_value = 1.0
 max_value = 16384.0
 value = 64.0
+rounded = true
 align = 2
 suffix = "px"
 
@@ -594,7 +601,7 @@ text = "Default fill color:"
 [node name="DefaultFillColor" type="ColorPickerButton" parent="HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions"]
 margin_left = 114.0
 margin_top = 56.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 76.0
 rect_min_size = Vector2( 64, 20 )
 hint_tooltip = "A default background color of a new image"
@@ -602,13 +609,14 @@ mouse_default_cursor_shape = 2
 color = Color( 0, 0, 0, 0 )
 
 [node name="Shortcuts" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
-margin_top = 1052.0
-margin_right = 494.0
-margin_bottom = 1286.0
+visible = false
+margin_top = 184.0
+margin_right = 506.0
+margin_bottom = 418.0
 script = ExtResource( 6 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts"]
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 20.0
 hint_tooltip = "Only custom preset can be modified"
 
@@ -620,7 +628,7 @@ text = "Preset:"
 
 [node name="PresetOptionButton" type="OptionButton" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/HBoxContainer"]
 margin_left = 49.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 20.0
 hint_tooltip = "Only custom preset can be modified"
 mouse_default_cursor_shape = 2
@@ -631,12 +639,12 @@ selected = 0
 
 [node name="HSeparator" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts"]
 margin_top = 24.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 28.0
 
 [node name="Shortcuts" type="GridContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts"]
 margin_top = 32.0
-margin_right = 494.0
+margin_right = 506.0
 margin_bottom = 234.0
 custom_constants/vseparation = 2
 custom_constants/hseparation = 5
@@ -648,7 +656,7 @@ margin_bottom = 14.0
 
 [node name="LeftToolLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 14.0
 hint_tooltip = "A tool assigned to the left mouse button"
 mouse_filter = 0
@@ -656,8 +664,8 @@ text = "Left Tool:"
 align = 1
 
 [node name="RightToolLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
-margin_right = 493.0
+margin_left = 326.0
+margin_right = 505.0
 margin_bottom = 14.0
 hint_tooltip = "A tool assigned to the right mouse button"
 mouse_filter = 0
@@ -671,20 +679,21 @@ margin_bottom = 20.0
 
 [node name="HSeparator" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 visible = false
-margin_top = 18.0
-margin_right = 137.0
-margin_bottom = 22.0
+margin_left = 184.0
+margin_top = 16.0
+margin_right = 321.0
+margin_bottom = 20.0
 
 [node name="HSeparator2" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 16.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 20.0
 
 [node name="HSeparator3" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 16.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 20.0
 
 [node name="RectSelectLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
@@ -696,14 +705,14 @@ text = "Rectangular Selection"
 [node name="left_rectangle_select_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 22.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 42.0
 size_flags_horizontal = 3
 
 [node name="right_rectangle_select_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 22.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 42.0
 size_flags_horizontal = 3
 
@@ -716,14 +725,14 @@ text = "Zoom"
 [node name="left_zoom_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 44.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 64.0
 size_flags_horizontal = 3
 
 [node name="right_zoom_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 44.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 64.0
 size_flags_horizontal = 3
 
@@ -736,13 +745,13 @@ text = "Color Picker"
 [node name="left_colorpicker_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 66.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 86.0
 
 [node name="right_colorpicker_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 66.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 86.0
 
 [node name="PencilLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
@@ -754,13 +763,13 @@ text = "Pencil"
 [node name="left_pencil_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 88.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 108.0
 
 [node name="right_pencil_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 88.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 108.0
 
 [node name="EraserLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
@@ -772,13 +781,13 @@ text = "Eraser"
 [node name="left_eraser_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 110.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 130.0
 
 [node name="right_eraser_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 110.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 130.0
 
 [node name="BucketLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
@@ -790,13 +799,13 @@ text = "Bucket"
 [node name="left_fill_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 132.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 152.0
 
 [node name="right_fill_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 132.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 152.0
 
 [node name="LightenDarkenLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
@@ -808,13 +817,13 @@ text = "Lighten/Darken"
 [node name="left_lightdark_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 154.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 174.0
 
 [node name="right_lightdark_tool" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 154.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 174.0
 
 [node name="HSeparator4" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
@@ -825,13 +834,13 @@ margin_bottom = 180.0
 [node name="HSeparator5" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 176.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 180.0
 
 [node name="HSeparator6" type="HSeparator" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
-margin_left = 320.0
+margin_left = 326.0
 margin_top = 176.0
-margin_right = 493.0
+margin_right = 505.0
 margin_bottom = 180.0
 
 [node name="Switch Colors" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
@@ -843,7 +852,7 @@ text = "Switch Colors"
 [node name="switch_colors" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/Shortcuts"]
 margin_left = 142.0
 margin_top = 182.0
-margin_right = 315.0
+margin_right = 321.0
 margin_bottom = 202.0
 
 [node name="Popups" type="Node" parent="."]
@@ -871,26 +880,7 @@ __meta__ = {
 }
 [connection signal="about_to_show" from="." to="." method="_on_PreferencesDialog_about_to_show"]
 [connection signal="popup_hide" from="." to="." method="_on_PreferencesDialog_popup_hide"]
-[connection signal="item_selected" from="HSplitContainer/Tree" to="." method="_on_Tree_item_selected"]
-[connection signal="pressed" from="HSplitContainer/ScrollContainer/VBoxContainer/General/SmoothZoom" to="." method="_on_SmoothZoom_pressed"]
-[connection signal="toggled" from="HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer/LeftIndicatorCheckbox" to="." method="_on_LeftIndicatorCheckbox_toggled"]
-[connection signal="toggled" from="HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer/RightIndicatorCheckbox" to="." method="_on_RightIndicatorCheckbox_toggled"]
-[connection signal="toggled" from="HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer/LeftToolIconCheckbox" to="." method="_on_LeftToolIconCheckbox_toggled"]
-[connection signal="toggled" from="HSplitContainer/ScrollContainer/VBoxContainer/General/GridContainer/RightToolIconCheckbox" to="." method="_on_RightToolIconCheckbox_toggled"]
-[connection signal="item_selected" from="HSplitContainer/ScrollContainer/VBoxContainer/General/PressureSentivity/PressureSensitivityOptionButton" to="." method="_on_PressureSensitivityOptionButton_item_selected"]
-[connection signal="pressed" from="HSplitContainer/ScrollContainer/VBoxContainer/General/OpenLastProject" to="." method="_on_OpenLastProject_pressed"]
-[connection signal="toggled" from="HSplitContainer/ScrollContainer/VBoxContainer/General/EnableAutosave" to="." method="_on_EnableAutosave_toggled"]
-[connection signal="value_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/General/AutosaveInterval/AutosaveInterval" to="." method="_on_AutosaveInterval_value_changed"]
-[connection signal="color_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GuideOptions/GuideColor" to="." method="_on_GuideColor_color_changed"]
-[connection signal="value_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions/GridWidthValue" to="." method="_on_GridWidthValue_value_changed"]
-[connection signal="value_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions/GridHeightValue" to="." method="_on_GridHeightValue_value_changed"]
-[connection signal="color_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/GridOptions/GridColor" to="." method="_on_GridColor_color_changed"]
-[connection signal="value_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions/CheckerSizeValue" to="." method="_on_CheckerSize_value_changed"]
-[connection signal="color_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions/CheckerColor1" to="." method="_on_CheckerColor1_color_changed"]
-[connection signal="color_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Canvas/CheckerOptions/CheckerColor2" to="." method="_on_CheckerColor2_color_changed"]
-[connection signal="value_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions/ImageDefaultWidth" to="." method="_on_ImageDefaultWidth_value_changed"]
-[connection signal="value_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions/ImageDefaultHeight" to="." method="_on_ImageDefaultHeight_value_changed"]
-[connection signal="color_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Image/ImageOptions/DefaultFillColor" to="." method="_on_DefaultBackground_color_changed"]
+[connection signal="item_selected" from="HSplitContainer/List" to="." method="_on_List_item_selected"]
 [connection signal="item_selected" from="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/HBoxContainer/PresetOptionButton" to="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts" method="_on_PresetOptionButton_item_selected"]
 [connection signal="confirmed" from="Popups/ShortcutSelector" to="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts" method="_on_ShortcutSelector_confirmed"]
 [connection signal="popup_hide" from="Popups/ShortcutSelector" to="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts" method="_on_ShortcutSelector_popup_hide"]


### PR DESCRIPTION
Using a table to auto set/get prop in global, config key and connect signal.

There are some global prop and config key is not same name in old code. The config key now is force to use the name of the global prop.

Change the tree in left side to item list, it is no need to use tree.

The autosave config value is move from OpenSave to Global because using auto code.