### PR TITLE
Add idle fps setting

### DIFF
--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -1055,13 +1055,13 @@ msgstr ""
 msgid "Set application FPS limit:"
 msgstr ""
 
-msgid "Limit FPS to 1 when app loses focus"
+msgid "Limit FPS to the idle FPS when app loses focus"
 msgstr ""
 
 msgid "Sets the limit of the application's frames per second. The lower the number, the lower the CPU usage, but the application gets slower, choppier and unresponsive. 0 means that there is no limit."
 msgstr ""
 
-msgid "If this is toggled on, when the application's window loses focus, the FPS limit of the application is set to 1. This helps lower CPU usage when idle. The FPS limit is being reset when the mouse enters the application's window."
+msgid "If this is toggled on, when the application's window loses focus, the FPS limit of the application is set to the idle FPS. This helps lower CPU usage when idle. The FPS limit is being reset when the mouse enters the application's window."
 msgstr ""
 
 msgid "Brush:"
@@ -1771,4 +1771,10 @@ msgid "Reducing palette size will reset positions of colors. Colors that don't f
 msgstr ""
 
 msgid "Position:"
+msgstr ""
+
+msgid "Set idle FPS:"
+msgstr ""
+
+msgid "Sets how many FPS Pixelorama uses when out of focus. The less the better the performance."
 msgstr ""

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -88,6 +88,7 @@ var selection_border_color_2 := Color.black
 
 var fps_limit_focus := true
 var fps_limit := 0
+var idle_fps := 1
 
 var autosave_interval := 1.0
 var enable_autosave := true

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -276,13 +276,16 @@ func _notification(what : int) -> void:
 	match what:
 		MainLoop.NOTIFICATION_WM_QUIT_REQUEST: # Handle exit
 			show_quit_dialog()
-		MainLoop.NOTIFICATION_WM_FOCUS_OUT: # Called when the mouse isn't in the window anymore
+		MainLoop.NOTIFICATION_WM_FOCUS_OUT: # Called when another program is currently focused
 			Global.has_focus = false
 			if Global.fps_limit_focus:
-				Engine.set_target_fps(1) # then set the fps to 1 to relieve the cpu
+				Engine.set_target_fps(Global.idle_fps) # then set the fps to the idle fps (by default 1) to facilitate the cpu
 		MainLoop.NOTIFICATION_WM_MOUSE_ENTER: # Opposite of the above
 			if Global.fps_limit_focus:
 				Engine.set_target_fps(Global.fps_limit) # 0 stands for maximum fps
+		MainLoop.NOTIFICATION_WM_MOUSE_EXIT: # if the mouse exits the window and another application has the focus set the fps to the idle fps
+			if !OS.is_window_focused() and Global.fps_limit_focus:
+				Engine.set_target_fps(Global.idle_fps)
 
 
 func _on_files_dropped(_files : PoolStringArray, _screen : int) -> void:

--- a/src/Preferences/PreferencesDialog.gd
+++ b/src/Preferences/PreferencesDialog.gd
@@ -48,6 +48,7 @@ var preferences = [
 
 	["fps_limit", "Performance/PerformanceContainer/SetFPSLimit", "value", Global.fps_limit],
 	["fps_limit_focus", "Performance/PerformanceContainer/EnableLimitFPSFocus", "pressed", Global.fps_limit_focus],
+	["idle_fps", "Performance/PerformanceContainer/IdleFPS", "value", Global.idle_fps]
 ]
 
 var selected_item := 0
@@ -58,6 +59,7 @@ onready var autosave_interval : SpinBox = $HSplitContainer/ScrollContainer/VBoxC
 onready var restore_default_button_scene = preload("res://src/Preferences/RestoreDefaultButton.tscn")
 onready var shrink_label : Label = $HSplitContainer/ScrollContainer/VBoxContainer/Interface/ShrinkContainer/ShrinkLabel
 onready var themes : BoxContainer = $"HSplitContainer/ScrollContainer/VBoxContainer/Interface/Themes"
+onready var idle_fps_spinbox : SpinBox = $HSplitContainer/ScrollContainer/VBoxContainer/Performance/PerformanceContainer/IdleFPS
 
 
 func _ready() -> void:
@@ -159,6 +161,9 @@ func preference_update(prop : String) -> void:
 
 	if prop in ["fps_limit"]:
 		Engine.set_target_fps(Global.fps_limit)
+	
+	if prop in ["fps_limit_focus"]:
+		idle_fps_spinbox.editable = !idle_fps_spinbox.editable
 
 	if prop in ["selection_animated_borders", "selection_border_color_1", "selection_border_color_2"]:
 		Global.canvas.selection.marching_ants_outline.material.set_shader_param("animated", Global.selection_animated_borders)

--- a/src/Preferences/PreferencesDialog.tscn
+++ b/src/Preferences/PreferencesDialog.tscn
@@ -1376,11 +1376,11 @@ __meta__ = {
 [node name="Performance" type="VBoxContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer"]
 visible = false
 margin_top = 28.0
-margin_right = 498.0
+margin_right = 553.0
 margin_bottom = 80.0
 
 [node name="PerformanceContainer" type="GridContainer" parent="HSplitContainer/ScrollContainer/VBoxContainer/Performance"]
-margin_right = 498.0
+margin_right = 553.0
 margin_bottom = 52.0
 columns = 3
 
@@ -1408,22 +1408,49 @@ __meta__ = {
 }
 
 [node name="EnableLimitFPSFocusLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Performance/PerformanceContainer"]
-margin_left = 261.0
+margin_left = 324.0
 margin_top = 5.0
-margin_right = 490.0
+margin_right = 553.0
 margin_bottom = 19.0
-hint_tooltip = "If this is toggled on, when the application's window loses focus, the FPS limit of the application is set to 1. This helps lower CPU usage when idle. The FPS limit is being reset when the mouse enters the application's window."
+hint_tooltip = "If this is toggled on, when the application's window loses focus, the FPS limit of the application is set to the idle FPS. This helps lower CPU usage when idle. The FPS limit is being reset when the mouse enters the application's window."
 mouse_filter = 0
-text = "Limit FPS to 1 when app loses focus"
+text = "Limit FPS to the idle FPS when app loses focus"
 
 [node name="EnableLimitFPSFocus" type="CheckBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Performance/PerformanceContainer"]
 margin_top = 28.0
 margin_right = 158.0
 margin_bottom = 52.0
-hint_tooltip = "If this is toggled on, when the application's window loses focus, the FPS limit of the application is set to 1. This helps lower CPU usage when idle. The FPS limit is being reset when the mouse enters the application's window."
+hint_tooltip = "If this is toggled on, when the application's window loses focus, the FPS limit of the application is set to the idle FPS. This helps lower CPU usage when idle. The FPS limit is being reset when the mouse enters the application's window."
 mouse_default_cursor_shape = 2
 pressed = true
 text = "On"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="IdleFPSLabel" type="Label" parent="HSplitContainer/ScrollContainer/VBoxContainer/Performance/PerformanceContainer"]
+margin_left = 162.0
+margin_top = 33.0
+margin_right = 320.0
+margin_bottom = 47.0
+hint_tooltip = "Sets how many FPS Pixelorama uses when out of focus."
+mouse_filter = 0
+size_flags_horizontal = 0
+text = "Set idle FPS:"
+
+[node name="IdleFPS" type="SpinBox" parent="HSplitContainer/ScrollContainer/VBoxContainer/Performance/PerformanceContainer"]
+margin_left = 324.0
+margin_top = 28.0
+margin_right = 419.0
+margin_bottom = 52.0
+rect_min_size = Vector2( 95, 0 )
+hint_tooltip = "Sets how many FPS Pixelorama uses when out of focus."
+mouse_default_cursor_shape = 2
+size_flags_horizontal = 0
+min_value = 1.0
+max_value = 60.0
+value = 1.0
+align = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }


### PR DESCRIPTION
A new setting was added trough which the user can set how many FPS Pixelorama should have when idle.
![image](https://user-images.githubusercontent.com/47503977/135092054-751d4668-e593-4dc8-903d-4e016e7fb73c.png)
Additionally a bug was fixed where when the user has another application as their focus and reenters Pixelorama with the mouse but not focusing it and then exiting with the mouse, the target_fps would be set to the standard.