### PR TITLE
Allow zooming with a touchpad

### DIFF
--- a/src/UI/Canvas/CameraMovement.gd
+++ b/src/UI/Canvas/CameraMovement.gd
@@ -128,6 +128,11 @@ func _input(event : InputEvent) -> void:
 			zoom_camera(1)
 		elif event is InputEventPanGesture: # Pan Gesture on a Latop touchpad
 			zoom_camera(round(event.delta.y))
+		elif event is InputEventMagnifyGesture: # Zoom Gesture on a Laptop touchpad
+			if event.factor < 1:
+				zoom_camera(1)
+			else:
+				zoom_camera(-1)
 		elif event is InputEventMouseMotion && drag:
 			offset = offset - event.relative * zoom
 			update_transparent_checker_offset()

--- a/src/UI/Canvas/CameraMovement.gd
+++ b/src/UI/Canvas/CameraMovement.gd
@@ -126,6 +126,8 @@ func _input(event : InputEvent) -> void:
 			zoom_camera(-1)
 		elif event.is_action_pressed("zoom_out"): # Wheel Down Event
 			zoom_camera(1)
+		elif event is InputEventPanGesture: # Pan Gesture on a Latop touchpad
+			zoom_camera(round(event.delta.y))
 		elif event is InputEventMouseMotion && drag:
 			offset = offset - event.relative * zoom
 			update_transparent_checker_offset()


### PR DESCRIPTION
Now through panning/zooming on a touchpad (e.g. from a latpop) it's possible to zoom.
I think I'll open another PR later so that panning moves the viewport (#271), let me know what you think.
The motions performed are "Panning with Inertia" and "Zoom" in this picture:
![grafik](https://user-images.githubusercontent.com/47503977/101202630-cf297a00-3669-11eb-8c48-a0690254165d.png)
