### PR TITLE
Fix hue and saturation getting reset when draging value slider to zero

### DIFF
--- a/src/UI/ColorAndToolOptions.gd
+++ b/src/UI/ColorAndToolOptions.gd
@@ -22,10 +22,12 @@ func _on_ColorPickerButton_color_changed(color : Color, right : bool):
 
 func _on_ColorPickerButton_pressed() -> void:
 	Global.can_draw = false
+	Tools.disconnect("color_changed", self, "update_color")
 
 
 func _on_ColorPickerButton_popup_closed() -> void:
 	Global.can_draw = true
+	Tools.connect("color_changed", self, "update_color")
 
 
 func _on_ColorDefaults_pressed() -> void:


### PR DESCRIPTION
The color picker widget in HSV mode was resetting HS when you drag V to zero.

Thought about changing Tools.assign_color() to take an optional `signal_color_changed` boolean. But, I can imagine other objects connected to `Tool.color_changed` that may want dynamic updates as you use a color picker in the future. So the fix here is to temporarily disconnect `ColorAndToolOptions` from `Tool.color_changed` while the popup is active. This isolates the fix to the thing that needs fixing.

### Bug:
![hsv-slider-bug](https://user-images.githubusercontent.com/3495802/113241055-e83ee200-927b-11eb-9653-22238b9f4858.gif)

### Fix:
![hsv-slider-fix](https://user-images.githubusercontent.com/3495802/113241075-f4c33a80-927b-11eb-8fb5-d9f9deb9ddd7.gif)