### PR TITLE
Use CMD+Shift+H for showing the pixel grid on OSX

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -678,6 +678,9 @@ func use_osx_shortcuts() -> void:
 
 	for action in inputmap.get_actions():
 		var event : InputEvent = inputmap.get_action_list(action)[0]
+		
+		if event.is_action("show_pixel_grid"):
+			event.shift = true
 
 		if event.control:
 			event.control = false


### PR DESCRIPTION
Fixes #493

It's debatable if it's the right choice, just using Shift, but I think it's fine.