### PR TITLE
Shader vision

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -4,6 +4,7 @@ enum GridTypes { CARTESIAN, ISOMETRIC, ALL }
 enum PressureSensitivity { NONE, ALPHA, SIZE, ALPHA_AND_SIZE }
 enum ThemeTypes { DARK, BLUE, CARAMEL, LIGHT }
 enum TileMode { NONE, BOTH, X_AXIS, Y_AXIS }
+enum ViewMode { NORMAL, GREY_SCALE }
 enum IconColorFrom { THEME, CUSTOM }
 enum ButtonSize { SMALL, BIG }
 
@@ -121,6 +122,7 @@ onready var cameras := [camera, camera2, camera_preview]
 onready var horizontal_ruler: BaseButton = control.find_node("HorizontalRuler")
 onready var vertical_ruler: BaseButton = control.find_node("VerticalRuler")
 onready var transparent_checker: ColorRect = control.find_node("TransparentChecker")
+onready var shader_vision: ColorRect = control.find_node("ShaderVision")
 onready var preview_zoom_slider: VSlider = control.find_node("PreviewZoomSlider")
 
 onready var tool_panel: ScrollContainer = control.find_node("Tools")

--- a/src/Shaders/Greyscale.gdshader
+++ b/src/Shaders/Greyscale.gdshader
@@ -1,0 +1,7 @@
+shader_type canvas_item;
+
+void fragment() {
+    COLOR = texture(SCREEN_TEXTURE, SCREEN_UV);
+    float avg = (COLOR.r + COLOR.g + COLOR.b) / 3.0;
+    COLOR.rgb = vec3(avg);
+}

--- a/src/UI/UI.gd
+++ b/src/UI/UI.gd
@@ -7,6 +7,13 @@ onready var main_canvas_container = Global.main_canvas_container
 func _ready() -> void:
 	update_transparent_shader()
 
+	#Set anchors for ShaderVision
+	Global.shader_vision.visible = false
+	Global.shader_vision.anchor_left = ANCHOR_BEGIN
+	Global.shader_vision.anchor_top = ANCHOR_BEGIN
+	Global.shader_vision.anchor_right = ANCHOR_END
+	Global.shader_vision.anchor_bottom = ANCHOR_END
+
 
 func _on_main_canvas_item_rect_changed() -> void:
 	update_transparent_shader()

--- a/src/UI/UI.tscn
+++ b/src/UI/UI.tscn
@@ -277,6 +277,13 @@ current = true
 zoom = Vector2( 0.15, 0.15 )
 script = ExtResource( 7 )
 
+[node name="CanvasLayer" type="CanvasLayer" parent="DockableContainer/Main Canvas/HSplitContainer/ViewportandVerticalRuler/ViewportContainer/Viewport"]
+
+[node name="ShaderVision" type="ColorRect" parent="DockableContainer/Main Canvas/HSplitContainer/ViewportandVerticalRuler/ViewportContainer/Viewport/CanvasLayer"]
+margin_right = 40.0
+margin_bottom = 40.0
+mouse_filter = 2
+
 [node name="ViewportContainer2" type="ViewportContainer" parent="DockableContainer/Main Canvas/HSplitContainer"]
 margin_left = 872.0
 margin_right = 872.0


### PR DESCRIPTION
A modified version of my earlier experiment now impemented as a viewmode instead of preview
I made it so any shader can be previewed easily (hence Shader Vision). Greyscale is just one!
The purpose of implementing grayscale vision is to help judge lighting during shading.
**A Demonstration:**

https://user-images.githubusercontent.com/77773850/152653194-4e31beeb-274f-49ca-a052-4f1a834af64b.mp4


