### PR TITLE
Faster Preview for HSV

### DIFF
--- a/src/Classes/ImageEffect.gd
+++ b/src/Classes/ImageEffect.gd
@@ -13,6 +13,7 @@ var preview_texture : ImageTexture
 var preview : TextureRect
 var selection_checkbox : CheckBox
 var affect_option_button : OptionButton
+var shrink_preview: bool = false
 
 
 func _ready() -> void:
@@ -112,6 +113,8 @@ func update_preview() -> void:
 			preview_image.copy_from(current_cel)
 		_:
 			preview_image.copy_from(current_frame)
+	if shrink_preview:
+		preview_image.resize(preview_image.get_width()/3, preview_image.get_height()/3,0)
 	commit_action(preview_image)
 	preview_image.unlock()
 	preview_texture.create_from_image(preview_image, 0)

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.gd
@@ -12,6 +12,8 @@ onready var val_spinbox = $VBoxContainer/HBoxContainer/TextBoxes/Value
 var shaderPath : String = "res://src/Shaders/HSV.shader"
 
 var confirmed: bool = false
+
+
 func _about_to_show():
 	reset()
 	var sm : ShaderMaterial = ShaderMaterial.new()
@@ -35,13 +37,23 @@ func _confirmed() -> void:
 func commit_action(_cel : Image, _project : Project = Global.current_project) -> void:
 	var selection = _project.bitmap_to_image(_project.selection_bitmap, false)
 	var selection_tex = ImageTexture.new()
-	selection_tex.create_from_image(selection)
-
+	selection_tex.create_from_image(selection, 3)
+	var preview_selection_tex
+	if shrink_preview:
+		var preview_selection = Image.new()
+		preview_selection.copy_from(selection)
+		preview_selection.resize(preview_selection.get_width()/3, preview_selection.get_height()/3, 0)
+		preview_selection_tex = ImageTexture.new()
+		preview_selection_tex.create_from_image(selection, 3)
+	else:
+		preview_selection_tex = selection_tex
+	
+	
 	if !confirmed:
 		preview.material.set_shader_param("hue_shift_amount", hue_slider.value /360)
 		preview.material.set_shader_param("sat_shift_amount", sat_slider.value /100)
 		preview.material.set_shader_param("val_shift_amount", val_slider.value /100)
-		preview.material.set_shader_param("selection", selection_tex)
+		preview.material.set_shader_param("selection", preview_selection_tex)
 		preview.material.set_shader_param("affect_selection", selection_checkbox.pressed)
 		preview.material.set_shader_param("has_selection", _project.has_selection)
 	else:
@@ -103,4 +115,9 @@ func _on_Saturation_value_changed(value : float) -> void:
 func _on_Value_value_changed(value : float) -> void:
 	val_spinbox.value = value
 	val_slider.value = value
+	update_preview()
+
+
+func _on_ShrinkPreviewCheckBox_toggled(button_pressed):
+	shrink_preview = button_pressed
 	update_preview()

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.tscn
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.tscn
@@ -4,6 +4,7 @@
 [ext_resource path="res://src/UI/TransparentChecker.tscn" type="PackedScene" id=2]
 
 [node name="HSVDialog" type="ConfirmationDialog"]
+visible = true
 margin_left = 1.0
 margin_top = -1.0
 margin_right = 464.0
@@ -34,10 +35,23 @@ stretch_mode = 5
 [node name="TransparentChecker" parent="VBoxContainer/Preview" instance=ExtResource( 2 )]
 show_behind_parent = true
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="ShrinkPreview" type="HBoxContainer" parent="VBoxContainer"]
 margin_top = 204.0
 margin_right = 447.0
-margin_bottom = 288.0
+margin_bottom = 228.0
+alignment = 2
+
+[node name="ShrinkPreviewCheckBox" type="CheckBox" parent="VBoxContainer/ShrinkPreview"]
+margin_left = 326.0
+margin_right = 447.0
+margin_bottom = 24.0
+hint_tooltip = "Shrinks preview by 3 times for fast updates. Not recommended for small Images."
+text = "Faster Preview"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 232.0
+margin_right = 447.0
+margin_bottom = 316.0
 custom_constants/separation = 10
 __meta__ = {
 "_edit_use_anchors_": false
@@ -131,9 +145,9 @@ mouse_default_cursor_shape = 1
 min_value = -100.0
 
 [node name="AffectHBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 292.0
+margin_top = 320.0
 margin_right = 447.0
-margin_bottom = 316.0
+margin_bottom = 344.0
 
 [node name="SelectionCheckBox" type="CheckBox" parent="VBoxContainer/AffectHBoxContainer"]
 margin_right = 160.0
@@ -144,13 +158,14 @@ text = "Only affect selection"
 
 [node name="AffectOptionButton" type="OptionButton" parent="VBoxContainer/AffectHBoxContainer"]
 margin_left = 164.0
-margin_right = 263.0
+margin_right = 278.0
 margin_bottom = 24.0
 mouse_default_cursor_shape = 2
 text = "Selected cels"
 items = [ "Selected cels", null, false, 0, null, "Current frame", null, false, 1, null, "All frames", null, false, 2, null, "All projects", null, false, 3, null ]
 selected = 0
 
+[connection signal="toggled" from="VBoxContainer/ShrinkPreview/ShrinkPreviewCheckBox" to="." method="_on_ShrinkPreviewCheckBox_toggled"]
 [connection signal="value_changed" from="VBoxContainer/HBoxContainer/Sliders/Hue" to="." method="_on_Hue_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/HBoxContainer/Sliders/Saturation" to="." method="_on_Saturation_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/HBoxContainer/Sliders/Value" to="." method="_on_Value_value_changed"]


### PR DESCRIPTION
1) Added checkbox in HSV Dialog to shrink preview image by 3 times as mentioned in #343.
2) Disables filter to make previews clearer 
3) Added `shrink_preview` to `ImageEffects.gd` so that any dialog can hook into it.