### PR TITLE
Revised nn_rotate

### DIFF
--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -188,16 +188,33 @@ func nn_rotate(sprite : Image, angle : float, pivot : Vector2) -> void:
 	aux.copy_from(sprite)
 	sprite.lock()
 	aux.lock()
-	var ox: int
-	var oy: int
-	for x in range(sprite.get_width()):
-		for y in range(sprite.get_height()):
-			ox = (x - pivot.x)*cos(angle) + (y - pivot.y)*sin(angle) + pivot.x
-			oy = -(x - pivot.x)*sin(angle) + (y - pivot.y)*cos(angle) + pivot.y
-			if ox >= 0 && ox < sprite.get_width() && oy >= 0 && oy < sprite.get_height():
-				sprite.set_pixel(x, y, aux.get_pixel(ox, oy))
+	
+	var sin_angle : float = sin(angle)
+	var cos_angle : float = cos(angle)
+	var x_pivot : float = pivot.x
+	var y_pivot : float = pivot.y
+
+	var sprite_height : int = sprite.get_height()
+	var sprite_width : int = sprite.get_width()
+	var pixel_range : Array = range(0, sprite_height * sprite_width, 1)
+
+	for i in pixel_range:
+		# warning-ignore:integer_division
+		var dy: int = i / sprite_width
+		var dx: int = i % sprite_width
+		var y_offset: int = dy - y_pivot
+		var x_offset: int = dx - x_pivot
+
+		var oy: int = y_pivot - x_offset * sin_angle + y_offset * cos_angle
+		if oy >= 0 && oy < sprite_height:
+			var ox: int = x_pivot + x_offset * cos_angle + y_offset * sin_angle
+			if ox >= 0 && ox < sprite_width:
+				sprite.set_pixel(dx, dy, aux.get_pixel(ox, oy))
 			else:
-				sprite.set_pixel(x, y, Color(0,0,0,0))
+				sprite.set_pixel(dx, dy, Color(0, 0, 0, 0))
+		else:
+			sprite.set_pixel(dx, dy, Color(0, 0, 0, 0))
+
 	sprite.unlock()
 	aux.unlock()
 

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -220,13 +220,23 @@ func nn_rotate(sprite : Image, angle : float, pivot : Vector2) -> void:
 
 
 func similarColors(c1 : Color, c2 : Color, tol : float = 100) -> bool:
-	var dist = colorDistance(c1, c2)
-	return dist <= tol
+	# Euclidean distance in gamma sRGB is not a reliable indicator
+	# of perceptual similarity and should only be used as a proxy
+	# for a formula like CIEDE2000, CIE76, etc. See
+	# https://en.wikipedia.org/wiki/Color_difference
+	var distSq : float = colorDistanceSq(c1, c2)
+	return distSq <= (tol * tol)
 
 
 func colorDistance(c1 : Color, c2 : Color) -> float:
-		return sqrt(pow((c1.r - c2.r)*255, 2) + pow((c1.g - c2.g)*255, 2)
-		+ pow((c1.b - c2.b)*255, 2) + pow((c1.a - c2.a)*255, 2))
+	return sqrt(colorDistanceSq(c1, c2))
+
+
+func colorDistanceSq(c1 : Color, c2 : Color) -> float:
+		var rd : float = (c1.r - c2.r) * 255
+		var gd : float = (c1.g - c2.g) * 255
+		var bd : float = (c1.b - c2.b) * 255
+		return rd * rd + gd * gd + bd * bd
 
 # Image effects
 


### PR DESCRIPTION
Revised nearest neighbor rotate to use one dimensional loop, to cache the sine and cosine of the angle outside of the loop, and to treat rows as major and columns as minor in boundary checks.

Edit: Whoops, looks like a committed change to color similarity and sRGB gamma Euclidean distance was included in the pull request as well. I changed the evaluation to use Euclidean distance-squared.