### PR TITLE
Speedup Draw.update_mask()

### DIFF
--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -131,10 +131,10 @@ func update_mirror_brush() -> void:
 
 func update_mask() -> void:
 	var size := _get_draw_image().get_size()
-	_mask = PoolByteArray()
-	_mask.resize(size.x * size.y)
-	for i in _mask.size():
-		_mask[i] = 0
+	# Faster then zeroing PoolByteArray directly. See: https://github.com/Orama-Interactive/Pixelorama/pull/439
+	var nulled_array := []
+	nulled_array.resize(size.x * size.y)
+	_mask = PoolByteArray(nulled_array)
 
 
 func update_line_polylines(start : Vector2, end : Vector2) -> void:


### PR DESCRIPTION
`Draw.update_mask()` is slow and it's being called by tools (pencil etc.) every time on `draw_start()`. This PR makes it a little faster by using the fact that [Array.resize()](https://docs.godotengine.org/en/3.2/classes/class_array.html?highlight=array#class-array-method-resize) makes new elements null contrary to [PoolByteArray.resize()](https://docs.godotengine.org/en/3.2/classes/class_poolbytearray.html#class-poolbytearray-method-resize) which isn't zeroing new elements.
<details>
<summary>PoolByteArray created by passing in Array with nulls is indeed zeroed.</summary>

```
var n := 10
var a := PoolByteArray()
a.resize(n)
print(a.hex_encode())
for i in range(n):
    a[i] = 0
print(a.hex_encode())

var arr := []
arr.resize(n)
print(arr)
var b := PoolByteArray(arr)
print(b.hex_encode())
```
example output:
```
7200650073003a002f00
00000000000000000000
[Null, Null, Null, Null, Null, Null, Null, Null, Null, Null]
00000000000000000000
```
</details>

---
Example comparison of execution times for 1920x1080 canvas size (calls are trigerred by single clicks with pencil tool):
![kVFCHsJbi0](https://user-images.githubusercontent.com/9283098/105207067-59a93880-5b47-11eb-9379-f8d578e5fdc2.png)

It's still not good but it's better.