### PR TITLE
Implement shrink option

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -43,6 +43,7 @@ var default_clear_color := Color.gray
 # Preferences
 var pressure_sensitivity_mode = Pressure_Sensitivity.NONE
 var open_last_project := false
+var shrink := 1.0
 var smooth_zoom := true
 var theme_type : int = Theme_Types.DARK
 var default_image_width := 64

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -63,6 +63,9 @@ func setup_application_window_size() -> void:
 		return
 	# Set a minimum window size to prevent UI elements from collapsing on each other.
 	OS.min_window_size = Vector2(1024, 576)
+	
+	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED,
+		SceneTree.STRETCH_ASPECT_IGNORE, Vector2(1014,576), Global.shrink)
 
 	# Restore the window position/size if values are present in the configuration cache
 	if Global.config_cache.has_section_key("window", "screen"):

--- a/src/Preferences/PreferencesDialog.gd
+++ b/src/Preferences/PreferencesDialog.gd
@@ -3,6 +3,7 @@ extends AcceptDialog
 # Preferences table: [Prop name in Global, relative node path, value type, default value]
 var preferences = [
 	["open_last_project", "Startup/StartupContainer/OpenLastProject", "pressed", Global.open_last_project],
+	["shrink", "Startup/ShrinkContainer/ShrinkHSlider", "value", Global.shrink],
 	["smooth_zoom", "Canvas/ZoomOptions/SmoothZoom", "pressed", Global.smooth_zoom],
 	["pressure_sensitivity_mode", "Startup/PressureSentivity/PressureSensitivityOptionButton", "selected", Global.pressure_sensitivity_mode],
 	["show_left_tool_icon", "Indicators/IndicatorsContainer/LeftToolIconCheckbox", "pressed", Global.show_left_tool_icon],
@@ -35,6 +36,7 @@ onready var list : ItemList = $HSplitContainer/List
 onready var right_side : VBoxContainer = $HSplitContainer/ScrollContainer/VBoxContainer
 onready var autosave_interval : SpinBox = $HSplitContainer/ScrollContainer/VBoxContainer/Backup/AutosaveContainer/AutosaveInterval
 onready var restore_default_button_scene = preload("res://src/Preferences/RestoreDefaultButton.tscn")
+onready var shrink_label : Label = $HSplitContainer/ScrollContainer/VBoxContainer/Startup/ShrinkContainer/ShrinkLabel
 
 
 func _ready() -> void:
@@ -171,3 +173,13 @@ func _on_List_item_selected(index : int) -> void:
 		if OS.get_name() == "HTML5":
 			content_list.erase("Startup")
 		child.visible = child.name == content_list[index]
+
+
+func _on_HSlider_value_changed(value):
+	shrink_label.text = str(value)
+
+
+func _on_ShrinkApplyButton_pressed():
+	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED,
+		SceneTree.STRETCH_ASPECT_IGNORE, Vector2(1014,576), Global.shrink)
+	Global.preferences_dialog.popup_centered(Vector2(400, 280))

--- a/src/Preferences/PreferencesDialog.gd
+++ b/src/Preferences/PreferencesDialog.gd
@@ -183,3 +183,5 @@ func _on_ShrinkApplyButton_pressed():
 	get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED,
 		SceneTree.STRETCH_ASPECT_IGNORE, Vector2(1014,576), Global.shrink)
 	Global.preferences_dialog.popup_centered(Vector2(400, 280))
+	Global.camera.zoom_100()
+	

--- a/src/Preferences/PreferencesDialog.tscn
+++ b/src/Preferences/PreferencesDialog.tscn
@@ -8,6 +8,7 @@
 [sub_resource type="ButtonGroup" id=1]
 
 [node name="PreferencesDialog" type="AcceptDialog"]
+visible = true
 margin_left = -3.0
 margin_top = 9.0
 margin_right = 419.0
@@ -51,12 +52,12 @@ size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HSplitContainer/ScrollContainer"]
 margin_right = 498.0
-margin_bottom = 24.0
+margin_bottom = 48.0
 size_flags_horizontal = 3
 
 [node name="Startup" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
 margin_right = 498.0
-margin_bottom = 24.0
+margin_bottom = 48.0
 
 [node name="StartupContainer" type="HBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Startup"]
 margin_right = 498.0
@@ -78,9 +79,9 @@ text = "On"
 
 [node name="PressureSentivity" type="HBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Startup"]
 visible = false
-margin_top = 100.0
-margin_right = 506.0
-margin_bottom = 120.0
+margin_top = 28.0
+margin_right = 498.0
+margin_bottom = 48.0
 
 [node name="PressureSensitivityLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Startup/PressureSentivity"]
 margin_top = 3.0
@@ -95,6 +96,44 @@ margin_bottom = 20.0
 text = "Affect Brush's Alpha"
 items = [ "None", null, false, 0, null, "Affect Brush's Alpha", null, false, 1, null ]
 selected = 1
+
+[node name="ShrinkContainer" type="HBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Startup"]
+margin_top = 28.0
+margin_right = 498.0
+margin_bottom = 48.0
+
+[node name="Label" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Startup/ShrinkContainer"]
+margin_top = 3.0
+margin_right = 68.0
+margin_bottom = 17.0
+text = "Shrink GUI"
+
+[node name="ShrinkLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Startup/ShrinkContainer"]
+margin_left = 72.0
+margin_top = 3.0
+margin_right = 122.0
+margin_bottom = 17.0
+rect_min_size = Vector2( 50, 0 )
+text = "1"
+align = 2
+
+[node name="ShrinkHSlider" type="HSlider" parent="HSplitContainer/ScrollContainer/VBoxContainer/Startup/ShrinkContainer"]
+margin_left = 126.0
+margin_right = 446.0
+margin_bottom = 16.0
+size_flags_horizontal = 3
+min_value = 1.0
+max_value = 4.0
+step = 0.5
+value = 1.0
+tick_count = 7
+ticks_on_borders = true
+
+[node name="ShrinkApplyButton" type="Button" parent="HSplitContainer/ScrollContainer/VBoxContainer/Startup/ShrinkContainer"]
+margin_left = 450.0
+margin_right = 498.0
+margin_bottom = 20.0
+text = "Apply"
 
 [node name="Languages" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
 visible = false
@@ -912,6 +951,8 @@ __meta__ = {
 [connection signal="about_to_show" from="." to="." method="_on_PreferencesDialog_about_to_show"]
 [connection signal="popup_hide" from="." to="." method="_on_PreferencesDialog_popup_hide"]
 [connection signal="item_selected" from="HSplitContainer/List" to="." method="_on_List_item_selected"]
+[connection signal="value_changed" from="HSplitContainer/ScrollContainer/VBoxContainer/Startup/ShrinkContainer/ShrinkHSlider" to="." method="_on_HSlider_value_changed"]
+[connection signal="pressed" from="HSplitContainer/ScrollContainer/VBoxContainer/Startup/ShrinkContainer/ShrinkApplyButton" to="." method="_on_ShrinkApplyButton_pressed"]
 [connection signal="item_selected" from="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts/HBoxContainer/PresetOptionButton" to="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts" method="_on_PresetOptionButton_item_selected"]
 [connection signal="confirmed" from="Popups/ShortcutSelector" to="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts" method="_on_ShortcutSelector_confirmed"]
 [connection signal="popup_hide" from="Popups/ShortcutSelector" to="HSplitContainer/ScrollContainer/VBoxContainer/Shortcuts" method="_on_ShortcutSelector_popup_hide"]

--- a/src/UI/Canvas/Canvas.gd
+++ b/src/UI/Canvas/Canvas.gd
@@ -50,7 +50,10 @@ func _input(event : InputEvent) -> void:
 #	elif not get_viewport_rect().has_point(event.position):
 #		return
 
-	current_pixel = get_local_mouse_position() + location
+	#current_pixel = get_local_mouse_position() + location
+	var tmp_transform = get_canvas_transform().affine_inverse()
+	var tmp_position = Global.main_viewport.get_local_mouse_position()
+	current_pixel = tmp_transform.basis_xform(tmp_position)+tmp_transform.origin
 
 	if Global.has_focus:
 		update()


### PR DESCRIPTION
Hello,

On my computer Pixelorama was unusable because of tiny size of the GUI. I using Linux with a screen with HiDPI but godot does not support HiDPI for Linux.

This patch some how fix the issue with an option to set the shrink value. This values is used by godot to scale the whole application. The option is available in the configuration panel of the godot project and it can be changed in live by the application. The purpose of this patch the add an option in the Parameter>Startup section to do the job.

I see few possible issue, in particular if the value is set at a too high value and the parameter screen is not usable anymore. Otherwise it work nice.

Let me know if you want some change.

Best regards.

Overloaded edit: Closes #140 