### PR TITLE
Add buttons for looking at different Splashscreen Artworks

### DIFF
--- a/src/UI/Dialogs/SplashDialog.gd
+++ b/src/UI/Dialogs/SplashDialog.gd
@@ -1,21 +1,24 @@
 extends WindowDialog
 
 
-var artworks := {
-	"Roroto Sic" : [preload("res://assets/graphics/splash_screen/artworks/roroto.png"), "https://linktr.ee/Roroto_Sic"],
-	"Kamilayza" : [preload("res://assets/graphics/splash_screen/artworks/kamilayza.png"), "https://twitter.com/kamilayza"],
-	"Wishdream" : [preload("res://assets/graphics/splash_screen/artworks/wishdream.png"), "https://twitter.com/WishdreamStar"]
-}
+var artworks := [
+	["Roroto Sic", preload("res://assets/graphics/splash_screen/artworks/roroto.png"), "https://linktr.ee/Roroto_Sic"],
+	["Kamilayza", preload("res://assets/graphics/splash_screen/artworks/kamilayza.png"), "https://twitter.com/kamilayza"],
+	["Wishdream", preload("res://assets/graphics/splash_screen/artworks/wishdream.png"), "https://twitter.com/WishdreamStar"]
+]
 
-var chosen_artwork = ""
+var chosen_artwork : int
+
+var splash_art_texturerect : TextureRect
+var art_by_label : Button
 
 onready var latin_font = preload("res://assets/fonts/Roboto-Small.tres")
 onready var cjk_font = preload("res://assets/fonts/CJK/DroidSansFallback-Small.tres")
 
 
 func _on_SplashDialog_about_to_show() -> void:
-	var splash_art_texturerect : TextureRect = find_node("SplashArt")
-	var art_by_label : Button = find_node("ArtistName")
+	splash_art_texturerect = find_node("SplashArt")
+	art_by_label = find_node("ArtistName")
 	var show_on_startup_button : CheckBox = find_node("ShowOnStartup")
 	var copyright_label : Label = find_node("CopyrightLabel")
 
@@ -23,11 +26,8 @@ func _on_SplashDialog_about_to_show() -> void:
 		show_on_startup_button.pressed = !Global.config_cache.get_value("preferences", "startup")
 	window_title = "Pixelorama" + " " + Global.current_version
 
-	chosen_artwork = artworks.keys()[randi() % artworks.size()]
-	splash_art_texturerect.texture = artworks[chosen_artwork][0]
-
-	art_by_label.text = tr("Art by: %s") % chosen_artwork
-	art_by_label.hint_tooltip = artworks[chosen_artwork][1]
+	chosen_artwork = randi() % artworks.size()
+	change_artwork(0)
 
 	if Global.is_cjk(TranslationServer.get_locale()):
 		show_on_startup_button.add_font_override("font", cjk_font)
@@ -41,9 +41,19 @@ func _on_SplashDialog_about_to_show() -> void:
 	if OS.get_name() == "HTML5":
 		$Contents/ButtonsPatronsLogos/Buttons/OpenLastBtn.visible = false
 
+func change_artwork(var direction : int) -> void:
+	if chosen_artwork+direction > artworks.size()-1 or chosen_artwork+direction < 0:
+		chosen_artwork = 0 if direction == 1 else artworks.size()-1
+	else:
+		chosen_artwork = chosen_artwork+direction
+	
+	splash_art_texturerect.texture = artworks[chosen_artwork][1]
+
+	art_by_label.text = tr("Art by: %s") % artworks[chosen_artwork][0]
+	art_by_label.hint_tooltip = artworks[chosen_artwork][2]
 
 func _on_ArtCredits_pressed() -> void:
-	OS.shell_open(artworks[chosen_artwork][1])
+	OS.shell_open(artworks[chosen_artwork][2])
 
 
 func _on_ShowOnStartup_toggled(pressed : bool) -> void:
@@ -79,3 +89,9 @@ func _on_OpenBtn__pressed() -> void:
 func _on_OpenLastBtn_pressed() -> void:
 	visible = false
 	Global.top_menu_container.file_menu_id_pressed(2)
+
+func _on_ChangeArtBtnLeft_pressed():
+	change_artwork(-1)
+
+func _on_ChangeArtBtnRight_pressed():
+	change_artwork(1)

--- a/src/UI/Dialogs/SplashDialog.tscn
+++ b/src/UI/Dialogs/SplashDialog.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://src/UI/Dialogs/SplashDialog.gd" type="Script" id=1]
 [ext_resource path="res://assets/graphics/splash_screen/artworks/wishdream.png" type="Texture" id=2]
+[ext_resource path="res://assets/graphics/timeline/move_arrow.png" type="Texture" id=3]
 [ext_resource path="res://assets/fonts/Roboto-Small.tres" type="DynamicFont" id=7]
 [ext_resource path="res://assets/graphics/splash_screen/discord.png" type="Texture" id=9]
 [ext_resource path="res://assets/graphics/splash_screen/github_32px.png" type="Texture" id=10]
@@ -12,6 +13,18 @@ bg_color = Color( 0.0705882, 0.0705882, 0.0705882, 1 )
 border_width_top = 20
 border_color = Color( 0.403922, 0.403922, 0.403922, 1 )
 expand_margin_top = 20.0
+
+[sub_resource type="StyleBoxFlat" id=4]
+bg_color = Color( 0.6, 0.6, 0.6, 0 )
+
+[sub_resource type="StyleBoxFlat" id=5]
+bg_color = Color( 0.6, 0.6, 0.6, 0 )
+
+[sub_resource type="StyleBoxFlat" id=2]
+bg_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="StyleBoxFlat" id=3]
+bg_color = Color( 0.6, 0.6, 0.6, 0 )
 
 [node name="SplashDialog" type="WindowDialog"]
 margin_right = 640.0
@@ -39,6 +52,75 @@ rect_min_size = Vector2( 640, 406 )
 texture = ExtResource( 2 )
 expand = true
 stretch_mode = 6
+
+[node name="ChangeArtBtnLeft" type="Button" parent="Contents/SplashArt" groups=[
+"UIButtons",
+]]
+anchor_top = 0.5
+anchor_bottom = 0.5
+margin_left = 5.0
+margin_top = -10.0
+margin_right = 30.0
+margin_bottom = 10.0
+mouse_default_cursor_shape = 2
+custom_styles/hover = SubResource( 4 )
+custom_styles/pressed = SubResource( 5 )
+custom_styles/focus = SubResource( 5 )
+custom_styles/normal = SubResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TextureRect" type="TextureRect" parent="Contents/SplashArt/ChangeArtBtnLeft"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -10.0
+margin_top = -7.0
+margin_right = 10.0
+margin_bottom = 7.0
+texture = ExtResource( 3 )
+expand = true
+flip_h = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ChangeArtBtnRight" type="Button" parent="Contents/SplashArt" groups=[
+"UIButtons",
+]]
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+margin_left = -30.0
+margin_top = -10.0
+margin_right = -5.0
+margin_bottom = 10.0
+mouse_default_cursor_shape = 2
+custom_styles/hover = SubResource( 5 )
+custom_styles/pressed = SubResource( 5 )
+custom_styles/focus = SubResource( 5 )
+custom_styles/normal = SubResource( 3 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TextureRect" type="TextureRect" parent="Contents/SplashArt/ChangeArtBtnRight"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -10.0
+margin_top = -7.0
+margin_right = 10.0
+margin_bottom = 7.0
+texture = ExtResource( 3 )
+expand = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="ArtBy" type="HBoxContainer" parent="Contents"]
 margin_top = 414.0
@@ -222,6 +304,8 @@ __meta__ = {
 }
 
 [connection signal="about_to_show" from="." to="." method="_on_SplashDialog_about_to_show"]
+[connection signal="pressed" from="Contents/SplashArt/ChangeArtBtnLeft" to="." method="_on_ChangeArtBtnLeft_pressed"]
+[connection signal="pressed" from="Contents/SplashArt/ChangeArtBtnRight" to="." method="_on_ChangeArtBtnRight_pressed"]
 [connection signal="pressed" from="Contents/ArtBy/ArtistName" to="." method="_on_ArtCredits_pressed"]
 [connection signal="pressed" from="Contents/ButtonsPatronsLogos/Buttons/NewBtn" to="." method="_on_NewBtn_pressed"]
 [connection signal="pressed" from="Contents/ButtonsPatronsLogos/Buttons/OpenBtn" to="." method="_on_OpenBtn__pressed"]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47503977/133937863-5ffdda88-0940-469f-8f84-37381acc3655.png)
Two arrows are now located at the sides of the current artwork. When pressed the artwork changes to the one next in the array of artworks. The array was a dictionary before, but using it simplifies everything a lot.
Everything should be accounted for, the arrow icons change according to theme and the code checks that the array doesn't go out of bounds.