### PR TITLE
Fix drop shadow

### DIFF
--- a/src/Shaders/DropShadow.tres
+++ b/src/Shaders/DropShadow.tres
@@ -2,6 +2,7 @@
 
 [resource]
 code = "shader_type canvas_item;
+render_mode unshaded;
 
 uniform vec2 shadow_offset; // Offset, in pixel coordinate [0, 1, 2, and so on]
 uniform vec4 shadow_color;
@@ -14,7 +15,20 @@ void fragment() {
 	float shadow = texture(TEXTURE, UV - offset).a; // Shadow, alpha only
 	shadow *= shadow_color.a; // Multiply this mask by shadow alpha
 	shadow = mix(0.0, shadow, texture(selection, UV).a); // Clip shadow by selection mask
+	shadow = mix(shadow, 0.0, original.a); // Erase shadow alpha on original area
 	
-	COLOR.rgb = mix(shadow_color.rgb, original.rgb, original.a); // Set background color
+	// Make a border to prevent stretching pixels on the edge
+	vec2 border_uv = UV - offset;
+	border_uv -= 0.5;
+	border_uv *= 2.0;
+	border_uv = abs(border_uv);
+	
+	float border = max(border_uv.x, border_uv.y);
+	border = floor(border);
+	border = 1.0 - clamp(border, 0.0, 1.0);
+	
+	shadow *= border; // Clip shadow by border so no more stretching
+	
+	COLOR.rgb = mix(original.rgb, shadow_color.rgb, shadow); // Set color on shadow area
 	COLOR.a = mix(original.a, 1.0, shadow); // Combine alpha
 }"

--- a/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
@@ -31,6 +31,7 @@ func _confirmed() -> void:
 func set_nodes() -> void:
 	preview = $VBoxContainer/AspectRatioContainer/Preview
 	selection_checkbox = $VBoxContainer/OptionsContainer/SelectionCheckBox
+	affect_option_button = $VBoxContainer/OptionsContainer/AffectOptionButton
 
 
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:


### PR DESCRIPTION
Currently drop shadow has issues

1. Incorrect blending because rgb blends with shadow color (as background, which is not a problem on opaque pixels)
2. Pixels on the edge are stretched

This PR will fix them.

Before:
![image](https://user-images.githubusercontent.com/54466934/166207066-a3d7712f-21f6-4b2c-880e-b3d221876ee4.png)

After:
![image](https://user-images.githubusercontent.com/54466934/166207095-afa17f9c-a243-4866-a523-e202a28841f2.png)


