### PR TITLE
Optimize the drawing of large amounts of pixels

### DIFF
--- a/src/Tools/BaseTool.gd
+++ b/src/Tools/BaseTool.gd
@@ -148,3 +148,32 @@ func _add_polylines_segment(lines : Array, start : Vector2, end : Vector2) -> vo
 			line.append(start)
 			return
 	lines.append([start, end])
+
+
+class Cache:
+	var cache = {}
+	
+	func clear():
+		self.cache = {}
+	
+	func store(position: Vector2):
+		self.cache[position] = true
+	
+	func is_cached(position: Vector2) -> bool:
+		return self.cache.get(position, false)
+
+
+var cache = Cache.new()
+
+
+func draw_start(_position : Vector2) -> void:
+	pass
+	
+	
+func draw_move(_position : Vector2) -> void:
+	pass
+	
+	
+func draw_end(_position : Vector2) -> void:
+	cache.clear()
+

--- a/src/Tools/Bucket.gd
+++ b/src/Tools/Bucket.gd
@@ -94,6 +94,7 @@ func update_pattern() -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	Global.canvas.selection.transform_content_confirm()
 	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn() or !Global.current_project.tile_mode_rects[Global.TileMode.NONE].has_point(position):
 		return
@@ -105,14 +106,6 @@ func draw_start(position : Vector2) -> void:
 	else:
 		fill_in_color(position)
 	commit_undo("Draw", undo_data)
-
-
-func draw_move(_position : Vector2) -> void:
-	pass
-
-
-func draw_end(_position : Vector2) -> void:
-	pass
 
 
 func fill_in_color(position : Vector2) -> void:

--- a/src/Tools/ColorPicker.gd
+++ b/src/Tools/ColorPicker.gd
@@ -25,15 +25,13 @@ func update_config() -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	_pick_color(position)
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	_pick_color(position)
-
-
-func draw_end(_position : Vector2) -> void:
-	pass
 
 
 func _pick_color(position : Vector2) -> void:

--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -106,6 +106,7 @@ func update_brush() -> void:
 	_polylines = _create_polylines(_indicator)
 	$Brush/Type/Texture.texture = _brush_texture
 	$ColorInterpolation.visible = _brush.type in [Brushes.FILE, Brushes.RANDOM_FILE, Brushes.CUSTOM]
+	clear_cache()
 
 
 func update_random_image() -> void:
@@ -144,6 +145,7 @@ func update_line_polylines(start : Vector2, end : Vector2) -> void:
 
 func prepare_undo() -> void:
 	_undo_data = _get_undo_data()
+	clear_cache()
 
 
 func commit_undo(action : String) -> void:
@@ -331,8 +333,21 @@ func draw_indicator_at(position : Vector2, offset : Vector2, color : Color) -> v
 			canvas.draw_polyline(pool, color)
 		canvas.draw_set_transform(canvas.position, canvas.rotation, canvas.scale)
 
+var cache = {}
+
+func cache_pixel(position : Vector2) -> void:
+	cache[position] = true
+
+func clear_cache() -> void:
+	cache = {}
+
+func is_cached(position : Vector2) -> bool:
+	return cache.get(position, false)
 
 func _set_pixel(position : Vector2, ignore_mirroring := false) -> void:
+	if is_cached(position):
+		return
+
 	var project : Project = Global.current_project
 	if project.tile_mode and project.get_tile_mode_rect().has_point(position):
 		position = position.posmodv(project.size)
@@ -350,6 +365,7 @@ func _set_pixel(position : Vector2, ignore_mirroring := false) -> void:
 	else:
 		for image in images:
 			_drawer.set_pixel(image, position, tool_slot.color, ignore_mirroring)
+	cache_pixel(position)
 
 
 func _draw_brush_image(_image : Image, _src_rect: Rect2, _dst: Vector2) -> void:

--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -106,7 +106,6 @@ func update_brush() -> void:
 	_polylines = _create_polylines(_indicator)
 	$Brush/Type/Texture.texture = _brush_texture
 	$ColorInterpolation.visible = _brush.type in [Brushes.FILE, Brushes.RANDOM_FILE, Brushes.CUSTOM]
-	clear_cache()
 
 
 func update_random_image() -> void:
@@ -145,7 +144,6 @@ func update_line_polylines(start : Vector2, end : Vector2) -> void:
 
 func prepare_undo() -> void:
 	_undo_data = _get_undo_data()
-	clear_cache()
 
 
 func commit_undo(action : String) -> void:
@@ -333,19 +331,8 @@ func draw_indicator_at(position : Vector2, offset : Vector2, color : Color) -> v
 			canvas.draw_polyline(pool, color)
 		canvas.draw_set_transform(canvas.position, canvas.rotation, canvas.scale)
 
-var cache = {}
-
-func cache_pixel(position : Vector2) -> void:
-	cache[position] = true
-
-func clear_cache() -> void:
-	cache = {}
-
-func is_cached(position : Vector2) -> bool:
-	return cache.get(position, false)
-
 func _set_pixel(position : Vector2, ignore_mirroring := false) -> void:
-	if is_cached(position):
+	if cache.is_cached(position):
 		return
 
 	var project : Project = Global.current_project
@@ -365,7 +352,7 @@ func _set_pixel(position : Vector2, ignore_mirroring := false) -> void:
 	else:
 		for image in images:
 			_drawer.set_pixel(image, position, tool_slot.color, ignore_mirroring)
-	cache_pixel(position)
+	cache.store(position)
 
 
 func _draw_brush_image(_image : Image, _src_rect: Rect2, _dst: Vector2) -> void:

--- a/src/Tools/Eraser.gd
+++ b/src/Tools/Eraser.gd
@@ -35,6 +35,7 @@ func set_config(config : Dictionary) -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	Global.canvas.selection.transform_content_confirm()
 	update_mask()
 	_changed = false
@@ -56,6 +57,7 @@ func draw_start(position : Vector2) -> void:
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	if _draw_line:
 		var d = _line_angle_constraint(_line_start, position)
 		_line_end = d.position
@@ -68,7 +70,8 @@ func draw_move(position : Vector2) -> void:
 		Global.canvas.sprite_changed_this_frame = true
 
 
-func draw_end(_position : Vector2) -> void:
+func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	if _draw_line:
 		draw_tool(_line_start)
 		draw_fill_gap(_line_start, _line_end)

--- a/src/Tools/LineTool.gd
+++ b/src/Tools/LineTool.gd
@@ -69,6 +69,7 @@ func _input(event : InputEvent) -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	Global.canvas.selection.transform_content_confirm()
 	update_mask()
 
@@ -80,6 +81,7 @@ func draw_start(position : Vector2) -> void:
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	if _drawing:
 		if _displace_origin:
 			_original_pos += position - _offset
@@ -93,7 +95,8 @@ func draw_move(position : Vector2) -> void:
 		_offset = position
 
 
-func draw_end(_position : Vector2) -> void:
+func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	if _drawing:
 		_draw_shape()
 

--- a/src/Tools/Move.gd
+++ b/src/Tools/Move.gd
@@ -28,6 +28,7 @@ func _input(event : InputEvent) -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
 		return
 	_start_pos = position
@@ -39,6 +40,7 @@ func draw_start(position : Vector2) -> void:
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
 		return
 	# This is true if content transformation has been confirmed (pressed Enter for example)
@@ -63,6 +65,7 @@ func draw_move(position : Vector2) -> void:
 
 
 func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
 		return
 	if _start_pos != Vector2.INF and _content_transformation_check == selection_node.is_moving_content:

--- a/src/Tools/Pan.gd
+++ b/src/Tools/Pan.gd
@@ -1,15 +1,13 @@
 extends BaseTool
 
 
-func draw_start(_position : Vector2) -> void:
+func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	Global.camera.drag = true
 	Global.camera2.drag = true
 
 
-func draw_move(_position : Vector2) -> void:
-	pass
-
-
-func draw_end(_position : Vector2) -> void:
+func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	Global.camera.drag = false
 	Global.camera2.drag = false

--- a/src/Tools/Pencil.gd
+++ b/src/Tools/Pencil.gd
@@ -55,6 +55,7 @@ func update_config() -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	Global.canvas.selection.transform_content_confirm()
 	update_mask()
 	_changed = false
@@ -80,6 +81,7 @@ func draw_start(position : Vector2) -> void:
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	if _draw_line:
 		var d = _line_angle_constraint(_line_start, position)
 		_line_end = d.position
@@ -94,14 +96,15 @@ func draw_move(position : Vector2) -> void:
 			_draw_points.append(position)
 
 
-func draw_end(_position : Vector2) -> void:
+func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	if _draw_line:
 		draw_tool(_line_start)
 		draw_fill_gap(_line_start, _line_end)
 		_draw_line = false
 	else:
 		if _fill_inside:
-			_draw_points.append(_position)
+			_draw_points.append(position)
 			if _draw_points.size() > 3:
 				var v = Vector2()
 				var image_size = Global.current_project.size

--- a/src/Tools/SelectionTools/PolygonSelect.gd
+++ b/src/Tools/SelectionTools/PolygonSelect.gd
@@ -27,6 +27,7 @@ func _input(event : InputEvent) -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	if !$DoubleClickTimer.is_stopped():
 		return
 	.draw_start(position)
@@ -37,12 +38,14 @@ func draw_start(position : Vector2) -> void:
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	if selection_node.arrow_key_move:
 		return
 	.draw_move(position)
 
 
 func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	if selection_node.arrow_key_move:
 		return
 	if !_move and _draw_points:

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -58,6 +58,7 @@ func set_spinbox_values() -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	if selection_node.arrow_key_move:
 		return
 	var project : Project = Global.current_project
@@ -114,6 +115,7 @@ func draw_start(position : Vector2) -> void:
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	if selection_node.arrow_key_move:
 		return
 	# This is true if content transformation has been confirmed (pressed Enter for example)
@@ -140,14 +142,15 @@ func draw_move(position : Vector2) -> void:
 		_set_cursor_text(selection_node.big_bounding_rectangle)
 
 
-func draw_end(_position : Vector2) -> void:
+func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	if selection_node.arrow_key_move:
 		return
 	if _content_transformation_check == selection_node.is_moving_content:
 		if _move:
 			selection_node.move_borders_end()
 		else:
-			apply_selection(_position)
+			apply_selection(position)
 
 	_move = false
 	_snap_to_grid = false

--- a/src/Tools/Shading.gd
+++ b/src/Tools/Shading.gd
@@ -200,6 +200,7 @@ func update_strength() -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	Global.canvas.selection.transform_content_confirm()
 	update_mask(false)
 	_changed = false
@@ -221,6 +222,7 @@ func draw_start(position : Vector2) -> void:
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	if _draw_line:
 		var d = _line_angle_constraint(_line_start, position)
 		_line_end = d.position
@@ -233,7 +235,8 @@ func draw_move(position : Vector2) -> void:
 		Global.canvas.sprite_changed_this_frame = true
 
 
-func draw_end(_position : Vector2) -> void:
+func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	if _draw_line:
 		draw_tool(_line_start)
 		draw_fill_gap(_line_start, _line_end)

--- a/src/Tools/ShapeDrawer.gd
+++ b/src/Tools/ShapeDrawer.gd
@@ -84,6 +84,7 @@ func _input(event : InputEvent) -> void:
 
 
 func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	Global.canvas.selection.transform_content_confirm()
 	update_mask()
 
@@ -94,6 +95,7 @@ func draw_start(position : Vector2) -> void:
 
 
 func draw_move(position : Vector2) -> void:
+	.draw_move(position)
 	if _drawing:
 		if _displace_origin:
 			_start += position - _offset
@@ -103,6 +105,7 @@ func draw_move(position : Vector2) -> void:
 
 
 func draw_end(position : Vector2) -> void:
+	.draw_end(position)
 	if _drawing:
 		_draw_shape(_start, position)
 

--- a/src/Tools/Zoom.gd
+++ b/src/Tools/Zoom.gd
@@ -32,7 +32,8 @@ func update_config() -> void:
 	$ModeOptions.selected = _zoom_mode
 
 
-func draw_start(_position : Vector2) -> void:
+func draw_start(position : Vector2) -> void:
+	.draw_start(position)
 	var mouse_pos := get_global_mouse_position()
 	var viewport_rect := Rect2(Global.main_viewport.rect_global_position, Global.main_viewport.rect_size)
 	var viewport_rect_2 := Rect2(Global.second_viewport.rect_global_position, Global.second_viewport.rect_size)
@@ -41,11 +42,3 @@ func draw_start(_position : Vector2) -> void:
 		Global.camera.zoom_camera(_zoom_mode * 2 - 1)
 	elif viewport_rect_2.has_point(mouse_pos):
 		Global.camera2.zoom_camera(_zoom_mode * 2 - 1)
-
-
-func draw_move(_position : Vector2) -> void:
-	pass
-
-
-func draw_end(_position : Vector2) -> void:
-	pass


### PR DESCRIPTION
#501 complains of lag when drawing a lot of pixels at once, a major reason for this lag seems to be a lot of redundant drawing attempts. Using GDNative here or C# will probably help, but a lot can be gained by just optimizing the algorithms used.

Doing this right though will require me to take some time to understand the entire flow of how pixels are drawn, so I'm making this a draft pull request until i can be more sure that what I've done is correct.