### PR TITLE
Move Guides without moving mouse outside canvas

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -22,6 +22,7 @@ var ui_tooltips := {}
 # Canvas related stuff
 var layers_changed_skip := false
 var can_draw := false
+var move_guides_on_canvas := false
 var has_focus := false
 
 var play_only_tags := true

--- a/src/Autoload/Tools.gd
+++ b/src/Autoload/Tools.gd
@@ -99,6 +99,11 @@ func set_tool(name: String, button: int) -> void:
 	var slot = _slots[button]
 	var panel: Node = _panels[button]
 	var node: Node = _tools[name].instance()
+	if button == BUTTON_LEFT: # As guides are only moved with left mouse
+		if name == "Pan": # tool you want to give more access at guides
+			Global.move_guides_on_canvas = true
+		else:
+			Global.move_guides_on_canvas = false
 	node.name = name
 	node.tool_slot = slot
 	slot.tool_node = node

--- a/src/Autoload/Tools.gd
+++ b/src/Autoload/Tools.gd
@@ -99,8 +99,8 @@ func set_tool(name: String, button: int) -> void:
 	var slot = _slots[button]
 	var panel: Node = _panels[button]
 	var node: Node = _tools[name].instance()
-	if button == BUTTON_LEFT: # As guides are only moved with left mouse
-		if name == "Pan": # tool you want to give more access at guides
+	if button == BUTTON_LEFT:  # As guides are only moved with left mouse
+		if name == "Pan":  # tool you want to give more access at guides
 			Global.move_guides_on_canvas = true
 		else:
 			Global.move_guides_on_canvas = false

--- a/src/UI/Canvas/Rulers/Guide.gd
+++ b/src/UI/Canvas/Rulers/Guide.gd
@@ -43,7 +43,7 @@ func _input(_event: InputEvent) -> void:
 	):
 		if (
 		!point_in_rectangle(Global.canvas.current_pixel, Vector2.ZERO, project.size)
-		or Global.move_guides_on_canvas # In case you want to proceed anyway
+		or Global.move_guides_on_canvas
 		):
 			has_focus = true
 			Global.has_focus = false

--- a/src/UI/Canvas/Rulers/Guide.gd
+++ b/src/UI/Canvas/Rulers/Guide.gd
@@ -41,7 +41,10 @@ func _input(_event: InputEvent) -> void:
 		and point_in_rectangle(mouse_pos, point0, point1)
 		and Input.is_action_just_pressed("left_mouse")
 	):
-		if !point_in_rectangle(Global.canvas.current_pixel, Vector2.ZERO, project.size):
+		if (
+		!point_in_rectangle(Global.canvas.current_pixel, Vector2.ZERO, project.size)
+		or Global.move_guides_on_canvas # In case you want to proceed anyway
+		):
 			has_focus = true
 			Global.has_focus = false
 			update()

--- a/src/UI/Canvas/Rulers/Guide.gd
+++ b/src/UI/Canvas/Rulers/Guide.gd
@@ -42,8 +42,8 @@ func _input(_event: InputEvent) -> void:
 		and Input.is_action_just_pressed("left_mouse")
 	):
 		if (
-		!point_in_rectangle(Global.canvas.current_pixel, Vector2.ZERO, project.size)
-		or Global.move_guides_on_canvas
+			!point_in_rectangle(Global.canvas.current_pixel, Vector2.ZERO, project.size)
+			or Global.move_guides_on_canvas
 		):
 			has_focus = true
 			Global.has_focus = false


### PR DESCRIPTION
Pan tool (**and Pan Tool alone**) is granted access to move guides without moving mouse outside canvas