### PR TITLE
Add PAL palette format import

### DIFF
--- a/src/Autoload/HTML5FileExchange.gd
+++ b/src/Autoload/HTML5FileExchange.gd
@@ -47,7 +47,7 @@ func _define_js() -> void:
 		canceled = true;
 		var input = document.createElement('INPUT');
 		input.setAttribute("type", "file");
-		input.setAttribute("accept", "application/json, .gpl, image/png, image/jpeg, image/webp");
+		input.setAttribute("accept", "application/json, .gpl, .pal, image/png, image/jpeg, image/webp");
 		input.click();
 		input.addEventListener('change', event => {
 			if (event.target.files.length > 0){
@@ -172,6 +172,10 @@ func load_palette() -> void:
 	if file_name.ends_with(".gpl"):
 		var palette := Palette.new()
 		palette = Import.import_gpl(file_name, palette_data)
+		Global.palette_container.attempt_to_import_palette(palette)
+	elif file_name.end_with(".pal"):
+		var palette := Palette.new()
+		palette = Import.import_pal_palette(file_name, palette_data)
 		Global.palette_container.attempt_to_import_palette(palette)
 	else:
 		match file_type:

--- a/src/Autoload/HTML5FileExchange.gd
+++ b/src/Autoload/HTML5FileExchange.gd
@@ -173,7 +173,7 @@ func load_palette() -> void:
 		var palette := Palette.new()
 		palette = Import.import_gpl(file_name, palette_data)
 		Global.palette_container.attempt_to_import_palette(palette)
-	elif file_name.end_with(".pal"):
+	elif file_name.ends_with(".pal"):
 		var palette := Palette.new()
 		palette = Import.import_pal_palette(file_name, palette_data)
 		Global.palette_container.attempt_to_import_palette(palette)

--- a/src/Autoload/Import.gd
+++ b/src/Autoload/Import.gd
@@ -301,7 +301,7 @@ func import_pal_palette(path : String, text : String) -> Palette:
 
 	var lines = text.split('\n')
 
-	if lines[0] != 'JASC-PAL' or lines[1] != '0100':
+	if not 'JASC-PAL' in lines[0] or not '0100' in lines[1]:
 		return result
 	else:
 		result = Palette.new()

--- a/src/Autoload/Import.gd
+++ b/src/Autoload/Import.gd
@@ -294,3 +294,28 @@ func import_png_palette(path: String, image : Image) -> Palette:
 	result.name = path.get_basename().get_file()
 
 	return result
+
+
+func import_pal_palette(path : String, text : String) -> Palette:
+	var result: Palette = null
+
+	var lines = text.split('\n')
+
+	if lines[0] != 'JASC-PAL' or lines[1] != '0100':
+		return result
+	else:
+		result = Palette.new()
+		result.name = path.get_basename().get_file()
+
+	var num_colors = int(lines[2])
+
+	for i in range(3, num_colors + 3):
+		var color_data = lines[i].split(' ')
+		var red : float = color_data[0].to_float() / 255.0
+		var green : float = color_data[1].to_float() / 255.0
+		var blue : float = color_data[2].to_float() / 255.0
+
+		var color = Color(red, green, blue)
+		result.add_color(color)
+
+	return result

--- a/src/Palette/PaletteContainer.gd
+++ b/src/Palette/PaletteContainer.gd
@@ -58,6 +58,13 @@ func on_palette_import_file_selected(path : String) -> void:
 			var text = file.get_as_text()
 			file.close()
 			palette = Import.import_gpl(path, text)
+	elif path.to_lower().ends_with("pal"):
+		var file = File.new()
+		if file.file_exists(path):
+			file.open(path, File.READ)
+			var text = file.get_as_text()
+			file.close()
+			palette = Import.import_pal_palette(path, text)
 	elif path.to_lower().ends_with("png") or path.to_lower().ends_with("bmp") or path.to_lower().ends_with("hdr") or path.to_lower().ends_with("jpg") or path.to_lower().ends_with("svg") or path.to_lower().ends_with("tga") or path.to_lower().ends_with("webp"):
 		var image := Image.new()
 		var err := image.load(path)

--- a/src/Palette/PaletteImportFileDialog.tscn
+++ b/src/Palette/PaletteImportFileDialog.tscn
@@ -10,6 +10,6 @@ window_title = "Open a File"
 resizable = true
 mode = 0
 access = 2
-filters = PoolStringArray( "*.json ; JavaScript Object Notation", "*.gpl ; Gimp Palette Library", "*.png; Portable Network Graphics" )
+filters = PoolStringArray( "*.json ; JavaScript Object Notation", "*.gpl ; Gimp Palette Library", "*.png; Portable Network Graphics", "*.pal; JASC Palette" )
 current_dir = "/Users"
 current_path = "/Users/"

--- a/src/Palette/PalettePanelContainer.tscn
+++ b/src/Palette/PalettePanelContainer.tscn
@@ -175,7 +175,6 @@ margin_left = 7.0
 margin_top = 7.0
 margin_right = 507.0
 margin_bottom = 307.0
-filters = PoolStringArray( "*.json ; JavaScript Object Notation", "*.gpl ; Gimp Palette Library", "*.png; Portable Network Graphics", "*.pal; JASC Palette" )
 
 [node name="EditPalettePopup" parent="." instance=ExtResource( 7 )]
 margin_left = 7.0

--- a/src/Palette/PalettePanelContainer.tscn
+++ b/src/Palette/PalettePanelContainer.tscn
@@ -175,6 +175,7 @@ margin_left = 7.0
 margin_top = 7.0
 margin_right = 507.0
 margin_bottom = 307.0
+filters = PoolStringArray( "*.json ; JavaScript Object Notation", "*.gpl ; Gimp Palette Library", "*.png; Portable Network Graphics", "*.pal; JASC Palette" )
 
 [node name="EditPalettePopup" parent="." instance=ExtResource( 7 )]
 margin_left = 7.0


### PR DESCRIPTION
Added a PAL importer to fix #307. I used a palette from Lowspec to test: [Isa's Limited Ramps](https://lospec.com/palette-list/isas-limited-ramps)

**Before palette import**
Before I imported the palette, you can see that it doesn't exist.
![image](https://user-images.githubusercontent.com/1484070/91215317-5453d900-e6e2-11ea-9746-084532d52384.png)

**Adding the accepted file formats**
![image](https://user-images.githubusercontent.com/1484070/91215416-78171f00-e6e2-11ea-973f-9a9432e148b8.png)

**Post-import Palette**
The palette takes the file name as the palette name. Note there are 28 colors which match the number of colors in the palette. 
![image](https://user-images.githubusercontent.com/1484070/91242588-d9a4b100-e715-11ea-98d3-0ef6a04871d7.png)

Let me know if I need to change anything.