### PR TITLE
Add transparent checker to export dialog and animation cels

### DIFF
--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -15,7 +15,7 @@ onready var export_progress_popup = $Popups/ExportProgressBar
 onready var export_progress_bar = $Popups/ExportProgressBar/MarginContainer/ProgressBar
 
 onready var animation_options_multiple_animations_directories = $VBoxContainer/AnimationOptions/MultipleAnimationsDirectories
-onready var previews = $VBoxContainer/PreviewScroll/Previews
+onready var previews = $VBoxContainer/PreviewPanel/PreviewScroll/Previews
 onready var frame_timer = $FrameTimer
 
 onready var frame_options = $VBoxContainer/FrameOptions
@@ -260,6 +260,9 @@ func _on_ExportDialog_about_to_show() -> void:
 
 	Export.file_exists_alert = tr("File %s already exists. Overwrite?") # Update translation
 
+	# Set the size of the preview checker
+	var checker = $VBoxContainer/PreviewPanel/TransparentChecker
+	checker.rect_size = checker.get_parent().rect_size
 
 func _on_Tabs_tab_clicked(tab : int) -> void:
 	Export.current_tab = tab
@@ -364,7 +367,7 @@ func _on_FileExistsAlert_custom_action(action : String) -> void:
 
 var pingpong_direction = Export.AnimationDirection.FORWARD
 func _on_FrameTimer_timeout() -> void:
-	$VBoxContainer/PreviewScroll/Previews/PreviewContainer/Preview.texture = animated_preview_frames[animated_preview_current_frame]
+	$VBoxContainer/PreviewPanel/PreviewScroll/Previews/PreviewContainer/Preview.texture = animated_preview_frames[animated_preview_current_frame]
 
 	match Export.direction:
 		Export.AnimationDirection.FORWARD:

--- a/src/UI/Dialogs/ExportDialog.tscn
+++ b/src/UI/Dialogs/ExportDialog.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://src/UI/Dialogs/ExportDialog.gd" type="Script" id=1]
+[ext_resource path="res://src/UI/TransparentChecker.tscn" type="PackedScene" id=2]
 
 [node name="ExportDialog" type="AcceptDialog"]
 margin_right = 532.0
@@ -41,14 +42,29 @@ margin_right = 516.0
 margin_bottom = 50.0
 text = "Preview:"
 
-[node name="PreviewScroll" type="ScrollContainer" parent="VBoxContainer"]
+[node name="PreviewPanel" type="Panel" parent="VBoxContainer"]
 margin_top = 54.0
 margin_right = 516.0
 margin_bottom = 278.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Previews" type="GridContainer" parent="VBoxContainer/PreviewScroll"]
+[node name="TransparentChecker" parent="VBoxContainer/PreviewPanel" instance=ExtResource( 2 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = 0.0
+margin_bottom = 0.0
+
+[node name="PreviewScroll" type="ScrollContainer" parent="VBoxContainer/PreviewPanel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Previews" type="GridContainer" parent="VBoxContainer/PreviewPanel/PreviewScroll"]
 margin_right = 516.0
 margin_bottom = 224.0
 size_flags_horizontal = 3

--- a/src/UI/Timeline/CelButton.gd
+++ b/src/UI/Timeline/CelButton.gd
@@ -17,6 +17,10 @@ func _ready() -> void:
 		popup_menu.set_item_text(4, "Link Cel")
 		popup_menu.set_item_metadata(4, "Link Cel")
 
+	# Reset the checkers size because it assumes you want the same size as the canvas
+	var checker = $CelTexture/TransparentChecker
+	checker.rect_size = checker.get_parent().rect_size
+
 
 func _on_CelButton_pressed() -> void:
 	if Input.is_action_just_released("left_mouse"):

--- a/src/UI/Timeline/CelButton.tscn
+++ b/src/UI/Timeline/CelButton.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://src/UI/Timeline/CelButton.gd" type="Script" id=1]
-
-
+[ext_resource path="res://src/UI/TransparentChecker.tscn" type="PackedScene" id=2]
 
 [node name="CelButton" type="Button"]
 margin_top = 18.0
@@ -32,6 +31,13 @@ stretch_mode = 6
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="TransparentChecker" parent="CelTexture" instance=ExtResource( 2 )]
+show_behind_parent = true
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = 0.0
+margin_bottom = 0.0
 
 [node name="PopupMenu" type="PopupMenu" parent="."]
 margin_right = 20.0


### PR DESCRIPTION
I added transparent backgrounds to both the export dialog and the animation cels. Fixes #206 if there's nothing holding this issue up.

**Export Dialog**
I had to make a few changes to the node structure on the dialog, as the scroll container didn't take to kindly to me adding a child checker. Neither did the grid container. I ended up putting them in a panel and sticking the checker behind them.
![image](https://user-images.githubusercontent.com/1484070/91247164-a49d5c00-e71f-11ea-8475-b9eb4162df63.png)

Here is a preview of the new node structure.
![image](https://user-images.githubusercontent.com/1484070/91247185-b252e180-e71f-11ea-96be-c7ce9e1dd7d5.png)

**Animation Cels**
These were as simple as adding the child and selecting display behind parent.
![image](https://user-images.githubusercontent.com/1484070/91247217-c72f7500-e71f-11ea-9d09-b988ac782f26.png)
