### PR TITLE
Use the Dummy audio driver since Pixelorama doesn't play any sounds

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -109,6 +109,10 @@ config/macos_native_icon="res://assets/graphics/icons/icon.icns"
 config/windows_native_icon="res://assets/graphics/icons/icon.ico"
 config/Version="v0.8-dev"
 
+[audio]
+
+driver="Dummy"
+
 [autoload]
 
 Global="*res://src/Autoload/Global.gd"


### PR DESCRIPTION
This prevents Godot from appearing as an application playing sound while Pixelorama is running. This also decreases CPU usage (especially on macOS due to a known engine bug).