### PR TITLE
Only update brush size config if size changed

### DIFF
--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -56,10 +56,11 @@ func _on_Brush_selected(brush: Brushes.Brush) -> void:
 
 
 func _on_BrushSize_value_changed(value: float) -> void:
-	_brush_size = int(value)
-	_cache_limit = (_brush_size * _brush_size) * 3  # This equation seems the best match
-	update_config()
-	save_config()
+	if _brush_size != int(value):
+		_brush_size = int(value)
+		_cache_limit = (_brush_size * _brush_size) * 3  # This equation seems the best match
+		update_config()
+		save_config()
 
 
 func _on_InterpolateFactor_value_changed(value: float) -> void:


### PR DESCRIPTION
This is the fix I proposed in #703 after noticing that the code in `update_config()` was being executed twice when changing the size of brushes.