### PR TITLE
Remove unneeded Canvas.location, Grid.location, TileMode.location

### DIFF
--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -320,7 +320,7 @@ func blend_layers(image : Image, frame : Frame, origin : Vector2 = Vector2(0, 0)
 						var pixel_color := cel_image.get_pixel(xx, yy)
 						var alpha : float = pixel_color.a * cel.opacity
 						cel_image.set_pixel(xx, yy, Color(pixel_color.r, pixel_color.g, pixel_color.b, alpha))
-			image.blend_rect(cel_image, Rect2(Global.canvas.location, Global.current_project.size), origin)
+			image.blend_rect(cel_image, Rect2(Vector2.ZERO, Global.current_project.size), origin)
 			cel_image.unlock()
 		layer_i += 1
 	image.unlock()

--- a/src/UI/Canvas/Canvas.gd
+++ b/src/UI/Canvas/Canvas.gd
@@ -2,7 +2,6 @@ class_name Canvas
 extends Node2D
 
 
-var location := Vector2.ZERO
 var fill_color := Color(0, 0, 0, 0)
 var current_pixel := Vector2.ZERO
 var can_undo := true
@@ -40,7 +39,7 @@ func _draw() -> void:
 	for i in range(Global.current_project.layers.size()):
 		var modulate_color := Color(1, 1, 1, current_cels[i].opacity)
 		if Global.current_project.layers[i].visible: # if it's visible
-			draw_texture(current_cels[i].image_texture, location, modulate_color)
+			draw_texture(current_cels[i].image_texture, Vector2.ZERO, modulate_color)
 
 	if Global.onion_skinning:
 		onion_skinning()
@@ -65,7 +64,7 @@ func _input(event : InputEvent) -> void:
 	# value when shrink parameter is not equal to one. At godot version 3.2.3
 	var tmp_transform = get_canvas_transform().affine_inverse()
 	var tmp_position = Global.main_viewport.get_local_mouse_position()
-	current_pixel = tmp_transform.basis_xform(tmp_position) + tmp_transform.origin + location
+	current_pixel = tmp_transform.basis_xform(tmp_position) + tmp_transform.origin
 
 	if Global.has_focus:
 		update()
@@ -237,7 +236,7 @@ func onion_skinning() -> void:
 				for layer in Global.current_project.frames[Global.current_project.current_frame - i].cels:
 					if Global.current_project.layers[layer_i].visible:
 						color.a = 0.6 / i
-						draw_texture(layer.image_texture, location, color)
+						draw_texture(layer.image_texture, Vector2.ZERO, color)
 					layer_i += 1
 
 	# Future
@@ -253,5 +252,5 @@ func onion_skinning() -> void:
 				for layer in Global.current_project.frames[Global.current_project.current_frame + i].cels:
 					if Global.current_project.layers[layer_i].visible:
 						color.a = 0.6 / i
-						draw_texture(layer.image_texture, location, color)
+						draw_texture(layer.image_texture, Vector2.ZERO, color)
 					layer_i += 1

--- a/src/UI/Canvas/Grid.gd
+++ b/src/UI/Canvas/Grid.gd
@@ -1,7 +1,6 @@
 extends Node2D
 
 
-var location := Vector2.ZERO
 var isometric_polylines := [] # An array of PoolVector2Arrays
 
 
@@ -14,10 +13,10 @@ func draw_grid(grid_type : int) -> void:
 	var size : Vector2 = Global.transparent_checker.rect_size
 	if grid_type == Global.Grid_Types.CARTESIAN || grid_type == Global.Grid_Types.ALL:
 		for x in range(Global.grid_width, size.x, Global.grid_width):
-			draw_line(Vector2(x, location.y), Vector2(x, size.y), Global.grid_color, true)
+			draw_line(Vector2(x, 0), Vector2(x, size.y), Global.grid_color, true)
 
 		for y in range(Global.grid_height, size.y, Global.grid_height):
-			draw_line(Vector2(location.x, y), Vector2(size.x, y), Global.grid_color, true)
+			draw_line(Vector2(0, y), Vector2(size.x, y), Global.grid_color, true)
 
 	if grid_type == Global.Grid_Types.ISOMETRIC || grid_type == Global.Grid_Types.ALL:
 		var i := 0

--- a/src/UI/Canvas/Rulers/Guide.gd
+++ b/src/UI/Canvas/Rulers/Guide.gd
@@ -28,7 +28,7 @@ func _input(_event : InputEvent):
 		point0.x -= width * 3
 		point1.x += width * 3
 	if Global.can_draw and Global.has_focus and point_in_rectangle(mouse_pos, point0, point1) and Input.is_action_just_pressed("left_mouse") and visible:
-		if !point_in_rectangle(Global.canvas.current_pixel, Global.canvas.location, Global.canvas.location + project.size):
+		if !point_in_rectangle(Global.canvas.current_pixel, Vector2.ZERO, project.size):
 			has_focus = true
 			Global.has_focus = false
 			update()

--- a/src/UI/Canvas/TileMode.gd
+++ b/src/UI/Canvas/TileMode.gd
@@ -1,9 +1,6 @@
 extends Node2D
 
 
-var location := Vector2.ZERO
-
-
 func _draw() -> void:
 	var size : Vector2 = Global.current_project.size
 	var positions : Array = get_tile_positions(size)
@@ -28,24 +25,24 @@ func get_tile_positions(size):
 	match Global.current_project.tile_mode:
 		1:
 			return [
-				Vector2(location.x, location.y + size.y), # Down
-				Vector2(location.x - size.x, location.y + size.y), # Down left
-				Vector2(location.x - size.x, location.y), # Left
-				location - size, # Up left
-				Vector2(location.x, location.y - size.y), # Up
-				Vector2(location.x + size.x, location.y - size.y), # Up right
-				Vector2(location.x + size.x, location.y), # Right
-				location + size # Down right
+				Vector2(0, size.y), # Down
+				Vector2(-size.x, size.y), # Down left
+				Vector2(-size.x, 0), # Left
+				-size, # Up left
+				Vector2(0, -size.y), # Up
+				Vector2(size.x, -size.y), # Up right
+				Vector2(size.x, 0), # Right
+				size # Down right
 			]
 		2:
 			return [
-				Vector2(location.x + size.x, location.y), # Right
-				Vector2(location.x - size.x, location.y), # Left
+				Vector2(size.x, 0), # Right
+				Vector2(-size.x, 0), # Left
 			]
 		3:
 			return [
-				Vector2(location.x, location.y + size.y), # Down
-				Vector2(location.x, location.y - size.y), # Up
+				Vector2(0, size.y), # Down
+				Vector2(0, -size.y), # Up
 			]
 		_:
 			return []

--- a/src/UI/Dialogs/ImageEffects/ResizeCanvas.gd
+++ b/src/UI/Dialogs/ImageEffects/ResizeCanvas.gd
@@ -31,7 +31,7 @@ func _on_ResizeCanvas_about_to_show() -> void:
 						var pixel_color := cel_image.get_pixel(xx, yy)
 						var alpha : float = pixel_color.a * cel.opacity
 						cel_image.set_pixel(xx, yy, Color(pixel_color.r, pixel_color.g, pixel_color.b, alpha))
-			image.blend_rect(cel_image, Rect2(Global.canvas.location, Global.current_project.size), Vector2.ZERO)
+			image.blend_rect(cel_image, Rect2(Vector2.ZERO, Global.current_project.size), Vector2.ZERO)
 		layer_i += 1
 	image.unlock()
 

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -465,7 +465,7 @@ func _on_MergeDownLayer_pressed() -> void:
 		var new_layer := Image.new()
 		new_layer.copy_from(f.cels[Global.current_project.current_layer - 1].image)
 		new_layer.lock()
-		new_layer.blend_rect(selected_layer, Rect2(Global.canvas.location, Global.current_project.size), Vector2.ZERO)
+		new_layer.blend_rect(selected_layer, Rect2(Vector2.ZERO, Global.current_project.size), Vector2.ZERO)
 		new_cels.remove(Global.current_project.current_layer)
 		if !selected_layer.is_invisible() and Global.current_project.layers[Global.current_project.current_layer - 1].linked_cels.size() > 1 and (f in Global.current_project.layers[Global.current_project.current_layer - 1].linked_cels):
 			new_layers[Global.current_project.current_layer - 1].linked_cels.erase(f)


### PR DESCRIPTION
All of these are initialized to `Vector.ZERO` and they're never changed. Also all of these classes (`Canvas`, `Grid`, `TileMode`) extend `Node2D` and thus each of them has a `transform` and a `position` (which is for example used instead of `location` when drawing mirrored view).