### PR TITLE
Ad-hoc sign Mac builds

### DIFF
--- a/.github/workflows/dev-desktop-builds.yml
+++ b/.github/workflows/dev-desktop-builds.yml
@@ -142,8 +142,10 @@ jobs:
           printf '%s\n' 'Before running Pixelorama for the first time, make sure to open a Terminal and run:' '' 'xattr -cr /path/to/Pixelorama.app' '' "If you don't, macOS will not let you run Pixelorama and claim it's damaged." "For more info, check disable-gatekeeper.github.io" > ./build/mac/ReadMeFirst.txt
       - name: Copy pixelorama_data folder 📁
         run: |
-          cp -R ./pixelorama_data ./build/mac/Pixelorama.app/Contents/MacOS
-          rm ./build/mac/Pixelorama.app/Contents/MacOS/pixelorama_data/.gdignore
+          cp -R ./pixelorama_data ./build/mac/Pixelorama.app/Contents/Resources
+          rm ./build/mac/Pixelorama.app/Contents/Resources/pixelorama_data/.gdignore
+      - name: Ad-hoc signing ✍️
+        run: codesign -s - --force --deep ./build/mac/Pixelorama.app
       - name: Create DMG archive 🔧
         run: hdiutil create -srcfolder ./build/mac -fs HFS+ -volname Pixelorama ./build/mac/Pixelorama.dmg
       - name: Upload Artifact 🚀

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,8 +258,10 @@ jobs:
         run: sips -s format icns ./build/mac/Pixelorama.app/Contents/Resources/icon.icns --out ./build/mac/Pixelorama.app/Contents/Resources/icon.icns
       - name: Copy pixelorama_data folder 📁
         run: |
-          cp -R ./pixelorama_data ./build/mac/Pixelorama.app/Contents/MacOS
-          rm ./build/mac/Pixelorama.app/Contents/MacOS/pixelorama_data/.gdignore
+          cp -R ./pixelorama_data ./build/mac/Pixelorama.app/Contents/Resources
+          rm ./build/mac/Pixelorama.app/Contents/Resources/pixelorama_data/.gdignore
+      - name: Ad-hoc signing ✍️
+        run: codesign -s - --force --deep ./build/mac/Pixelorama.app
       - name: Create DMG archive 🔧
         run: hdiutil create -srcfolder ./build/mac -fs HFS+ -volname Pixelorama ./build/mac/Pixelorama.dmg
       - name: Upload Release Asset 🚀


### PR DESCRIPTION
This should solve the "Pixelorama is damaged" error on macOS, as suggested by https://github.com/Orama-Interactive/Pixelorama/issues/516#issuecomment-983360949.