### PR TITLE
Enable multi-threaded rendering

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -423,5 +423,6 @@ file_logging/enable_file_logging=true
 quality/driver/driver_name="GLES2"
 quality/intended_usage/framebuffer_allocation=0
 quality/intended_usage/framebuffer_allocation.mobile=0
+threads/thread_model=2
 vram_compression/import_etc=true
 vram_compression/import_etc2=false


### PR DESCRIPTION
For access to VisualServer singleton from a separate thread in GDScript