### PR TITLE
Shading Tool Hue Shift Fixes + Tweaks

### DIFF
--- a/src/Tools/Shading.gd
+++ b/src/Tools/Shading.gd
@@ -56,20 +56,16 @@ class LightenDarkenOp extends Drawer.ColorOp:
 			if lighten_or_darken == LightenDarken.LIGHTEN:
 				hue_shift = hue_limit_lighten(dst.h, hue_shift)
 				dst.h += hue_shift
-				dst.s -= sat_shift
+				if dst.s > sat_lighten_limit:
+					dst.s = max(dst.s - min(sat_shift, dst.s), sat_lighten_limit)
 				dst.v += value_shift
-				if dst.s < sat_lighten_limit:
-					dst.v = prev_value
-					dst.s = prev_sat
-					dst.h = prev_hue
 
 			else:
 				hue_shift = hue_limit_darken(dst.h, hue_shift)
 				dst.h -= hue_shift
 				dst.s += sat_shift
-				dst.v -= value_shift
-				if dst.v < value_darken_limit:
-					dst.v = prev_value
+				if dst.v > value_darken_limit:
+					dst.v = max(dst.v - min(value_shift, dst.v), value_darken_limit)
 
 		return dst
 

--- a/src/Tools/Shading.tscn
+++ b/src/Tools/Shading.tscn
@@ -113,7 +113,7 @@ margin_bottom = 42.0
 hint_tooltip = "Lighten/Darken amount"
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
-max_value = 359.0
+max_value = 180.0
 value = 10.0
 align = 1
 
@@ -128,7 +128,7 @@ focus_mode = 0
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
 size_flags_vertical = 1
-max_value = 359.0
+max_value = 180.0
 value = 10.0
 ticks_on_borders = true
 


### PR DESCRIPTION
- Changed hue_darken_limit from purple to blue.

- Limited the Hue Shift slider to a range of 180 so that half of it wouldn't always hit the hue shift limits.

- Fixed hue shifting issues:
  - Lightening past the limit would do nothing for some colors rather than set it to the hue limit: (Left side before, right side after)
![image](https://user-images.githubusercontent.com/65431647/130376796-cf2ca9fd-e23b-45e1-acc8-77a4451e4911.png)
  - Same happened with darkening for some colors (the red and magenta patches), while others would end up not being limited at all, instead going to incorrect hues (everywhere should have been changed purple).
![image](https://user-images.githubusercontent.com/65431647/130377030-d581ef4d-c000-4699-b0e9-5cd321f9834d.png)

- Also:

- When finally shifting the hue used fposmod to work around a Godot Color bug that made shifting the hue around the "ends" of the color wheel not always return the correct hue.

- Replaced 359.0 in code to 360.0 which fixed some instances of the hue shift being 1 off the expected value.

- To make a little easier to read removed the **!** on the hue_range check and flipped the results of the hue_range function.

- Updated comments to reflect changes, and make color ranges a little more specific.

- NOTE: Added a PR in the documentation repository for changing the shading limit from purple to blue.