### PR TITLE
Change shortcut key from CTRL to CMD on OSX

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -176,6 +176,8 @@ onready var current_version : String = ProjectSettings.get_setting("application/
 
 func _ready() -> void:
 	randomize()
+	if OS.get_name() == "OSX":
+		use_osx_shortcuts()
 	if OS.has_feature("standalone"):
 		root_directory = OS.get_executable_path().get_base_dir()
 	# Load settings from the config file
@@ -551,3 +553,13 @@ func save_project_to_recent_list(path : String) -> void:
 func update_recent_projects_submenu() -> void:
 	for project in Global.recent_projects:
 		recent_projects_submenu.add_item(project.get_file())
+
+func use_osx_shortcuts() -> void:
+	var inputmap := InputMap 
+	
+	for action in inputmap.get_actions():
+		var event : InputEvent = inputmap.get_action_list(action)[0] 
+		
+		if event.control:
+			event.control = false
+			event.command = true


### PR DESCRIPTION
Note that the events in the InputMap still are like this: `ctrl + cmd + s`. Maybe you wanna change it to something like this: `ctrl + s` someday. Also thanks for the better solution!
Closes #67.