### PR TITLE
Implemented text clipboard system instead of the old one

### DIFF
--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -690,7 +690,11 @@ func copy() -> void:
 		"big_bounding_rectangle": cl_big_bounding_rectangle,
 		"selection_offset": cl_selection_offset,
 	}
-	OS.set_clipboard(var2str(transfer_clipboard))
+	# Store to ".clipboard.txt" file
+	var clipboard_file = File.new()
+	clipboard_file.open("user://clipboard.txt", File.WRITE)
+	clipboard_file.store_var(transfer_clipboard, true)
+	clipboard_file.close()
 
 	if !to_copy.is_empty():
 		var pattern: Patterns.Pattern = Global.patterns_popup.get_pattern(0)
@@ -702,7 +706,14 @@ func copy() -> void:
 
 
 func paste() -> void:
-	var clipboard = str2var(OS.get_clipboard())
+	# Read from the ".clipboard.txt" file
+	var clipboard_file = File.new()
+	if !clipboard_file.file_exists("user://clipboard.txt"):
+		return
+	clipboard_file.open("user://clipboard.txt", File.READ)
+	var clipboard = clipboard_file.get_var(true)
+	clipboard_file.close()
+
 	if typeof(clipboard) == TYPE_DICTIONARY:
 		# A sanity check
 		if not clipboard.has_all(


### PR DESCRIPTION
I changed the pull name from
`Implemented OS.clipboard (using var2str())` to `Implemented text clipboard system instead of the old one`

Uses ~~the `OS.clipboard`~~ a `text file` instead of the custom `Clipboard` class, thus allowing it to transfer/share images between multiple **"Pixelorama"** instances (Which is still _quite a lot of freedom and power_)
### Adresses:
https://github.com/Orama-Interactive/Pixelorama/discussions/402 the experience should now be the same as when pasting to a separate tab
> When opening the software and then opening another project (not from file>open) made with pixelorama, it opens two seperate windows instead of an extra tab. This makes it uncomfortable to copy and paste something between projects, if they are in a different window

### A Demonstration:

https://user-images.githubusercontent.com/77773850/167196576-1eb825fd-51ab-473f-94ca-d37c5d337c8d.mp4
