### PR TITLE
Fix drawing bug reported in issue-555

### DIFF
--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -152,7 +152,7 @@ func prepare_undo(action: String) -> void:
 	project.undo_redo.create_action(action)
 
 
-func commit_undo(action: String) -> void:
+func commit_undo() -> void:
 	var redo_data := _get_undo_data()
 	var project: Project = Global.current_project
 	var frame := -1

--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -146,8 +146,10 @@ func update_line_polylines(start: Vector2, end: Vector2) -> void:
 	_line_polylines = _create_polylines(indicator)
 
 
-func prepare_undo() -> void:
+func prepare_undo(action: String) -> void:
+	var project: Project = Global.current_project
 	_undo_data = _get_undo_data()
+	project.undo_redo.create_action(action)
 
 
 func commit_undo(action: String) -> void:
@@ -160,7 +162,6 @@ func commit_undo(action: String) -> void:
 		layer = project.current_layer
 
 	project.undos += 1
-	project.undo_redo.create_action(action)
 	for image in redo_data:
 		project.undo_redo.add_do_property(image, "data", redo_data[image])
 		image.unlock()

--- a/src/Tools/Eraser.gd
+++ b/src/Tools/Eraser.gd
@@ -46,7 +46,7 @@ func draw_start(position: Vector2) -> void:
 	_changed = false
 	_drawer.color_op.changed = false
 
-	prepare_undo()
+	prepare_undo("Draw")
 	_drawer.reset()
 
 	_draw_line = Tools.shift

--- a/src/Tools/Eraser.gd
+++ b/src/Tools/Eraser.gd
@@ -88,7 +88,7 @@ func draw_end(_position: Vector2) -> void:
 		draw_fill_gap(_line_start, _line_end)
 		_draw_line = false
 	if _changed or _drawer.color_op.changed:
-		commit_undo("Draw")
+		commit_undo()
 	cursor_text = ""
 	update_random_image()
 

--- a/src/Tools/LineTool.gd
+++ b/src/Tools/LineTool.gd
@@ -155,7 +155,7 @@ func _draw_shape() -> void:
 		# Draw each point offseted based on the shape's thickness
 		draw_tool(point)
 
-	commit_undo("Draw Shape")
+	commit_undo()
 
 
 func _get_points() -> PoolVector2Array:

--- a/src/Tools/LineTool.gd
+++ b/src/Tools/LineTool.gd
@@ -148,7 +148,7 @@ func draw_preview() -> void:
 func _draw_shape() -> void:
 #	var rect := _get_result_rect(origin, dest)
 	var points := _get_points()
-	prepare_undo()
+	prepare_undo("Draw Shape")
 	for point in points:
 		# Reset drawer every time because pixel perfect sometimes breaks the tool
 		_drawer.reset()

--- a/src/Tools/Pencil.gd
+++ b/src/Tools/Pencil.gd
@@ -83,7 +83,7 @@ func draw_start(position: Vector2) -> void:
 	_drawer.color_op.overwrite = _overwrite
 	_draw_points = Array()
 
-	prepare_undo()
+	prepare_undo("Draw")
 	_drawer.reset()
 
 	_draw_line = Tools.shift

--- a/src/Tools/Pencil.gd
+++ b/src/Tools/Pencil.gd
@@ -141,7 +141,7 @@ func draw_end(_position: Vector2) -> void:
 						if Geometry.is_point_in_polygon(v, _draw_points):
 							draw_tool(v)
 	if _changed or _drawer.color_op.changed:
-		commit_undo("Draw")
+		commit_undo()
 	cursor_text = ""
 	update_random_image()
 

--- a/src/Tools/Shading.gd
+++ b/src/Tools/Shading.gd
@@ -221,7 +221,7 @@ func draw_start(position: Vector2) -> void:
 	_changed = false
 	_drawer.color_op.changed = false
 
-	prepare_undo()
+	prepare_undo("Draw")
 	_drawer.reset()
 
 	_draw_line = Tools.shift

--- a/src/Tools/Shading.gd
+++ b/src/Tools/Shading.gd
@@ -263,7 +263,7 @@ func draw_end(_position: Vector2) -> void:
 		draw_fill_gap(_line_start, _line_end)
 		_draw_line = false
 	if _changed or _drawer.color_op.changed:
-		commit_undo("Draw")
+		commit_undo()
 	cursor_text = ""
 	update_random_image()
 

--- a/src/Tools/ShapeDrawer.gd
+++ b/src/Tools/ShapeDrawer.gd
@@ -149,7 +149,7 @@ func draw_preview() -> void:
 func _draw_shape(origin: Vector2, dest: Vector2) -> void:
 	var rect := _get_result_rect(origin, dest)
 	var points := _get_points(rect.size)
-	prepare_undo()
+	prepare_undo("Draw Shape")
 	for point in points:
 		# Reset drawer every time because pixel perfect sometimes breaks the tool
 		_drawer.reset()

--- a/src/Tools/ShapeDrawer.gd
+++ b/src/Tools/ShapeDrawer.gd
@@ -156,7 +156,7 @@ func _draw_shape(origin: Vector2, dest: Vector2) -> void:
 		# Draw each point offseted based on the shape's thickness
 		draw_tool(rect.position + point - Vector2.ONE * (_thickness - 1))
 
-	commit_undo("Draw Shape")
+	commit_undo()
 
 
 # Given an origin point and destination point, returns a rect representing


### PR DESCRIPTION
I have fixed a bug reported in [https://github.com/Orama-Interactive/Pixelorama/issues/555](url) which happens when undo is performed while drawing with pencil/eraser/shading tools.


![undo_1](https://user-images.githubusercontent.com/90295085/144758803-697944bd-2f33-4a9b-9fc2-28d4786b0359.gif)
The gif above is a bug I reproduced by following the steps described in the issue. The first line reappears if undo is performed while drawing the third line. But it can be removed by performing undo once more.


![undo_2](https://user-images.githubusercontent.com/90295085/144759056-abe4fe4b-6742-4927-8968-711b7f348c66.gif)
This one would be the worst case scenario. If undo is performed twice after drawing the third line, The reappeared first line cannot be removed with undo so it should be removed manually.

The simplest solution I have come up with was moving `project.undo_redo.create_action(action)` in `commit_undo()` in Draw.gd to `prepare_undo()` so undo would be disabled while drawing. Due to this change, I also have modified `func prepare_undo() -> void:` to take 1 String parameter like `func prepare_undo(action: String) -> void:` and some scripts calling this method.


![undo_3](https://user-images.githubusercontent.com/90295085/144759348-210045b3-1a66-4618-8e5d-701868a8ffcd.gif)
One side effect is that Line/Shape tools are also affected by this change. So actions like above will no longer be possible. Though it might be considered as a nice change since actions like that could have potentially made redo difficult by overwriting the undo list with a new change.

Maintainer edit: Closes #555 