### PR TITLE
Refactor the selection system to use an Image instead of a BitMap

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -104,6 +104,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/Classes/Project.gd"
 }, {
+"base": "Image",
+"class": "SelectionMap",
+"language": "GDScript",
+"path": "res://src/Classes/SelectionMap.gd"
+}, {
 "base": "BaseTool",
 "class": "SelectionTool",
 "language": "GDScript",
@@ -149,6 +154,7 @@ _global_script_class_icons={
 "PaletteSwatch": "",
 "Patterns": "",
 "Project": "",
+"SelectionMap": "",
 "SelectionTool": "",
 "ShaderImageEffect": "",
 "ShortcutProfile": "",

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -427,7 +427,7 @@ func general_do_scale(width: int, height: int) -> void:
 	var y_ratio = project.size.y / height
 
 	var selection_map_copy := SelectionMap.new()
-	selection_map_copy.copy_from(project.selection_image)
+	selection_map_copy.copy_from(project.selection_map)
 	selection_map_copy.crop(size.x, size.y)
 
 	var new_x_symmetry_point = project.x_symmetry_point / x_ratio
@@ -442,7 +442,7 @@ func general_do_scale(width: int, height: int) -> void:
 	project.undos += 1
 	project.undo_redo.create_action("Scale")
 	project.undo_redo.add_do_property(project, "size", size)
-	project.undo_redo.add_do_property(project, "selection_image", selection_map_copy)
+	project.undo_redo.add_do_property(project, "selection_map", selection_map_copy)
 	project.undo_redo.add_do_property(project, "x_symmetry_point", new_x_symmetry_point)
 	project.undo_redo.add_do_property(project, "y_symmetry_point", new_y_symmetry_point)
 	project.undo_redo.add_do_property(project.x_symmetry_axis, "points", new_x_symmetry_axis_points)
@@ -452,7 +452,7 @@ func general_do_scale(width: int, height: int) -> void:
 func general_undo_scale() -> void:
 	var project: Project = Global.current_project
 	project.undo_redo.add_undo_property(project, "size", project.size)
-	project.undo_redo.add_undo_property(project, "selection_image", project.selection_image)
+	project.undo_redo.add_undo_property(project, "selection_map", project.selection_map)
 	project.undo_redo.add_undo_property(project, "x_symmetry_point", project.x_symmetry_point)
 	project.undo_redo.add_undo_property(project, "y_symmetry_point", project.y_symmetry_point)
 	project.undo_redo.add_undo_property(

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -426,8 +426,9 @@ func general_do_scale(width: int, height: int) -> void:
 	var x_ratio = project.size.x / width
 	var y_ratio = project.size.y / height
 
-	var selection_map: SelectionMap = project.selection_image.duplicate()
-	selection_map.crop(size.x, size.y)
+	var selection_map_copy := SelectionMap.new()
+	selection_map_copy.copy_from(project.selection_image)
+	selection_map_copy.crop(size.x, size.y)
 
 	var new_x_symmetry_point = project.x_symmetry_point / x_ratio
 	var new_y_symmetry_point = project.y_symmetry_point / y_ratio
@@ -441,7 +442,7 @@ func general_do_scale(width: int, height: int) -> void:
 	project.undos += 1
 	project.undo_redo.create_action("Scale")
 	project.undo_redo.add_do_property(project, "size", size)
-	project.undo_redo.add_do_property(project, "selection_image", selection_map)
+	project.undo_redo.add_do_property(project, "selection_image", selection_map_copy)
 	project.undo_redo.add_do_property(project, "x_symmetry_point", new_x_symmetry_point)
 	project.undo_redo.add_do_property(project, "y_symmetry_point", new_y_symmetry_point)
 	project.undo_redo.add_do_property(project.x_symmetry_axis, "points", new_x_symmetry_axis_points)

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -426,8 +426,8 @@ func general_do_scale(width: int, height: int) -> void:
 	var x_ratio = project.size.x / width
 	var y_ratio = project.size.y / height
 
-	var bitmap: BitMap
-	bitmap = project.resize_bitmap(project.selection_bitmap, size)
+	var selection_map: SelectionMap = project.selection_image.duplicate()
+	selection_map.crop(size.x, size.y)
 
 	var new_x_symmetry_point = project.x_symmetry_point / x_ratio
 	var new_y_symmetry_point = project.y_symmetry_point / y_ratio
@@ -441,7 +441,7 @@ func general_do_scale(width: int, height: int) -> void:
 	project.undos += 1
 	project.undo_redo.create_action("Scale")
 	project.undo_redo.add_do_property(project, "size", size)
-	project.undo_redo.add_do_property(project, "selection_bitmap", bitmap)
+	project.undo_redo.add_do_property(project, "selection_image", selection_map)
 	project.undo_redo.add_do_property(project, "x_symmetry_point", new_x_symmetry_point)
 	project.undo_redo.add_do_property(project, "y_symmetry_point", new_y_symmetry_point)
 	project.undo_redo.add_do_property(project.x_symmetry_axis, "points", new_x_symmetry_axis_points)
@@ -451,7 +451,7 @@ func general_do_scale(width: int, height: int) -> void:
 func general_undo_scale() -> void:
 	var project: Project = Global.current_project
 	project.undo_redo.add_undo_property(project, "size", project.size)
-	project.undo_redo.add_undo_property(project, "selection_bitmap", project.selection_bitmap)
+	project.undo_redo.add_undo_property(project, "selection_image", project.selection_image)
 	project.undo_redo.add_undo_property(project, "x_symmetry_point", project.x_symmetry_point)
 	project.undo_redo.add_undo_property(project, "y_symmetry_point", project.y_symmetry_point)
 	project.undo_redo.add_undo_property(

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -452,6 +452,7 @@ func undo_or_redo(
 			canvas.camera_zoom()
 			canvas.grid.update()
 			canvas.pixel_grid.update()
+			project.selection_bitmap_changed()
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
 	elif "Frame" in action_name:

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -452,7 +452,7 @@ func undo_or_redo(
 			canvas.camera_zoom()
 			canvas.grid.update()
 			canvas.pixel_grid.update()
-			project.selection_bitmap_changed()
+			project.selection_map_changed()
 			cursor_position_label.text = "[%s×%s]" % [project.size.x, project.size.y]
 
 	elif "Frame" in action_name:

--- a/src/Autoload/Palettes.gd
+++ b/src/Autoload/Palettes.gd
@@ -144,7 +144,7 @@ func _create_new_palette_from_current_selection(
 	for x in current_project.size.x:
 		for y in current_project.size.y:
 			var pos := Vector2(x, y)
-			if current_project.selection_bitmap.get_bit(pos):
+			if current_project.selection_image.is_pixel_selected(pos):
 				pixels.append(pos)
 	_fill_new_palette_with_colors(pixels, new_palette, add_alpha_colors, get_colors_from)
 

--- a/src/Autoload/Palettes.gd
+++ b/src/Autoload/Palettes.gd
@@ -144,7 +144,7 @@ func _create_new_palette_from_current_selection(
 	for x in current_project.size.x:
 		for y in current_project.size.y:
 			var pos := Vector2(x, y)
-			if current_project.selection_image.is_pixel_selected(pos):
+			if current_project.selection_map.is_pixel_selected(pos):
 				pixels.append(pos)
 	_fill_new_palette_with_colors(pixels, new_palette, add_alpha_colors, get_colors_from)
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -25,7 +25,7 @@ var y_symmetry_point
 var x_symmetry_axis := SymmetryGuide.new()
 var y_symmetry_axis := SymmetryGuide.new()
 
-var selection_image := Image.new()
+var selection_image := SelectionMap.new()
 var selection_bitmap := BitMap.new()
 # This is useful for when the selection is outside of the canvas boundaries,
 # on the left and/or above (negative coords)
@@ -261,7 +261,7 @@ func change_project() -> void:
 	# Change selection effect & bounding rectangle
 	Global.canvas.selection.marching_ants_outline.offset = selection_offset
 	selection_bitmap_changed()
-	Global.canvas.selection.big_bounding_rectangle = get_selection_rectangle()
+	Global.canvas.selection.big_bounding_rectangle = selection_image.get_used_rect()
 	Global.canvas.selection.big_bounding_rectangle.position += selection_offset
 	Global.canvas.selection.update()
 	Global.top_menu_container.edit_menu_button.get_popup().set_item_disabled(6, !has_selection)
@@ -762,7 +762,7 @@ func duplicate_layers() -> Array:
 
 func can_pixel_get_drawn(
 	pixel: Vector2,
-	image: Image = selection_image,
+	image: SelectionMap = selection_image,
 	selection_position: Vector2 = Global.canvas.selection.big_bounding_rectangle.position
 ) -> bool:
 	if pixel.x < 0 or pixel.y < 0 or pixel.x >= size.x or pixel.y >= size.y:
@@ -776,25 +776,9 @@ func can_pixel_get_drawn(
 			pixel.x -= selection_position.x
 		if selection_position.y < 0:
 			pixel.y -= selection_position.y
-		return is_pixel_selected(pixel, image)
+		return image.is_pixel_selected(pixel)
 	else:
 		return true
-
-
-func is_pixel_selected(pixel: Vector2, image: Image = selection_image) -> bool:
-	image.lock()
-	var selected: bool = image.get_pixelv(pixel).a > 0
-	image.unlock()
-	return selected
-
-
-func select_pixel(pixel: Vector2, select := true, image: Image = selection_image) -> void:
-	image.lock()
-	if select:
-		image.set_pixelv(pixel, Color(1))
-	else:
-		image.set_pixelv(pixel, Color(0))
-	image.unlock()
 
 
 func invert_bitmap(bitmap: BitMap) -> void:
@@ -835,10 +819,6 @@ func bitmap_to_image(bitmap: BitMap) -> Image:
 			image.set_pixelv(pos, color)
 	image.unlock()
 	return image
-
-
-func get_selection_rectangle(image: Image = selection_image) -> Rect2:
-	return image.get_used_rect()
 
 
 func move_bitmap_values(image: Image, move_offset := true) -> void:

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -120,7 +120,7 @@ func new_empty_frame() -> Frame:
 
 func selection_bitmap_changed() -> void:
 	var image_texture := ImageTexture.new()
-	has_selection = selection_image.is_invisible()
+	has_selection = !selection_image.is_invisible()
 	if has_selection:
 		image_texture.create_from_image(selection_image, 0)
 	Global.canvas.selection.marching_ants_outline.texture = image_texture

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -781,13 +781,6 @@ func can_pixel_get_drawn(
 		return true
 
 
-func invert_bitmap(bitmap: BitMap) -> void:
-	for x in bitmap.get_size().x:
-		for y in bitmap.get_size().y:
-			var pos := Vector2(x, y)
-			bitmap.set_bit(pos, !bitmap.get_bit(pos))
-
-
 # Unexposed BitMap class function
 # https://github.com/godotengine/godot/blob/master/scene/resources/bit_map.cpp#L605
 func resize_bitmap(bitmap: BitMap, new_size: Vector2) -> BitMap:
@@ -818,76 +811,4 @@ func bitmap_to_image(bitmap: BitMap) -> Image:
 			var color = Color(1, 1, 1, 1) if bitmap.get_bit(pos) else Color(0, 0, 0, 0)
 			image.set_pixelv(pos, color)
 	image.unlock()
-	return image
-
-
-func move_bitmap_values(image: Image, move_offset := true) -> void:
-	var selection_node = Global.canvas.selection
-	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
-	var selection_end: Vector2 = selection_node.big_bounding_rectangle.end
-
-	var selection_rect := image.get_used_rect()
-	var smaller_image := image.get_rect(selection_rect)
-	image.fill(Color(0))
-	var dst := selection_position
-	var x_diff = selection_end.x - size.x
-	var y_diff = selection_end.y - size.y
-	var nw = max(size.x, size.x + x_diff)
-	var nh = max(size.y, size.y + y_diff)
-
-	if selection_position.x < 0:
-		nw -= selection_position.x
-		if move_offset:
-			self.selection_offset.x = selection_position.x
-		dst.x = 0
-	else:
-		if move_offset:
-			self.selection_offset.x = 0
-	if selection_position.y < 0:
-		nh -= selection_position.y
-		if move_offset:
-			self.selection_offset.y = selection_position.y
-		dst.y = 0
-	else:
-		if move_offset:
-			self.selection_offset.y = 0
-
-	if nw <= image.get_size().x:
-		nw = image.get_size().x
-	if nh <= image.get_size().y:
-		nh = image.get_size().y
-
-	image.crop(nw, nh)
-	image.blit_rect(smaller_image, Rect2(Vector2.ZERO, Vector2(nw, nh)), dst)
-
-
-func resize_bitmap_values(image: Image, new_size: Vector2, flip_x: bool, flip_y: bool) -> Image:
-	var selection_node = Global.canvas.selection
-	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
-	var dst := selection_position
-	var new_bitmap_size := size
-	new_bitmap_size.x = max(size.x, abs(selection_position.x) + new_size.x)
-	new_bitmap_size.y = max(size.y, abs(selection_position.y) + new_size.y)
-	var selection_rect := image.get_used_rect()
-	var smaller_image := image.get_rect(selection_rect)
-	if selection_position.x <= 0:
-		self.selection_offset.x = selection_position.x
-		dst.x = 0
-	else:
-		self.selection_offset.x = 0
-	if selection_position.y <= 0:
-		self.selection_offset.y = selection_position.y
-		dst.y = 0
-	else:
-		self.selection_offset.y = 0
-	image.fill(Color(0))
-	smaller_image.resize(new_size.x, new_size.y, Image.INTERPOLATE_NEAREST)
-	if flip_x:
-		smaller_image.flip_x()
-	if flip_y:
-		smaller_image.flip_y()
-	if new_bitmap_size != size:
-		image.crop(new_bitmap_size.x, new_bitmap_size.y)
-	image.blit_rect(smaller_image, Rect2(Vector2.ZERO, new_bitmap_size), dst)
-
 	return image

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -25,7 +25,7 @@ var y_symmetry_point
 var x_symmetry_axis := SymmetryGuide.new()
 var y_symmetry_axis := SymmetryGuide.new()
 
-var selection_image := SelectionMap.new()
+var selection_map := SelectionMap.new()
 # This is useful for when the selection is outside of the canvas boundaries,
 # on the left and/or above (negative coords)
 var selection_offset := Vector2.ZERO setget _selection_offset_changed
@@ -55,7 +55,7 @@ func _init(_frames := [], _name := tr("untitled"), _size := Vector2(64, 64)) -> 
 	name = _name
 	size = _size
 	tiles = Tiles.new(size)
-	selection_image.create(size.x, size.y, false, Image.FORMAT_LA8)
+	selection_map.create(size.x, size.y, false, Image.FORMAT_LA8)
 
 	Global.tabs.add_tab(name)
 	OpenSave.current_save_paths.append("")
@@ -120,9 +120,9 @@ func new_empty_frame() -> Frame:
 
 func selection_bitmap_changed() -> void:
 	var image_texture := ImageTexture.new()
-	has_selection = !selection_image.is_invisible()
+	has_selection = !selection_map.is_invisible()
 	if has_selection:
-		image_texture.create_from_image(selection_image, 0)
+		image_texture.create_from_image(selection_map, 0)
 	Global.canvas.selection.marching_ants_outline.texture = image_texture
 	Global.top_menu_container.edit_menu_button.get_popup().set_item_disabled(6, !has_selection)
 
@@ -260,7 +260,7 @@ func change_project() -> void:
 	# Change selection effect & bounding rectangle
 	Global.canvas.selection.marching_ants_outline.offset = selection_offset
 	selection_bitmap_changed()
-	Global.canvas.selection.big_bounding_rectangle = selection_image.get_used_rect()
+	Global.canvas.selection.big_bounding_rectangle = selection_map.get_used_rect()
 	Global.canvas.selection.big_bounding_rectangle.position += selection_offset
 	Global.canvas.selection.update()
 	Global.top_menu_container.edit_menu_button.get_popup().set_item_disabled(6, !has_selection)
@@ -386,7 +386,7 @@ func deserialize(dict: Dictionary) -> void:
 		size.x = dict.size_x
 		size.y = dict.size_y
 		tiles.tile_size = size
-		selection_image.crop(size.x, size.y)
+		selection_map.crop(size.x, size.y)
 	if dict.has("has_mask"):
 		tiles.has_mask = dict.has_mask
 	if dict.has("tile_mode_x_basis_x") and dict.has("tile_mode_x_basis_y"):
@@ -761,7 +761,7 @@ func duplicate_layers() -> Array:
 
 func can_pixel_get_drawn(
 	pixel: Vector2,
-	image: SelectionMap = selection_image,
+	image: SelectionMap = selection_map,
 	selection_position: Vector2 = Global.canvas.selection.big_bounding_rectangle.position
 ) -> bool:
 	if pixel.x < 0 or pixel.y < 0 or pixel.x >= size.x or pixel.y >= size.y:

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -118,7 +118,7 @@ func new_empty_frame() -> Frame:
 	return frame
 
 
-func selection_bitmap_changed() -> void:
+func selection_map_changed() -> void:
 	var image_texture := ImageTexture.new()
 	has_selection = !selection_map.is_invisible()
 	if has_selection:
@@ -259,7 +259,7 @@ func change_project() -> void:
 
 	# Change selection effect & bounding rectangle
 	Global.canvas.selection.marching_ants_outline.offset = selection_offset
-	selection_bitmap_changed()
+	selection_map_changed()
 	Global.canvas.selection.big_bounding_rectangle = selection_map.get_used_rect()
 	Global.canvas.selection.big_bounding_rectangle.position += selection_offset
 	Global.canvas.selection.update()

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -778,20 +778,3 @@ func can_pixel_get_drawn(
 		return image.is_pixel_selected(pixel)
 	else:
 		return true
-
-
-# Unexposed BitMap class function
-# https://github.com/godotengine/godot/blob/master/scene/resources/bit_map.cpp#L622
-func bitmap_to_image(bitmap: BitMap) -> Image:
-	var image := Image.new()
-	var width := bitmap.get_size().x
-	var height := bitmap.get_size().y
-	image.create(width, height, false, Image.FORMAT_LA8)
-	image.lock()
-	for x in width:
-		for y in height:
-			var pos := Vector2(x, y)
-			var color = Color(1, 1, 1, 1) if bitmap.get_bit(pos) else Color(0, 0, 0, 0)
-			image.set_pixelv(pos, color)
-	image.unlock()
-	return image

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -26,7 +26,6 @@ var x_symmetry_axis := SymmetryGuide.new()
 var y_symmetry_axis := SymmetryGuide.new()
 
 var selection_image := SelectionMap.new()
-var selection_bitmap := BitMap.new()
 # This is useful for when the selection is outside of the canvas boundaries,
 # on the left and/or above (negative coords)
 var selection_offset := Vector2.ZERO setget _selection_offset_changed
@@ -779,22 +778,6 @@ func can_pixel_get_drawn(
 		return image.is_pixel_selected(pixel)
 	else:
 		return true
-
-
-# Unexposed BitMap class function
-# https://github.com/godotengine/godot/blob/master/scene/resources/bit_map.cpp#L605
-func resize_bitmap(bitmap: BitMap, new_size: Vector2) -> BitMap:
-	if new_size == bitmap.get_size():
-		return bitmap
-	var new_bitmap := BitMap.new()
-	new_bitmap.create(new_size)
-	var lw = min(bitmap.get_size().x, new_size.x)
-	var lh = min(bitmap.get_size().y, new_size.y)
-	for x in lw:
-		for y in lh:
-			new_bitmap.set_bit(Vector2(x, y), bitmap.get_bit(Vector2(x, y)))
-
-	return new_bitmap
 
 
 # Unexposed BitMap class function

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -1,0 +1,94 @@
+class_name SelectionMap
+extends Image
+
+
+func is_pixel_selected(pixel: Vector2) -> bool:
+	lock()
+	var selected: bool = get_pixelv(pixel).a > 0
+	unlock()
+	return selected
+
+
+func select_pixel(pixel: Vector2, select := true) -> void:
+	lock()
+	if select:
+		set_pixelv(pixel, Color(1))
+	else:
+		set_pixelv(pixel, Color(0))
+	unlock()
+
+
+func clear() -> void:
+	fill(Color(0))
+
+
+func move_bitmap_values(move_offset := true) -> void:
+	var size := get_size()
+	var selection_node = Global.canvas.selection
+	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
+	var selection_end: Vector2 = selection_node.big_bounding_rectangle.end
+
+	var selection_rect := get_used_rect()
+	var smaller_image := get_rect(selection_rect)
+	clear()
+	var dst := selection_position
+	var x_diff = selection_end.x - size.x
+	var y_diff = selection_end.y - size.y
+	var nw = max(size.x, size.x + x_diff)
+	var nh = max(size.y, size.y + y_diff)
+
+	if selection_position.x < 0:
+		nw -= selection_position.x
+		if move_offset:
+			self.selection_offset.x = selection_position.x
+		dst.x = 0
+	else:
+		if move_offset:
+			self.selection_offset.x = 0
+	if selection_position.y < 0:
+		nh -= selection_position.y
+		if move_offset:
+			self.selection_offset.y = selection_position.y
+		dst.y = 0
+	else:
+		if move_offset:
+			self.selection_offset.y = 0
+
+	if nw <= size.x:
+		nw = size.x
+	if nh <= size.y:
+		nh = size.y
+
+	crop(nw, nh)
+	blit_rect(smaller_image, Rect2(Vector2.ZERO, Vector2(nw, nh)), dst)
+
+
+func resize_bitmap_values(new_size: Vector2, flip_x: bool, flip_y: bool) -> void:
+	var size := get_size()
+	var selection_node = Global.canvas.selection
+	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
+	var dst := selection_position
+	var new_bitmap_size := size
+	new_bitmap_size.x = max(size.x, abs(selection_position.x) + new_size.x)
+	new_bitmap_size.y = max(size.y, abs(selection_position.y) + new_size.y)
+	var selection_rect := get_used_rect()
+	var smaller_image := get_rect(selection_rect)
+	if selection_position.x <= 0:
+		self.selection_offset.x = selection_position.x
+		dst.x = 0
+	else:
+		self.selection_offset.x = 0
+	if selection_position.y <= 0:
+		self.selection_offset.y = selection_position.y
+		dst.y = 0
+	else:
+		self.selection_offset.y = 0
+	clear()
+	smaller_image.resize(new_size.x, new_size.y, Image.INTERPOLATE_NEAREST)
+	if flip_x:
+		smaller_image.flip_x()
+	if flip_y:
+		smaller_image.flip_y()
+	if new_bitmap_size != size:
+		crop(new_bitmap_size.x, new_bitmap_size.y)
+	blit_rect(smaller_image, Rect2(Vector2.ZERO, new_bitmap_size), dst)

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -30,6 +30,7 @@ func invert() -> void:
 	var params := {"red": true, "green": true, "blue": true, "alpha": true}
 	var gen := ShaderImageEffect.new()
 	gen.generate_image(self, invert_shader, params, get_size())
+	self.convert(Image.FORMAT_LA8)
 
 
 func move_bitmap_values(project, move_offset := true) -> void:

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -74,7 +74,7 @@ func move_bitmap_values(project, move_offset := true) -> void:
 
 func resize_bitmap_values(project, new_size: Vector2, flip_x: bool, flip_y: bool) -> void:
 	var size := get_size()
-	var selection_node = Global.canvas.selection
+	var selection_node: Node2D = Global.canvas.selection
 	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
 	var dst := selection_position
 	var new_bitmap_size := size

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -1,7 +1,7 @@
 class_name SelectionMap
 extends Image
 
-var shader: Shader = preload("res://src/Shaders/Invert.shader")
+var invert_shader: Shader = preload("res://src/Shaders/Invert.shader")
 
 func is_pixel_selected(pixel: Vector2) -> bool:
 	if pixel.x < 0 or pixel.y < 0 or pixel.x >= get_width() or pixel.y >= get_height():
@@ -33,7 +33,7 @@ func invert() -> void:
 		"alpha": true
 	}
 	var gen := ShaderImageEffect.new()
-	gen.generate_image(self, shader, params, get_size())
+	gen.generate_image(self, invert_shader, params, get_size())
 
 
 func move_bitmap_values(project, move_offset := true) -> void:

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -1,6 +1,7 @@
 class_name SelectionMap
 extends Image
 
+var shader: Shader = preload("res://src/Shaders/Invert.shader")
 
 func is_pixel_selected(pixel: Vector2) -> bool:
 	if pixel.x < 0 or pixel.y < 0 or pixel.x >= get_width() or pixel.y >= get_height():
@@ -25,10 +26,14 @@ func clear() -> void:
 
 
 func invert() -> void:
-	for x in get_size().x:
-		for y in get_size().y:
-			var pos := Vector2(x, y)
-			select_pixel(pos, !is_pixel_selected(pos))
+	var params := {
+		"red": true,
+		"green": true,
+		"blue": true,
+		"alpha": true
+	}
+	var gen := ShaderImageEffect.new()
+	gen.generate_image(self, shader, params, get_size())
 
 
 func move_bitmap_values(project, move_offset := true) -> void:

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -3,6 +3,8 @@ extends Image
 
 
 func is_pixel_selected(pixel: Vector2) -> bool:
+	if pixel.x < 0 or pixel.y < 0 or pixel.x >= get_width() or pixel.y >= get_height():
+		return false
 	lock()
 	var selected: bool = get_pixelv(pixel).a > 0
 	unlock()
@@ -29,7 +31,7 @@ func invert() -> void:
 			select_pixel(pos, !is_pixel_selected(pos))
 
 
-func move_bitmap_values(move_offset := true) -> void:
+func move_bitmap_values(project, move_offset := true) -> void:
 	var size := get_size()
 	var selection_node = Global.canvas.selection
 	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
@@ -47,19 +49,19 @@ func move_bitmap_values(move_offset := true) -> void:
 	if selection_position.x < 0:
 		nw -= selection_position.x
 		if move_offset:
-			self.selection_offset.x = selection_position.x
+			project.selection_offset.x = selection_position.x
 		dst.x = 0
 	else:
 		if move_offset:
-			self.selection_offset.x = 0
+			project.selection_offset.x = 0
 	if selection_position.y < 0:
 		nh -= selection_position.y
 		if move_offset:
-			self.selection_offset.y = selection_position.y
+			project.selection_offset.y = selection_position.y
 		dst.y = 0
 	else:
 		if move_offset:
-			self.selection_offset.y = 0
+			project.selection_offset.y = 0
 
 	if nw <= size.x:
 		nw = size.x
@@ -70,7 +72,7 @@ func move_bitmap_values(move_offset := true) -> void:
 	blit_rect(smaller_image, Rect2(Vector2.ZERO, Vector2(nw, nh)), dst)
 
 
-func resize_bitmap_values(new_size: Vector2, flip_x: bool, flip_y: bool) -> void:
+func resize_bitmap_values(project, new_size: Vector2, flip_x: bool, flip_y: bool) -> void:
 	var size := get_size()
 	var selection_node = Global.canvas.selection
 	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
@@ -81,15 +83,15 @@ func resize_bitmap_values(new_size: Vector2, flip_x: bool, flip_y: bool) -> void
 	var selection_rect := get_used_rect()
 	var smaller_image := get_rect(selection_rect)
 	if selection_position.x <= 0:
-		self.selection_offset.x = selection_position.x
+		project.selection_offset.x = selection_position.x
 		dst.x = 0
 	else:
-		self.selection_offset.x = 0
+		project.selection_offset.x = 0
 	if selection_position.y <= 0:
-		self.selection_offset.y = selection_position.y
+		project.selection_offset.y = selection_position.y
 		dst.y = 0
 	else:
-		self.selection_offset.y = 0
+		project.selection_offset.y = 0
 	clear()
 	smaller_image.resize(new_size.x, new_size.y, Image.INTERPOLATE_NEAREST)
 	if flip_x:

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -22,6 +22,13 @@ func clear() -> void:
 	fill(Color(0))
 
 
+func invert() -> void:
+	for x in get_size().x:
+		for y in get_size().y:
+			var pos := Vector2(x, y)
+			select_pixel(pos, !is_pixel_selected(pos))
+
+
 func move_bitmap_values(move_offset := true) -> void:
 	var size := get_size()
 	var selection_node = Global.canvas.selection

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -3,6 +3,7 @@ extends Image
 
 var invert_shader: Shader = preload("res://src/Shaders/Invert.shader")
 
+
 func is_pixel_selected(pixel: Vector2) -> bool:
 	if pixel.x < 0 or pixel.y < 0 or pixel.x >= get_width() or pixel.y >= get_height():
 		return false
@@ -26,12 +27,7 @@ func clear() -> void:
 
 
 func invert() -> void:
-	var params := {
-		"red": true,
-		"green": true,
-		"blue": true,
-		"alpha": true
-	}
+	var params := {"red": true, "green": true, "blue": true, "alpha": true}
 	var gen := ShaderImageEffect.new()
 	gen.generate_image(self, invert_shader, params, get_size())
 

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -32,7 +32,7 @@ func invert() -> void:
 
 
 func move_bitmap_values(project, move_offset := true) -> void:
-	var size := get_size()
+	var size: Vector2 = project.size
 	var selection_node = Global.canvas.selection
 	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
 	var selection_end: Vector2 = selection_node.big_bounding_rectangle.end
@@ -73,7 +73,7 @@ func move_bitmap_values(project, move_offset := true) -> void:
 
 
 func resize_bitmap_values(project, new_size: Vector2, flip_x: bool, flip_y: bool) -> void:
-	var size := get_size()
+	var size: Vector2 = project.size
 	var selection_node: Node2D = Global.canvas.selection
 	var selection_position: Vector2 = selection_node.big_bounding_rectangle.position
 	var dst := selection_position

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -12,7 +12,7 @@ func is_pixel_selected(pixel: Vector2) -> bool:
 func select_pixel(pixel: Vector2, select := true) -> void:
 	lock()
 	if select:
-		set_pixelv(pixel, Color(1))
+		set_pixelv(pixel, Color(1, 1, 1, 1))
 	else:
 		set_pixelv(pixel, Color(0))
 	unlock()

--- a/src/Shaders/ColorSelect.gdshader
+++ b/src/Shaders/ColorSelect.gdshader
@@ -1,0 +1,29 @@
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D selection : hint_black;
+uniform vec4 color;
+uniform float similarity_percent : hint_range(0.0, 100.0);
+uniform int operation = 0; // 0 = add, 1 = subtract, 2 = intersect
+
+void fragment() {
+	vec4 original_color = texture(TEXTURE, UV); 
+	float diff = distance(original_color, color);
+	float similarity = abs(2.0 - ((similarity_percent/100.0) * 2.0));
+	vec4 col = texture(selection, UV);
+	if (col.rgb == vec3(0.0))
+		col.a = 0.0;
+
+	if (diff <= similarity)
+	{
+		if (operation == 0)
+			col = vec4(1.0);
+		else if (operation == 1)
+			col = vec4(0.0);
+	}
+	else
+		if (operation == 2)
+			col = vec4(0.0);
+
+	COLOR = col;
+}

--- a/src/Tools/BaseTool.gd
+++ b/src/Tools/BaseTool.gd
@@ -75,7 +75,7 @@ func draw_preview() -> void:
 
 func _get_draw_rect() -> Rect2:
 	if Global.current_project.has_selection:
-		return Global.current_project.get_selection_rectangle()
+		return Global.current_project.selection_image.get_used_rect()
 	else:
 		return Rect2(Vector2.ZERO, Global.current_project.size)
 

--- a/src/Tools/BaseTool.gd
+++ b/src/Tools/BaseTool.gd
@@ -75,7 +75,7 @@ func draw_preview() -> void:
 
 func _get_draw_rect() -> Rect2:
 	if Global.current_project.has_selection:
-		return Global.current_project.selection_image.get_used_rect()
+		return Global.current_project.selection_map.get_used_rect()
 	else:
 		return Rect2(Vector2.ZERO, Global.current_project.size)
 

--- a/src/Tools/Bucket.gd
+++ b/src/Tools/Bucket.gd
@@ -181,7 +181,7 @@ func fill_in_color(position: Vector2) -> void:
 		var selection: Image
 		var selection_tex := ImageTexture.new()
 		if project.has_selection:
-			selection = project.selection_image
+			selection = project.selection_map
 		else:
 			selection = Image.new()
 			selection.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)

--- a/src/Tools/Bucket.gd
+++ b/src/Tools/Bucket.gd
@@ -181,7 +181,7 @@ func fill_in_color(position: Vector2) -> void:
 		var selection: Image
 		var selection_tex := ImageTexture.new()
 		if project.has_selection:
-			selection = project.bitmap_to_image(project.selection_bitmap)
+			selection = project.selection_image
 		else:
 			selection = Image.new()
 			selection.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)

--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -397,7 +397,7 @@ func remove_unselected_parts_of_brush(brush: Image, dst: Vector2) -> Image:
 	for x in size.x:
 		for y in size.y:
 			var pos := Vector2(x, y) + dst
-			if !project.selection_bitmap.get_bit(pos):
+			if !project.selection_image.is_pixel_selected(pos):
 				new_brush.set_pixel(x, y, Color(0))
 	new_brush.unlock()
 	return new_brush

--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -397,7 +397,7 @@ func remove_unselected_parts_of_brush(brush: Image, dst: Vector2) -> Image:
 	for x in size.x:
 		for y in size.y:
 			var pos := Vector2(x, y) + dst
-			if !project.selection_image.is_pixel_selected(pos):
+			if !project.selection_map.is_pixel_selected(pos):
 				new_brush.set_pixel(x, y, Color(0))
 	new_brush.unlock()
 	return new_brush

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -11,10 +11,9 @@ func apply_selection(position: Vector2) -> void:
 	if !_add and !_subtract and !_intersect:
 		Global.canvas.selection.clear_selection()
 
-	var selection_bitmap_copy: Image = project.selection_image.duplicate()
+	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
 	if _intersect:
-		var full_rect = Rect2(Vector2.ZERO, selection_bitmap_copy.get_size())
-		selection_bitmap_copy.set_bit_rect(full_rect, false)
+		selection_map_copy.clear()
 
 	var cel_image := Image.new()
 	cel_image.copy_from(_get_draw_image())
@@ -25,13 +24,11 @@ func apply_selection(position: Vector2) -> void:
 			var pos := Vector2(x, y)
 			if color.is_equal_approx(cel_image.get_pixelv(pos)):
 				if _intersect:
-					project.select_pixel(pos, project.is_pixel_selected(pos), selection_bitmap_copy)
+					selection_map_copy.select_pixel(pos, selection_map_copy.is_pixel_selected(pos))
 				else:
-					project.select_pixel(pos, !_subtract, selection_bitmap_copy)
+					selection_map_copy.select_pixel(pos, !_subtract)
 
 	cel_image.unlock()
-	project.selection_image = selection_bitmap_copy
-	Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle(
-		project.selection_image
-	)
+	project.selection_image = selection_map_copy
+	Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
 	Global.canvas.selection.commit_undo("Select", undo_data)

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -12,7 +12,7 @@ func apply_selection(position: Vector2) -> void:
 		Global.canvas.selection.clear_selection()
 
 	var selection_map_copy := SelectionMap.new()
-	selection_map_copy.copy_from(project.selection_image)
+	selection_map_copy.copy_from(project.selection_map)
 	if _intersect:
 		selection_map_copy.clear()
 
@@ -30,6 +30,6 @@ func apply_selection(position: Vector2) -> void:
 					selection_map_copy.select_pixel(pos, !_subtract)
 
 	cel_image.unlock()
-	project.selection_image = selection_map_copy
-	Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
+	project.selection_map = selection_map_copy
+	Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	Global.canvas.selection.commit_undo("Select", undo_data)

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -11,7 +11,7 @@ func apply_selection(position: Vector2) -> void:
 	if !_add and !_subtract and !_intersect:
 		Global.canvas.selection.clear_selection()
 
-	var selection_bitmap_copy: BitMap = project.selection_bitmap.duplicate()
+	var selection_bitmap_copy: Image = project.selection_image.duplicate()
 	if _intersect:
 		var full_rect = Rect2(Vector2.ZERO, selection_bitmap_copy.get_size())
 		selection_bitmap_copy.set_bit_rect(full_rect, false)
@@ -25,13 +25,13 @@ func apply_selection(position: Vector2) -> void:
 			var pos := Vector2(x, y)
 			if color.is_equal_approx(cel_image.get_pixelv(pos)):
 				if _intersect:
-					selection_bitmap_copy.set_bit(pos, project.selection_bitmap.get_bit(pos))
+					project.select_pixel(pos, project.is_pixel_selected(pos), selection_bitmap_copy)
 				else:
-					selection_bitmap_copy.set_bit(pos, !_subtract)
+					project.select_pixel(pos, !_subtract, selection_bitmap_copy)
 
 	cel_image.unlock()
-	project.selection_bitmap = selection_bitmap_copy
+	project.selection_image = selection_bitmap_copy
 	Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle(
-		project.selection_bitmap
+		project.selection_image
 	)
 	Global.canvas.selection.commit_undo("Select", undo_data)

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -11,7 +11,8 @@ func apply_selection(position: Vector2) -> void:
 	if !_add and !_subtract and !_intersect:
 		Global.canvas.selection.clear_selection()
 
-	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+	var selection_map_copy := SelectionMap.new()
+	selection_map_copy.copy_from(project.selection_image)
 	if _intersect:
 		selection_map_copy.clear()
 

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -1,5 +1,27 @@
 extends SelectionTool
 
+var shader: Shader = preload("res://src/Shaders/ColorSelect.gdshader")
+var _similarity := 100
+
+
+func get_config() -> Dictionary:
+	return {"similarity": _similarity}
+
+
+func set_config(config: Dictionary) -> void:
+	_similarity = config.get("similarity", _similarity)
+
+
+func update_config() -> void:
+	$Similarity/SimilaritySpinBox.value = _similarity
+	$Similarity/SimilaritySlider.value = _similarity
+
+
+func _on_Similarity_value_changed(value: float) -> void:
+	_similarity = value
+	update_config()
+	save_config()
+
 
 func apply_selection(position: Vector2) -> void:
 	var project: Project = Global.current_project
@@ -8,29 +30,28 @@ func apply_selection(position: Vector2) -> void:
 	if position.x > project.size.x - 1 or position.y > project.size.y - 1:
 		return
 
-	if !_add and !_subtract and !_intersect:
-		Global.canvas.selection.clear_selection()
-
-	var selection_map_copy := SelectionMap.new()
-	selection_map_copy.copy_from(project.selection_map)
-	if _intersect:
-		selection_map_copy.clear()
-
 	var cel_image := Image.new()
 	cel_image.copy_from(_get_draw_image())
 	cel_image.lock()
 	var color := cel_image.get_pixelv(position)
-	for x in cel_image.get_width():
-		for y in cel_image.get_height():
-			var pos := Vector2(x, y)
-			if color.is_equal_approx(cel_image.get_pixelv(pos)):
-				if _intersect:
-					var selected: bool = project.selection_map.is_pixel_selected(pos)
-					selection_map_copy.select_pixel(pos, selected)
-				else:
-					selection_map_copy.select_pixel(pos, !_subtract)
-
 	cel_image.unlock()
+	var operation := 0
+	if _subtract:
+		operation = 1
+	elif _intersect:
+		operation = 2
+
+	var params := {"color": color, "similarity_percent": _similarity, "operation": operation}
+	if _add or _subtract or _intersect:
+		var selection_tex := ImageTexture.new()
+		selection_tex.create_from_image(project.selection_map, 0)
+		params["selection"] = selection_tex
+	var gen := ShaderImageEffect.new()
+	gen.generate_image(cel_image, shader, params, project.size)
+	cel_image.convert(Image.FORMAT_LA8)
+
+	var selection_map_copy := SelectionMap.new()
+	selection_map_copy.copy_from(cel_image)
 	project.selection_map = selection_map_copy
 	Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	Global.canvas.selection.commit_undo("Select", undo_data)

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -25,7 +25,8 @@ func apply_selection(position: Vector2) -> void:
 			var pos := Vector2(x, y)
 			if color.is_equal_approx(cel_image.get_pixelv(pos)):
 				if _intersect:
-					selection_map_copy.select_pixel(pos, selection_map_copy.is_pixel_selected(pos))
+					var selected: bool = project.selection_map.is_pixel_selected(pos)
+					selection_map_copy.select_pixel(pos, selected)
 				else:
 					selection_map_copy.select_pixel(pos, !_subtract)
 

--- a/src/Tools/SelectionTools/ColorSelect.tscn
+++ b/src/Tools/SelectionTools/ColorSelect.tscn
@@ -5,3 +5,50 @@
 
 [node name="ToolOptions" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
+
+[node name="Similarity" type="VBoxContainer" parent="." index="8"]
+margin_top = 166.0
+margin_right = 116.0
+margin_bottom = 228.0
+alignment = 1
+
+[node name="Label" type="Label" parent="Similarity" index="0"]
+margin_left = 26.0
+margin_right = 90.0
+margin_bottom = 14.0
+size_flags_horizontal = 4
+text = "Similarity:"
+
+[node name="SimilaritySpinBox" type="SpinBox" parent="Similarity" index="1"]
+margin_left = 21.0
+margin_top = 18.0
+margin_right = 95.0
+margin_bottom = 42.0
+hint_tooltip = "How much two colors are Similar/Close together"
+mouse_default_cursor_shape = 2
+size_flags_horizontal = 4
+value = 100.0
+align = 1
+suffix = "%"
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="SimilaritySlider" type="HSlider" parent="Similarity" index="2"]
+margin_left = 12.0
+margin_top = 46.0
+margin_right = 104.0
+margin_bottom = 62.0
+rect_min_size = Vector2( 92, 0 )
+hint_tooltip = "How much two colors are Similar/Close together"
+focus_mode = 0
+mouse_default_cursor_shape = 2
+size_flags_horizontal = 4
+size_flags_vertical = 1
+value = 100.0
+__meta__ = {
+"_editor_description_": ""
+}
+
+[connection signal="value_changed" from="Similarity/SimilaritySpinBox" to="." method="_on_Similarity_value_changed"]
+[connection signal="value_changed" from="Similarity/SimilaritySlider" to="." method="_on_Similarity_value_changed"]

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -72,7 +72,8 @@ func apply_selection(_position: Vector2) -> void:
 			Global.canvas.selection.commit_undo("Select", undo_data)
 
 	if _rect.size != Vector2.ZERO:
-		var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+		var selection_map_copy := SelectionMap.new()
+		selection_map_copy.copy_from(project.selection_image)
 		set_ellipse(selection_map_copy, _rect.position)
 
 		# Handle mirroring

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -111,6 +111,7 @@ func apply_selection(_position: Vector2) -> void:
 
 
 func set_ellipse(selection_map: SelectionMap, position: Vector2) -> void:
+	var project: Project = Global.current_project
 	var bitmap_size: Vector2 = selection_map.get_size()
 	if _intersect:
 		selection_map.clear()
@@ -120,7 +121,7 @@ func set_ellipse(selection_map: SelectionMap, position: Vector2) -> void:
 		if pos.x < 0 or pos.y < 0 or pos.x >= bitmap_size.x or pos.y >= bitmap_size.y:
 			continue
 		if _intersect:
-			if selection_map.is_pixel_selected(pos):
+			if project.selection_map.is_pixel_selected(pos):
 				selection_map.select_pixel(pos, true)
 		else:
 			selection_map.select_pixel(pos, !_subtract)

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -72,7 +72,7 @@ func apply_selection(_position: Vector2) -> void:
 			Global.canvas.selection.commit_undo("Select", undo_data)
 
 	if _rect.size != Vector2.ZERO:
-		var selection_bitmap_copy: BitMap = project.selection_bitmap.duplicate()
+		var selection_bitmap_copy: Image = project.selection_image.duplicate()
 		set_ellipse(selection_bitmap_copy, _rect.position)
 
 		# Handle mirroring
@@ -104,28 +104,26 @@ func apply_selection(_position: Vector2) -> void:
 			mirror_y_rect.end.y = Global.current_project.y_symmetry_point - _rect.end.y + 1
 			set_ellipse(selection_bitmap_copy, mirror_y_rect.abs().position)
 
-		project.selection_bitmap = selection_bitmap_copy
-		Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle(
-			project.selection_bitmap
-		)
+		project.selection_image = selection_bitmap_copy
+		Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle()
 		Global.canvas.selection.commit_undo("Select", undo_data)
 
 
-func set_ellipse(bitmap: BitMap, position: Vector2) -> void:
+func set_ellipse(image: Image, position: Vector2) -> void:
 	var project: Project = Global.current_project
-	var bitmap_size: Vector2 = bitmap.get_size()
+	var bitmap_size: Vector2 = image.get_size()
 	if _intersect:
-		bitmap.set_bit_rect(Rect2(Vector2.ZERO, bitmap_size), false)
+		image.fill(Color(0))
 	var points := _get_shape_points_filled(_rect.size)
 	for p in points:
 		var pos: Vector2 = position + p
 		if pos.x < 0 or pos.y < 0 or pos.x >= bitmap_size.x or pos.y >= bitmap_size.y:
 			continue
 		if _intersect:
-			if project.selection_bitmap.get_bit(pos):
-				bitmap.set_bit(pos, true)
+			if project.is_pixel_selected(pos):
+				project.select_pixel(pos, true, image)
 		else:
-			bitmap.set_bit(pos, !_subtract)
+			project.select_pixel(pos, !_subtract, image)
 
 
 # Given an origin point and destination point, returns a rect representing

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -73,7 +73,7 @@ func apply_selection(_position: Vector2) -> void:
 
 	if _rect.size != Vector2.ZERO:
 		var selection_map_copy := SelectionMap.new()
-		selection_map_copy.copy_from(project.selection_image)
+		selection_map_copy.copy_from(project.selection_map)
 		set_ellipse(selection_map_copy, _rect.position)
 
 		# Handle mirroring
@@ -105,8 +105,8 @@ func apply_selection(_position: Vector2) -> void:
 			mirror_y_rect.end.y = Global.current_project.y_symmetry_point - _rect.end.y + 1
 			set_ellipse(selection_map_copy, mirror_y_rect.abs().position)
 
-		project.selection_image = selection_map_copy
-		Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
+		project.selection_map = selection_map_copy
+		Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 		Global.canvas.selection.commit_undo("Select", undo_data)
 
 

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -72,8 +72,8 @@ func apply_selection(_position: Vector2) -> void:
 			Global.canvas.selection.commit_undo("Select", undo_data)
 
 	if _rect.size != Vector2.ZERO:
-		var selection_bitmap_copy: Image = project.selection_image.duplicate()
-		set_ellipse(selection_bitmap_copy, _rect.position)
+		var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+		set_ellipse(selection_map_copy, _rect.position)
 
 		# Handle mirroring
 		if Tools.horizontal_mirror:
@@ -84,7 +84,7 @@ func apply_selection(_position: Vector2) -> void:
 				+ 1
 			)
 			mirror_x_rect.end.x = Global.current_project.x_symmetry_point - _rect.end.x + 1
-			set_ellipse(selection_bitmap_copy, mirror_x_rect.abs().position)
+			set_ellipse(selection_map_copy, mirror_x_rect.abs().position)
 			if Tools.vertical_mirror:
 				var mirror_xy_rect := mirror_x_rect
 				mirror_xy_rect.position.y = (
@@ -93,7 +93,7 @@ func apply_selection(_position: Vector2) -> void:
 					+ 1
 				)
 				mirror_xy_rect.end.y = Global.current_project.y_symmetry_point - _rect.end.y + 1
-				set_ellipse(selection_bitmap_copy, mirror_xy_rect.abs().position)
+				set_ellipse(selection_map_copy, mirror_xy_rect.abs().position)
 		if Tools.vertical_mirror:
 			var mirror_y_rect := _rect
 			mirror_y_rect.position.y = (
@@ -102,18 +102,18 @@ func apply_selection(_position: Vector2) -> void:
 				+ 1
 			)
 			mirror_y_rect.end.y = Global.current_project.y_symmetry_point - _rect.end.y + 1
-			set_ellipse(selection_bitmap_copy, mirror_y_rect.abs().position)
+			set_ellipse(selection_map_copy, mirror_y_rect.abs().position)
 
-		project.selection_image = selection_bitmap_copy
-		Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle()
+		project.selection_image = selection_map_copy
+		Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
 		Global.canvas.selection.commit_undo("Select", undo_data)
 
 
-func set_ellipse(image: Image, position: Vector2) -> void:
+func set_ellipse(selection_map: SelectionMap, position: Vector2) -> void:
 	var project: Project = Global.current_project
-	var bitmap_size: Vector2 = image.get_size()
+	var bitmap_size: Vector2 = selection_map.get_size()
 	if _intersect:
-		image.fill(Color(0))
+		selection_map.clear()
 	var points := _get_shape_points_filled(_rect.size)
 	for p in points:
 		var pos: Vector2 = position + p
@@ -121,9 +121,9 @@ func set_ellipse(image: Image, position: Vector2) -> void:
 			continue
 		if _intersect:
 			if project.is_pixel_selected(pos):
-				project.select_pixel(pos, true, image)
+				selection_map.select_pixel(pos, true)
 		else:
-			project.select_pixel(pos, !_subtract, image)
+			selection_map.select_pixel(pos, !_subtract)
 
 
 # Given an origin point and destination point, returns a rect representing

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -111,7 +111,6 @@ func apply_selection(_position: Vector2) -> void:
 
 
 func set_ellipse(selection_map: SelectionMap, position: Vector2) -> void:
-	var project: Project = Global.current_project
 	var bitmap_size: Vector2 = selection_map.get_size()
 	if _intersect:
 		selection_map.clear()
@@ -121,7 +120,7 @@ func set_ellipse(selection_map: SelectionMap, position: Vector2) -> void:
 		if pos.x < 0 or pos.y < 0 or pos.x >= bitmap_size.x or pos.y >= bitmap_size.y:
 			continue
 		if _intersect:
-			if project.is_pixel_selected(pos):
+			if selection_map.is_pixel_selected(pos):
 				selection_map.select_pixel(pos, true)
 		else:
 			selection_map.select_pixel(pos, !_subtract)

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -78,7 +78,7 @@ func apply_selection(_position) -> void:
 		Global.canvas.selection.clear_selection()
 	if _draw_points.size() > 3:
 		var selection_map_copy := SelectionMap.new()
-		selection_map_copy.copy_from(project.selection_image)
+		selection_map_copy.copy_from(project.selection_map)
 		if _intersect:
 			selection_map_copy.clear()
 		lasso_selection(selection_map_copy, _draw_points)
@@ -91,8 +91,8 @@ func apply_selection(_position) -> void:
 		if Tools.vertical_mirror:
 			lasso_selection(selection_map_copy, mirror_array(_draw_points, false, true))
 
-		project.selection_image = selection_map_copy
-		Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
+		project.selection_map = selection_map_copy
+		Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	else:
 		if !cleared:
 			Global.canvas.selection.clear_selection()

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -77,22 +77,21 @@ func apply_selection(_position) -> void:
 		cleared = true
 		Global.canvas.selection.clear_selection()
 	if _draw_points.size() > 3:
-		var selection_bitmap_copy: Image = project.selection_image.duplicate()
-		var bitmap_size: Vector2 = selection_bitmap_copy.get_size()
+		var selection_map_copy: SelectionMap = project.selection_image.duplicate()
 		if _intersect:
-			selection_bitmap_copy.set_bit_rect(Rect2(Vector2.ZERO, bitmap_size), false)
-		lasso_selection(selection_bitmap_copy, _draw_points)
+			selection_map_copy.clear()
+		lasso_selection(selection_map_copy, _draw_points)
 
 		# Handle mirroring
 		if Tools.horizontal_mirror:
-			lasso_selection(selection_bitmap_copy, mirror_array(_draw_points, true, false))
+			lasso_selection(selection_map_copy, mirror_array(_draw_points, true, false))
 			if Tools.vertical_mirror:
-				lasso_selection(selection_bitmap_copy, mirror_array(_draw_points, true, true))
+				lasso_selection(selection_map_copy, mirror_array(_draw_points, true, true))
 		if Tools.vertical_mirror:
-			lasso_selection(selection_bitmap_copy, mirror_array(_draw_points, false, true))
+			lasso_selection(selection_map_copy, mirror_array(_draw_points, false, true))
 
-		project.selection_image = selection_bitmap_copy
-		Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle()
+		project.selection_image = selection_map_copy
+		Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
 	else:
 		if !cleared:
 			Global.canvas.selection.clear_selection()
@@ -102,17 +101,17 @@ func apply_selection(_position) -> void:
 	_last_position = Vector2.INF
 
 
-func lasso_selection(image: Image, points: PoolVector2Array) -> void:
+func lasso_selection(selection_map: SelectionMap, points: PoolVector2Array) -> void:
 	var project: Project = Global.current_project
-	var size := image.get_size()
+	var size := selection_map.get_size()
 	for point in points:
 		if point.x < 0 or point.y < 0 or point.x >= size.x or point.y >= size.y:
 			continue
 		if _intersect:
 			if project.is_pixel_selected(point):
-				project.select_pixel(point, true, image)
+				selection_map.select_pixel(point, true)
 		else:
-			project.select_pixel(point, !_subtract, image)
+			selection_map.select_pixel(point, !_subtract)
 
 	var v := Vector2()
 	var image_size: Vector2 = project.size
@@ -123,9 +122,9 @@ func lasso_selection(image: Image, points: PoolVector2Array) -> void:
 			if Geometry.is_point_in_polygon(v, points):
 				if _intersect:
 					if project.is_pixel_selected(v):
-						project.select_pixel(v, true, image)
+						selection_map.select_pixel(v, true)
 				else:
-					project.select_pixel(v, !_subtract, image)
+					selection_map.select_pixel(v, !_subtract)
 
 
 # Bresenham's Algorithm

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -77,7 +77,8 @@ func apply_selection(_position) -> void:
 		cleared = true
 		Global.canvas.selection.clear_selection()
 	if _draw_points.size() > 3:
-		var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+		var selection_map_copy := SelectionMap.new()
+		selection_map_copy.copy_from(project.selection_image)
 		if _intersect:
 			selection_map_copy.clear()
 		lasso_selection(selection_map_copy, _draw_points)

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -77,7 +77,7 @@ func apply_selection(_position) -> void:
 		cleared = true
 		Global.canvas.selection.clear_selection()
 	if _draw_points.size() > 3:
-		var selection_bitmap_copy: BitMap = project.selection_bitmap.duplicate()
+		var selection_bitmap_copy: Image = project.selection_image.duplicate()
 		var bitmap_size: Vector2 = selection_bitmap_copy.get_size()
 		if _intersect:
 			selection_bitmap_copy.set_bit_rect(Rect2(Vector2.ZERO, bitmap_size), false)
@@ -91,10 +91,8 @@ func apply_selection(_position) -> void:
 		if Tools.vertical_mirror:
 			lasso_selection(selection_bitmap_copy, mirror_array(_draw_points, false, true))
 
-		project.selection_bitmap = selection_bitmap_copy
-		Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle(
-			project.selection_bitmap
-		)
+		project.selection_image = selection_bitmap_copy
+		Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle()
 	else:
 		if !cleared:
 			Global.canvas.selection.clear_selection()
@@ -104,17 +102,17 @@ func apply_selection(_position) -> void:
 	_last_position = Vector2.INF
 
 
-func lasso_selection(bitmap: BitMap, points: PoolVector2Array) -> void:
+func lasso_selection(image: Image, points: PoolVector2Array) -> void:
 	var project: Project = Global.current_project
-	var size := bitmap.get_size()
+	var size := image.get_size()
 	for point in points:
 		if point.x < 0 or point.y < 0 or point.x >= size.x or point.y >= size.y:
 			continue
 		if _intersect:
-			if project.selection_bitmap.get_bit(point):
-				bitmap.set_bit(point, true)
+			if project.is_pixel_selected(point):
+				project.select_pixel(point, true, image)
 		else:
-			bitmap.set_bit(point, !_subtract)
+			project.select_pixel(point, !_subtract, image)
 
 	var v := Vector2()
 	var image_size: Vector2 = project.size
@@ -124,10 +122,10 @@ func lasso_selection(bitmap: BitMap, points: PoolVector2Array) -> void:
 			v.y = y
 			if Geometry.is_point_in_polygon(v, points):
 				if _intersect:
-					if project.selection_bitmap.get_bit(v):
-						bitmap.set_bit(v, true)
+					if project.is_pixel_selected(v):
+						project.select_pixel(v, true, image)
 				else:
-					bitmap.set_bit(v, !_subtract)
+					project.select_pixel(v, !_subtract, image)
 
 
 # Bresenham's Algorithm

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -109,7 +109,7 @@ func lasso_selection(selection_map: SelectionMap, points: PoolVector2Array) -> v
 		if point.x < 0 or point.y < 0 or point.x >= size.x or point.y >= size.y:
 			continue
 		if _intersect:
-			if project.is_pixel_selected(point):
+			if selection_map.is_pixel_selected(point):
 				selection_map.select_pixel(point, true)
 		else:
 			selection_map.select_pixel(point, !_subtract)
@@ -122,7 +122,7 @@ func lasso_selection(selection_map: SelectionMap, points: PoolVector2Array) -> v
 			v.y = y
 			if Geometry.is_point_in_polygon(v, points):
 				if _intersect:
-					if project.is_pixel_selected(v):
+					if selection_map.is_pixel_selected(v):
 						selection_map.select_pixel(v, true)
 				else:
 					selection_map.select_pixel(v, !_subtract)

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -109,7 +109,7 @@ func lasso_selection(selection_map: SelectionMap, points: PoolVector2Array) -> v
 		if point.x < 0 or point.y < 0 or point.x >= size.x or point.y >= size.y:
 			continue
 		if _intersect:
-			if selection_map.is_pixel_selected(point):
+			if project.selection_map.is_pixel_selected(point):
 				selection_map.select_pixel(point, true)
 		else:
 			selection_map.select_pixel(point, !_subtract)
@@ -122,7 +122,7 @@ func lasso_selection(selection_map: SelectionMap, points: PoolVector2Array) -> v
 			v.y = y
 			if Geometry.is_point_in_polygon(v, points):
 				if _intersect:
-					if selection_map.is_pixel_selected(v):
+					if project.selection_map.is_pixel_selected(v):
 						selection_map.select_pixel(v, true)
 				else:
 					selection_map.select_pixel(v, !_subtract)

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -8,7 +8,8 @@ var _allegro_image_segments: Array
 
 func apply_selection(position: Vector2) -> void:
 	var project: Project = Global.current_project
-	if position.x < 0 or position.y < 0 or position.x >= project.size.x or position.y >= project.size.y:
+	var size: Vector2 = project.size
+	if position.x < 0 or position.y < 0 or position.x >= size.x or position.y >= size.y:
 		return
 	if !_add and !_subtract and !_intersect:
 		Global.canvas.selection.clear_selection()

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -11,7 +11,8 @@ func apply_selection(position: Vector2) -> void:
 	if !_add and !_subtract and !_intersect:
 		Global.canvas.selection.clear_selection()
 
-	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+	var selection_map_copy := SelectionMap.new()
+	selection_map_copy.copy_from(project.selection_image)
 	if _intersect:
 		selection_map_copy.clear()
 

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -12,7 +12,7 @@ func apply_selection(position: Vector2) -> void:
 		Global.canvas.selection.clear_selection()
 
 	var selection_map_copy := SelectionMap.new()
-	selection_map_copy.copy_from(project.selection_image)
+	selection_map_copy.copy_from(project.selection_map)
 	if _intersect:
 		selection_map_copy.clear()
 
@@ -35,8 +35,8 @@ func apply_selection(position: Vector2) -> void:
 		mirror_y.y = Global.current_project.y_symmetry_point - position.y
 		_flood_fill(mirror_y, cel_image, selection_map_copy)
 	cel_image.unlock()
-	project.selection_image = selection_map_copy
-	Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
+	project.selection_map = selection_map_copy
+	Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	Global.canvas.selection.commit_undo("Select", undo_data)
 
 

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -182,7 +182,8 @@ func _select_segments(selection_map: SelectionMap) -> void:
 
 
 func _set_bit(p: Vector2, selection_map: SelectionMap) -> void:
+	var project: Project = Global.current_project
 	if _intersect:
-		selection_map.select_pixel(p, selection_map.is_pixel_selected(p))
+		selection_map.select_pixel(p, project.selection_map.is_pixel_selected(p))
 	else:
 		selection_map.select_pixel(p, !_subtract)

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -8,6 +8,8 @@ var _allegro_image_segments: Array
 
 func apply_selection(position: Vector2) -> void:
 	var project: Project = Global.current_project
+	if position.x < 0 or position.y < 0 or position.x >= project.size.x or position.y >= project.size.y:
+		return
 	if !_add and !_subtract and !_intersect:
 		Global.canvas.selection.clear_selection()
 

--- a/src/Tools/SelectionTools/PolygonSelect.gd
+++ b/src/Tools/SelectionTools/PolygonSelect.gd
@@ -113,21 +113,21 @@ func apply_selection(_position) -> void:
 		cleared = true
 		Global.canvas.selection.clear_selection()
 	if _draw_points.size() > 3:
-		var selection_bitmap_copy: Image = project.selection_image.duplicate()
+		var selection_map_copy: SelectionMap = project.selection_image.duplicate()
 		if _intersect:
-			selection_bitmap_copy.fill(Color(0))
-		lasso_selection(selection_bitmap_copy, _draw_points)
+			selection_map_copy.clear()
+		lasso_selection(selection_map_copy, _draw_points)
 
 		# Handle mirroring
 		if Tools.horizontal_mirror:
-			lasso_selection(selection_bitmap_copy, mirror_array(_draw_points, true, false))
+			lasso_selection(selection_map_copy, mirror_array(_draw_points, true, false))
 			if Tools.vertical_mirror:
-				lasso_selection(selection_bitmap_copy, mirror_array(_draw_points, true, true))
+				lasso_selection(selection_map_copy, mirror_array(_draw_points, true, true))
 		if Tools.vertical_mirror:
-			lasso_selection(selection_bitmap_copy, mirror_array(_draw_points, false, true))
+			lasso_selection(selection_map_copy, mirror_array(_draw_points, false, true))
 
-		project.selection_image = selection_bitmap_copy
-		Global.canvas.selection.big_bounding_rectangle = project.get_selection_rectangle()
+		project.selection_image = selection_map_copy
+		Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
 	else:
 		if !cleared:
 			Global.canvas.selection.clear_selection()
@@ -139,17 +139,17 @@ func apply_selection(_position) -> void:
 	Global.canvas.previews.update()
 
 
-func lasso_selection(image: Image, points: PoolVector2Array) -> void:
+func lasso_selection(selection_map: SelectionMap, points: PoolVector2Array) -> void:
 	var project: Project = Global.current_project
-	var size := image.get_size()
+	var size := selection_map.get_size()
 	for point in points:
 		if point.x < 0 or point.y < 0 or point.x >= size.x or point.y >= size.y:
 			continue
 		if _intersect:
-			if project.is_pixel_selected(point):
-				project.select_pixel(point, true, image)
+			if project.selection_image.is_pixel_selected(point):
+				selection_map.select_pixel(point, true)
 		else:
-			project.select_pixel(point, !_subtract, image)
+			selection_map.select_pixel(point, !_subtract)
 
 	var v := Vector2()
 	var image_size: Vector2 = project.size
@@ -159,10 +159,10 @@ func lasso_selection(image: Image, points: PoolVector2Array) -> void:
 			v.y = y
 			if Geometry.is_point_in_polygon(v, points):
 				if _intersect:
-					if project.is_pixel_selected(v):
-						project.select_pixel(v, true, image)
+					if project.selection_image.is_pixel_selected(v):
+						selection_map.select_pixel(v, true)
 				else:
-					project.select_pixel(v, !_subtract, image)
+					selection_map.select_pixel(v, !_subtract)
 
 
 # Bresenham's Algorithm

--- a/src/Tools/SelectionTools/PolygonSelect.gd
+++ b/src/Tools/SelectionTools/PolygonSelect.gd
@@ -113,7 +113,8 @@ func apply_selection(_position) -> void:
 		cleared = true
 		Global.canvas.selection.clear_selection()
 	if _draw_points.size() > 3:
-		var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+		var selection_map_copy := SelectionMap.new()
+		selection_map_copy.copy_from(project.selection_image)
 		if _intersect:
 			selection_map_copy.clear()
 		lasso_selection(selection_map_copy, _draw_points)

--- a/src/Tools/SelectionTools/PolygonSelect.gd
+++ b/src/Tools/SelectionTools/PolygonSelect.gd
@@ -114,7 +114,7 @@ func apply_selection(_position) -> void:
 		Global.canvas.selection.clear_selection()
 	if _draw_points.size() > 3:
 		var selection_map_copy := SelectionMap.new()
-		selection_map_copy.copy_from(project.selection_image)
+		selection_map_copy.copy_from(project.selection_map)
 		if _intersect:
 			selection_map_copy.clear()
 		lasso_selection(selection_map_copy, _draw_points)
@@ -127,8 +127,8 @@ func apply_selection(_position) -> void:
 		if Tools.vertical_mirror:
 			lasso_selection(selection_map_copy, mirror_array(_draw_points, false, true))
 
-		project.selection_image = selection_map_copy
-		Global.canvas.selection.big_bounding_rectangle = project.selection_image.get_used_rect()
+		project.selection_map = selection_map_copy
+		Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	else:
 		if !cleared:
 			Global.canvas.selection.clear_selection()
@@ -147,7 +147,7 @@ func lasso_selection(selection_map: SelectionMap, points: PoolVector2Array) -> v
 		if point.x < 0 or point.y < 0 or point.x >= size.x or point.y >= size.y:
 			continue
 		if _intersect:
-			if project.selection_image.is_pixel_selected(point):
+			if project.selection_map.is_pixel_selected(point):
 				selection_map.select_pixel(point, true)
 		else:
 			selection_map.select_pixel(point, !_subtract)
@@ -160,7 +160,7 @@ func lasso_selection(selection_map: SelectionMap, points: PoolVector2Array) -> v
 			v.y = y
 			if Geometry.is_point_in_polygon(v, points):
 				if _intersect:
-					if project.selection_image.is_pixel_selected(v):
+					if project.selection_map.is_pixel_selected(v):
 						selection_map.select_pixel(v, true)
 				else:
 					selection_map.select_pixel(v, !_subtract)

--- a/src/Tools/SelectionTools/RectSelect.gd
+++ b/src/Tools/SelectionTools/RectSelect.gd
@@ -87,49 +87,39 @@ func draw_preview() -> void:
 		canvas.draw_set_transform(canvas.position, canvas.rotation, canvas.scale)
 
 
-func apply_selection(_position) -> void:
+func apply_selection(_position: Vector2) -> void:
+	var project: Project = Global.current_project
 	if !_add and !_subtract and !_intersect:
 		Global.canvas.selection.clear_selection()
-		if _rect.size == Vector2.ZERO and Global.current_project.has_selection:
+		if _rect.size == Vector2.ZERO and project.has_selection:
 			Global.canvas.selection.commit_undo("Select", undo_data)
-	if _rect.size != Vector2.ZERO:
-		var operation := 0
-		if _subtract:
-			operation = 1
-		elif _intersect:
-			operation = 2
-		Global.canvas.selection.select_rect(_rect, operation)
+	if _rect.size == Vector2.ZERO:
+		return
+	var operation := 0
+	if _subtract:
+		operation = 1
+	elif _intersect:
+		operation = 2
+	Global.canvas.selection.select_rect(_rect, operation)
 
-		# Handle mirroring
-		if Tools.horizontal_mirror:
-			var mirror_x_rect := _rect
-			mirror_x_rect.position.x = (
-				Global.current_project.x_symmetry_point
-				- _rect.position.x
-				+ 1
-			)
-			mirror_x_rect.end.x = Global.current_project.x_symmetry_point - _rect.end.x + 1
-			Global.canvas.selection.select_rect(mirror_x_rect.abs(), operation)
-			if Tools.vertical_mirror:
-				var mirror_xy_rect := mirror_x_rect
-				mirror_xy_rect.position.y = (
-					Global.current_project.y_symmetry_point
-					- _rect.position.y
-					+ 1
-				)
-				mirror_xy_rect.end.y = Global.current_project.y_symmetry_point - _rect.end.y + 1
-				Global.canvas.selection.select_rect(mirror_xy_rect.abs(), operation)
+	# Handle mirroring
+	if Tools.horizontal_mirror:
+		var mirror_x_rect := _rect
+		mirror_x_rect.position.x = project.x_symmetry_point - _rect.position.x + 1
+		mirror_x_rect.end.x = project.x_symmetry_point - _rect.end.x + 1
+		Global.canvas.selection.select_rect(mirror_x_rect.abs(), operation)
 		if Tools.vertical_mirror:
-			var mirror_y_rect := _rect
-			mirror_y_rect.position.y = (
-				Global.current_project.y_symmetry_point
-				- _rect.position.y
-				+ 1
-			)
-			mirror_y_rect.end.y = Global.current_project.y_symmetry_point - _rect.end.y + 1
-			Global.canvas.selection.select_rect(mirror_y_rect.abs(), operation)
+			var mirror_xy_rect := mirror_x_rect
+			mirror_xy_rect.position.y = project.y_symmetry_point - _rect.position.y + 1
+			mirror_xy_rect.end.y = project.y_symmetry_point - _rect.end.y + 1
+			Global.canvas.selection.select_rect(mirror_xy_rect.abs(), operation)
+	if Tools.vertical_mirror:
+		var mirror_y_rect := _rect
+		mirror_y_rect.position.y = project.y_symmetry_point - _rect.position.y + 1
+		mirror_y_rect.end.y = project.y_symmetry_point - _rect.end.y + 1
+		Global.canvas.selection.select_rect(mirror_y_rect.abs(), operation)
 
-		Global.canvas.selection.commit_undo("Select", undo_data)
+	Global.canvas.selection.commit_undo("Select", undo_data)
 
 
 # Given an origin point and destination point, returns a rect representing

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -85,10 +85,11 @@ func draw_start(position: Vector2) -> void:
 						selection_node.big_bounding_rectangle.position
 					)
 
-				var selected_bitmap_copy: SelectionMap = project.selection_image.duplicate()
-				selected_bitmap_copy.move_bitmap_values()
+				var selection_map_copy := SelectionMap.new()
+				selection_map_copy.copy_from(project.selection_image)
+				selection_map_copy.move_bitmap_values()
 
-				project.selection_image = selected_bitmap_copy
+				project.selection_image = selection_map_copy
 				selection_node.commit_undo("Move Selection", selection_node.undo_data)
 				selection_node.undo_data = selection_node.get_undo_data(true)
 			else:
@@ -190,7 +191,8 @@ func _on_XSpinBox_value_changed(value: float) -> void:
 	timer.start()
 	selection_node.big_bounding_rectangle.position.x = value
 
-	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+	var selection_map_copy := SelectionMap.new()
+	selection_map_copy.copy_from(project.selection_image)
 	selection_map_copy.move_bitmap_values()
 	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
@@ -205,7 +207,8 @@ func _on_YSpinBox_value_changed(value: float) -> void:
 	timer.start()
 	selection_node.big_bounding_rectangle.position.y = value
 
-	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+	var selection_map_copy := SelectionMap.new()
+	selection_map_copy.copy_from(project.selection_image)
 	selection_map_copy.move_bitmap_values()
 	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
@@ -255,7 +258,8 @@ func resize_selection() -> void:
 		)
 		selection_node.preview_image_texture.create_from_image(preview_image, 0)
 
-	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+	var selection_map_copy := SelectionMap.new()
+	selection_map_copy.copy_from(project.selection_image)
 	selection_map_copy = image
 	selection_map_copy.resize_bitmap_values(
 		selection_node.big_bounding_rectangle.size, false, false

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -66,7 +66,7 @@ func draw_start(position: Vector2) -> void:
 	if (
 		offsetted_pos.x >= 0
 		and offsetted_pos.y >= 0
-		and project.is_pixel_selected(offsetted_pos)
+		and project.selection_image.is_pixel_selected(offsetted_pos)
 		and (!_add and !_subtract and !_intersect or quick_copy)
 		and !_ongoing_selection
 	):
@@ -85,7 +85,7 @@ func draw_start(position: Vector2) -> void:
 						selection_node.big_bounding_rectangle.position
 					)
 
-				var selected_bitmap_copy = project.selection_image.duplicate()
+				var selected_bitmap_copy: SelectionMap = project.selection_image.duplicate()
 				project.move_bitmap_values(selected_bitmap_copy)
 
 				project.selection_image = selected_bitmap_copy
@@ -190,9 +190,9 @@ func _on_XSpinBox_value_changed(value: float) -> void:
 	timer.start()
 	selection_node.big_bounding_rectangle.position.x = value
 
-	var selection_bitmap_copy: Image = project.selection_image.duplicate()
-	project.move_bitmap_values(selection_bitmap_copy)
-	project.selection_image = selection_bitmap_copy
+	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+	project.move_bitmap_values(selection_map_copy)
+	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
 
 
@@ -205,9 +205,9 @@ func _on_YSpinBox_value_changed(value: float) -> void:
 	timer.start()
 	selection_node.big_bounding_rectangle.position.y = value
 
-	var selection_bitmap_copy: Image = project.selection_image.duplicate()
-	project.move_bitmap_values(selection_bitmap_copy)
-	project.selection_image = selection_bitmap_copy
+	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+	project.move_bitmap_values(selection_map_copy)
+	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
 
 
@@ -243,7 +243,7 @@ func _on_HSpinBox_value_changed(value: float) -> void:
 
 func resize_selection() -> void:
 	var project: Project = Global.current_project
-	var image: Image = project.selection_image
+	var image: SelectionMap = project.selection_image
 	if selection_node.is_moving_content:
 		image = selection_node.selection_image
 		var preview_image: Image = selection_node.preview_image
@@ -255,11 +255,11 @@ func resize_selection() -> void:
 		)
 		selection_node.preview_image_texture.create_from_image(preview_image, 0)
 
-	var selection_bitmap_copy: Image = project.selection_image.duplicate()
-	selection_bitmap_copy = project.resize_bitmap_values(
+	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
+	selection_map_copy = project.resize_bitmap_values(
 		image, selection_node.big_bounding_rectangle.size, false, false
 	)
-	project.selection_image = selection_bitmap_copy
+	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
 
 

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -86,7 +86,7 @@ func draw_start(position: Vector2) -> void:
 					)
 
 				var selected_bitmap_copy: SelectionMap = project.selection_image.duplicate()
-				project.move_bitmap_values(selected_bitmap_copy)
+				selected_bitmap_copy.move_bitmap_values()
 
 				project.selection_image = selected_bitmap_copy
 				selection_node.commit_undo("Move Selection", selection_node.undo_data)
@@ -191,7 +191,7 @@ func _on_XSpinBox_value_changed(value: float) -> void:
 	selection_node.big_bounding_rectangle.position.x = value
 
 	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
-	project.move_bitmap_values(selection_map_copy)
+	selection_map_copy.move_bitmap_values()
 	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
 
@@ -206,7 +206,7 @@ func _on_YSpinBox_value_changed(value: float) -> void:
 	selection_node.big_bounding_rectangle.position.y = value
 
 	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
-	project.move_bitmap_values(selection_map_copy)
+	selection_map_copy.move_bitmap_values()
 	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
 
@@ -256,8 +256,9 @@ func resize_selection() -> void:
 		selection_node.preview_image_texture.create_from_image(preview_image, 0)
 
 	var selection_map_copy: SelectionMap = project.selection_image.duplicate()
-	selection_map_copy = project.resize_bitmap_values(
-		image, selection_node.big_bounding_rectangle.size, false, false
+	selection_map_copy = image
+	selection_map_copy.resize_bitmap_values(
+		selection_node.big_bounding_rectangle.size, false, false
 	)
 	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -66,7 +66,7 @@ func draw_start(position: Vector2) -> void:
 	if (
 		offsetted_pos.x >= 0
 		and offsetted_pos.y >= 0
-		and project.selection_image.is_pixel_selected(offsetted_pos)
+		and project.selection_map.is_pixel_selected(offsetted_pos)
 		and (!_add and !_subtract and !_intersect or quick_copy)
 		and !_ongoing_selection
 	):
@@ -81,15 +81,15 @@ func draw_start(position: Vector2) -> void:
 					image.blit_rect_mask(
 						selection_node.preview_image,
 						selection_node.preview_image,
-						Rect2(Vector2.ZERO, project.selection_image.get_size()),
+						Rect2(Vector2.ZERO, project.selection_map.get_size()),
 						selection_node.big_bounding_rectangle.position
 					)
 
 				var selection_map_copy := SelectionMap.new()
-				selection_map_copy.copy_from(project.selection_image)
+				selection_map_copy.copy_from(project.selection_map)
 				selection_map_copy.move_bitmap_values(project)
 
-				project.selection_image = selection_map_copy
+				project.selection_map = selection_map_copy
 				selection_node.commit_undo("Move Selection", selection_node.undo_data)
 				selection_node.undo_data = selection_node.get_undo_data(true)
 			else:
@@ -99,7 +99,7 @@ func draw_start(position: Vector2) -> void:
 					image.blit_rect_mask(
 						selection_node.preview_image,
 						selection_node.preview_image,
-						Rect2(Vector2.ZERO, project.selection_image.get_size()),
+						Rect2(Vector2.ZERO, project.selection_map.get_size()),
 						selection_node.big_bounding_rectangle.position
 					)
 				Global.canvas.update_selected_cels_textures()
@@ -192,9 +192,9 @@ func _on_XSpinBox_value_changed(value: float) -> void:
 	selection_node.big_bounding_rectangle.position.x = value
 
 	var selection_map_copy := SelectionMap.new()
-	selection_map_copy.copy_from(project.selection_image)
+	selection_map_copy.copy_from(project.selection_map)
 	selection_map_copy.move_bitmap_values(project)
-	project.selection_image = selection_map_copy
+	project.selection_map = selection_map_copy
 	project.selection_bitmap_changed()
 
 
@@ -208,9 +208,9 @@ func _on_YSpinBox_value_changed(value: float) -> void:
 	selection_node.big_bounding_rectangle.position.y = value
 
 	var selection_map_copy := SelectionMap.new()
-	selection_map_copy.copy_from(project.selection_image)
+	selection_map_copy.copy_from(project.selection_map)
 	selection_map_copy.move_bitmap_values(project)
-	project.selection_image = selection_map_copy
+	project.selection_map = selection_map_copy
 	project.selection_bitmap_changed()
 
 
@@ -246,9 +246,9 @@ func _on_HSpinBox_value_changed(value: float) -> void:
 
 func resize_selection() -> void:
 	var project: Project = Global.current_project
-	var image: SelectionMap = project.selection_image
+	var image: SelectionMap = project.selection_map
 	if selection_node.is_moving_content:
-		image = selection_node.selection_image
+		image = selection_node.original_bitmap
 		var preview_image: Image = selection_node.preview_image
 		preview_image.copy_from(selection_node.original_preview_image)
 		preview_image.resize(
@@ -259,12 +259,12 @@ func resize_selection() -> void:
 		selection_node.preview_image_texture.create_from_image(preview_image, 0)
 
 	var selection_map_copy := SelectionMap.new()
-	selection_map_copy.copy_from(project.selection_image)
+	selection_map_copy.copy_from(project.selection_map)
 	selection_map_copy = image
 	selection_map_copy.resize_bitmap_values(
 		project, selection_node.big_bounding_rectangle.size, false, false
 	)
-	project.selection_image = selection_map_copy
+	project.selection_map = selection_map_copy
 	project.selection_bitmap_changed()
 
 

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -195,7 +195,7 @@ func _on_XSpinBox_value_changed(value: float) -> void:
 	selection_map_copy.copy_from(project.selection_map)
 	selection_map_copy.move_bitmap_values(project)
 	project.selection_map = selection_map_copy
-	project.selection_bitmap_changed()
+	project.selection_map_changed()
 
 
 func _on_YSpinBox_value_changed(value: float) -> void:
@@ -211,7 +211,7 @@ func _on_YSpinBox_value_changed(value: float) -> void:
 	selection_map_copy.copy_from(project.selection_map)
 	selection_map_copy.move_bitmap_values(project)
 	project.selection_map = selection_map_copy
-	project.selection_bitmap_changed()
+	project.selection_map_changed()
 
 
 func _on_WSpinBox_value_changed(value: float) -> void:
@@ -265,7 +265,7 @@ func resize_selection() -> void:
 		project, selection_node.big_bounding_rectangle.size, false, false
 	)
 	project.selection_map = selection_map_copy
-	project.selection_bitmap_changed()
+	project.selection_map_changed()
 
 
 func _on_Timer_timeout() -> void:

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -66,7 +66,7 @@ func draw_start(position: Vector2) -> void:
 	if (
 		offsetted_pos.x >= 0
 		and offsetted_pos.y >= 0
-		and project.selection_bitmap.get_bit(offsetted_pos)
+		and project.is_pixel_selected(offsetted_pos)
 		and (!_add and !_subtract and !_intersect or quick_copy)
 		and !_ongoing_selection
 	):
@@ -81,14 +81,14 @@ func draw_start(position: Vector2) -> void:
 					image.blit_rect_mask(
 						selection_node.preview_image,
 						selection_node.preview_image,
-						Rect2(Vector2.ZERO, project.selection_bitmap.get_size()),
+						Rect2(Vector2.ZERO, project.selection_image.get_size()),
 						selection_node.big_bounding_rectangle.position
 					)
 
-				var selected_bitmap_copy = project.selection_bitmap.duplicate()
+				var selected_bitmap_copy = project.selection_image.duplicate()
 				project.move_bitmap_values(selected_bitmap_copy)
 
-				project.selection_bitmap = selected_bitmap_copy
+				project.selection_image = selected_bitmap_copy
 				selection_node.commit_undo("Move Selection", selection_node.undo_data)
 				selection_node.undo_data = selection_node.get_undo_data(true)
 			else:
@@ -98,7 +98,7 @@ func draw_start(position: Vector2) -> void:
 					image.blit_rect_mask(
 						selection_node.preview_image,
 						selection_node.preview_image,
-						Rect2(Vector2.ZERO, project.selection_bitmap.get_size()),
+						Rect2(Vector2.ZERO, project.selection_image.get_size()),
 						selection_node.big_bounding_rectangle.position
 					)
 				Global.canvas.update_selected_cels_textures()
@@ -190,9 +190,9 @@ func _on_XSpinBox_value_changed(value: float) -> void:
 	timer.start()
 	selection_node.big_bounding_rectangle.position.x = value
 
-	var selection_bitmap_copy: BitMap = project.selection_bitmap.duplicate()
+	var selection_bitmap_copy: Image = project.selection_image.duplicate()
 	project.move_bitmap_values(selection_bitmap_copy)
-	project.selection_bitmap = selection_bitmap_copy
+	project.selection_image = selection_bitmap_copy
 	project.selection_bitmap_changed()
 
 
@@ -205,9 +205,9 @@ func _on_YSpinBox_value_changed(value: float) -> void:
 	timer.start()
 	selection_node.big_bounding_rectangle.position.y = value
 
-	var selection_bitmap_copy: BitMap = project.selection_bitmap.duplicate()
+	var selection_bitmap_copy: Image = project.selection_image.duplicate()
 	project.move_bitmap_values(selection_bitmap_copy)
-	project.selection_bitmap = selection_bitmap_copy
+	project.selection_image = selection_bitmap_copy
 	project.selection_bitmap_changed()
 
 
@@ -243,9 +243,9 @@ func _on_HSpinBox_value_changed(value: float) -> void:
 
 func resize_selection() -> void:
 	var project: Project = Global.current_project
-	var bitmap: BitMap = project.selection_bitmap
+	var image: Image = project.selection_image
 	if selection_node.is_moving_content:
-		bitmap = selection_node.original_bitmap
+		image = selection_node.selection_image
 		var preview_image: Image = selection_node.preview_image
 		preview_image.copy_from(selection_node.original_preview_image)
 		preview_image.resize(
@@ -255,11 +255,11 @@ func resize_selection() -> void:
 		)
 		selection_node.preview_image_texture.create_from_image(preview_image, 0)
 
-	var selection_bitmap_copy: BitMap = project.selection_bitmap.duplicate()
+	var selection_bitmap_copy: Image = project.selection_image.duplicate()
 	selection_bitmap_copy = project.resize_bitmap_values(
-		bitmap, selection_node.big_bounding_rectangle.size, false, false
+		image, selection_node.big_bounding_rectangle.size, false, false
 	)
-	project.selection_bitmap = selection_bitmap_copy
+	project.selection_image = selection_bitmap_copy
 	project.selection_bitmap_changed()
 
 

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -87,7 +87,7 @@ func draw_start(position: Vector2) -> void:
 
 				var selection_map_copy := SelectionMap.new()
 				selection_map_copy.copy_from(project.selection_image)
-				selection_map_copy.move_bitmap_values()
+				selection_map_copy.move_bitmap_values(project)
 
 				project.selection_image = selection_map_copy
 				selection_node.commit_undo("Move Selection", selection_node.undo_data)
@@ -193,7 +193,7 @@ func _on_XSpinBox_value_changed(value: float) -> void:
 
 	var selection_map_copy := SelectionMap.new()
 	selection_map_copy.copy_from(project.selection_image)
-	selection_map_copy.move_bitmap_values()
+	selection_map_copy.move_bitmap_values(project)
 	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
 
@@ -209,7 +209,7 @@ func _on_YSpinBox_value_changed(value: float) -> void:
 
 	var selection_map_copy := SelectionMap.new()
 	selection_map_copy.copy_from(project.selection_image)
-	selection_map_copy.move_bitmap_values()
+	selection_map_copy.move_bitmap_values(project)
 	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()
 
@@ -262,7 +262,7 @@ func resize_selection() -> void:
 	selection_map_copy.copy_from(project.selection_image)
 	selection_map_copy = image
 	selection_map_copy.resize_bitmap_values(
-		selection_node.big_bounding_rectangle.size, false, false
+		project, selection_node.big_bounding_rectangle.size, false, false
 	)
 	project.selection_image = selection_map_copy
 	project.selection_bitmap_changed()

--- a/src/Tools/SelectionTools/SelectionTool.gd
+++ b/src/Tools/SelectionTools/SelectionTool.gd
@@ -259,8 +259,7 @@ func resize_selection() -> void:
 		selection_node.preview_image_texture.create_from_image(preview_image, 0)
 
 	var selection_map_copy := SelectionMap.new()
-	selection_map_copy.copy_from(project.selection_map)
-	selection_map_copy = image
+	selection_map_copy.copy_from(image)
 	selection_map_copy.resize_bitmap_values(
 		project, selection_node.big_bounding_rectangle.size, false, false
 	)

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -442,7 +442,7 @@ func select_rect(rect: Rect2, operation: int = SelectionOperation.ADD) -> void:
 				if !Rect2(Vector2.ZERO, selection_bitmap_copy.get_size()).has_point(pos):
 					continue
 				selection_bitmap_copy.set_bit(pos, project.selection_bitmap.get_bit(pos))
-	big_bounding_rectangle = project.get_selection_rectangle(selection_bitmap_copy)
+	big_bounding_rectangle = selection_bitmap_copy.get_used_rect()
 
 	if offset_position != Vector2.ZERO:
 		big_bounding_rectangle.position += offset_position
@@ -843,7 +843,7 @@ func invert() -> void:
 	project.invert_bitmap(selection_bitmap_copy)
 	project.selection_bitmap = selection_bitmap_copy
 	project.selection_bitmap_changed()
-	self.big_bounding_rectangle = project.get_selection_rectangle(selection_bitmap_copy)
+	self.big_bounding_rectangle = selection_bitmap_copy.get_used_rect()
 	project.selection_offset = Vector2.ZERO
 	commit_undo("Select", undo_data_tmp)
 

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -433,7 +433,7 @@ func select_rect(rect: Rect2, operation: int = SelectionOperation.ADD) -> void:
 		selection_map_copy.move_bitmap_values()
 
 	if operation == SelectionOperation.ADD:
-		selection_map_copy.fill_rect(rect, Color(1))
+		selection_map_copy.fill_rect(rect, Color(1, 1, 1, 1))
 	elif operation == SelectionOperation.SUBTRACT:
 		selection_map_copy.fill_rect(rect, Color(0))
 	elif operation == SelectionOperation.INTERSECT:

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -588,9 +588,7 @@ func commit_undo(action: String, undo_data_tmp: Dictionary) -> void:
 	)
 	project.undo_redo.add_do_property(project, "selection_offset", redo_data["outline_offset"])
 
-	project.undo_redo.add_undo_property(
-		project, "selection_map", undo_data_tmp["selection_map"]
-	)
+	project.undo_redo.add_undo_property(project, "selection_map", undo_data_tmp["selection_map"])
 	project.undo_redo.add_undo_property(
 		self, "big_bounding_rectangle", undo_data_tmp["big_bounding_rectangle"]
 	)

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -352,10 +352,12 @@ func _gizmo_resize() -> void:
 			preview_image.flip_y()
 		preview_image_texture.create_from_image(preview_image, 0)
 
-	Global.current_project.selection_map = temp_bitmap
-	Global.current_project.selection_map.resize_bitmap_values(
+	var temp_bitmap_copy := SelectionMap.new()
+	temp_bitmap_copy.copy_from(temp_bitmap)
+	temp_bitmap_copy.resize_bitmap_values(
 		Global.current_project, size, temp_rect.size.x < 0, temp_rect.size.y < 0
 	)
+	Global.current_project.selection_map = temp_bitmap_copy
 	Global.current_project.selection_map_changed()
 	update()
 

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -443,7 +443,7 @@ func select_rect(rect: Rect2, operation: int = SelectionOperation.ADD) -> void:
 				var pos := Vector2(x, y)
 				if !Rect2(Vector2.ZERO, selection_map_copy.get_size()).has_point(pos):
 					continue
-				selection_map_copy.set_bit(pos, project.selection_image.is_pixel_selected(pos))
+				selection_map_copy.select_pixel(pos, project.selection_image.is_pixel_selected(pos))
 	big_bounding_rectangle = selection_map_copy.get_used_rect()
 
 	if offset_position != Vector2.ZERO:
@@ -489,7 +489,7 @@ func transform_content_start() -> void:
 			undo_data = get_undo_data(false)
 			return
 		is_moving_content = true
-		original_bitmap.copy_from(Global.current_project.selection_images)
+		original_bitmap.copy_from(Global.current_project.selection_image)
 		original_big_bounding_rectangle = big_bounding_rectangle
 		original_offset = Global.current_project.selection_offset
 		update()
@@ -866,8 +866,7 @@ func clear_selection(use_undo := false) -> void:
 	var selection_map_copy := SelectionMap.new()
 	selection_map_copy.copy_from(project.selection_image)
 	selection_map_copy.crop(project.size.x, project.size.y)
-	var full_rect = Rect2(Vector2.ZERO, selection_map_copy.get_size())
-	selection_map_copy.set_bit_rect(full_rect, false)
+	selection_map_copy.clear()
 	project.selection_image = selection_map_copy
 
 	self.big_bounding_rectangle = Rect2()

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -356,7 +356,7 @@ func _gizmo_resize() -> void:
 	Global.current_project.selection_map.resize_bitmap_values(
 		Global.current_project, size, temp_rect.size.x < 0, temp_rect.size.y < 0
 	)
-	Global.current_project.selection_bitmap_changed()
+	Global.current_project.selection_map_changed()
 	update()
 
 
@@ -409,7 +409,7 @@ func _gizmo_rotate() -> void:  # Does not work properly yet
 	)
 	DrawingAlgos.nn_rotate(bitmap_image, angle, bitmap_pivot)
 	Global.current_project.selection_map = bitmap_image
-	Global.current_project.selection_bitmap_changed()
+	Global.current_project.selection_map_changed()
 	self.big_bounding_rectangle = bitmap_image.get_used_rect()
 	update()
 
@@ -475,7 +475,7 @@ func move_borders_end() -> void:
 	if !is_moving_content:
 		commit_undo("Select", undo_data)
 	else:
-		Global.current_project.selection_bitmap_changed()
+		Global.current_project.selection_map_changed()
 	update()
 
 
@@ -555,7 +555,7 @@ func transform_content_cancel() -> void:
 	is_moving_content = false
 	self.big_bounding_rectangle = original_big_bounding_rectangle
 	project.selection_map = original_bitmap
-	project.selection_bitmap_changed()
+	project.selection_map_changed()
 	preview_image = original_preview_image
 	if !is_pasting:
 		var cel_image: Image = project.frames[project.current_frame].cels[project.current_layer].image
@@ -609,9 +609,9 @@ func commit_undo(action: String, undo_data_tmp: Dictionary) -> void:
 				continue
 			project.undo_redo.add_undo_property(image, "data", undo_data_tmp[image])
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
-	project.undo_redo.add_do_method(project, "selection_bitmap_changed")
+	project.undo_redo.add_do_method(project, "selection_map_changed")
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true)
-	project.undo_redo.add_undo_method(project, "selection_bitmap_changed")
+	project.undo_redo.add_undo_method(project, "selection_map_changed")
 	project.undo_redo.commit_action()
 
 	undo_data.clear()
@@ -756,7 +756,7 @@ func paste() -> void:
 		preview_image.copy_from(original_preview_image)
 		preview_image_texture.create_from_image(preview_image, 0)
 
-		project.selection_bitmap_changed()
+		project.selection_map_changed()
 
 
 func delete(selected_cels := true) -> void:
@@ -851,7 +851,7 @@ func invert() -> void:
 	selection_map_copy.crop(project.size.x, project.size.y)
 	selection_map_copy.invert()
 	project.selection_map = selection_map_copy
-	project.selection_bitmap_changed()
+	project.selection_map_changed()
 	self.big_bounding_rectangle = selection_map_copy.get_used_rect()
 	project.selection_offset = Vector2.ZERO
 	commit_undo("Select", undo_data_tmp)

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -354,7 +354,7 @@ func _gizmo_resize() -> void:
 
 	Global.current_project.selection_image = temp_bitmap
 	Global.current_project.selection_image.resize_bitmap_values(
-		size, temp_rect.size.x < 0, temp_rect.size.y < 0
+		Global.current_project, size, temp_rect.size.x < 0, temp_rect.size.y < 0
 	)
 	Global.current_project.selection_bitmap_changed()
 	update()
@@ -430,7 +430,7 @@ func select_rect(rect: Rect2, operation: int = SelectionOperation.ADD) -> void:
 
 	if offset_position != Vector2.ZERO:
 		big_bounding_rectangle.position -= offset_position
-		selection_map_copy.move_bitmap_values()
+		selection_map_copy.move_bitmap_values(project)
 
 	if operation == SelectionOperation.ADD:
 		selection_map_copy.fill_rect(rect, Color(1, 1, 1, 1))
@@ -448,7 +448,7 @@ func select_rect(rect: Rect2, operation: int = SelectionOperation.ADD) -> void:
 
 	if offset_position != Vector2.ZERO:
 		big_bounding_rectangle.position += offset_position
-		selection_map_copy.move_bitmap_values()
+		selection_map_copy.move_bitmap_values(project)
 
 	project.selection_image = selection_map_copy
 	self.big_bounding_rectangle = big_bounding_rectangle  # call getter method
@@ -469,7 +469,7 @@ func move_borders(move: Vector2) -> void:
 func move_borders_end() -> void:
 	var selection_map_copy := SelectionMap.new()
 	selection_map_copy.copy_from(Global.current_project.selection_image)
-	selection_map_copy.move_bitmap_values()
+	selection_map_copy.move_bitmap_values(Global.current_project)
 
 	Global.current_project.selection_image = selection_map_copy
 	if !is_moving_content:
@@ -533,7 +533,7 @@ func transform_content_confirm() -> void:
 				)
 	var selection_map_copy := SelectionMap.new()
 	selection_map_copy.copy_from(project.selection_image)
-	selection_map_copy.move_bitmap_values()
+	selection_map_copy.move_bitmap_values(project)
 	project.selection_image = selection_map_copy
 	commit_undo("Move Selection", undo_data)
 
@@ -667,7 +667,7 @@ func copy() -> void:
 		to_copy.copy_from(preview_image)
 		var selection_map_copy := SelectionMap.new()
 		selection_map_copy.copy_from(project.selection_image)
-		selection_map_copy.move_bitmap_values(false)
+		selection_map_copy.move_bitmap_values(project, false)
 		cl_selection_bitmap = selection_map_copy
 	else:
 		to_copy = image.get_rect(big_bounding_rectangle)
@@ -802,7 +802,7 @@ func new_brush() -> void:
 		brush.copy_from(preview_image)
 		var selection_map_copy := SelectionMap.new()
 		selection_map_copy.copy_from(project.selection_image)
-		selection_map_copy.move_bitmap_values(false)
+		selection_map_copy.move_bitmap_values(project, false)
 		var clipboard = str2var(OS.get_clipboard())
 		if typeof(clipboard) == TYPE_DICTIONARY:
 			# A sanity check

--- a/src/UI/Dialogs/ImageEffects/DesaturateDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DesaturateDialog.gd
@@ -23,8 +23,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_map
-		selection_tex.create_from_image(selection, 0)
+		selection_tex.create_from_image(project.selection_map, 0)
 
 	var params := {
 		"red": red,

--- a/src/UI/Dialogs/ImageEffects/DesaturateDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DesaturateDialog.gd
@@ -23,7 +23,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_image
+		var selection: Image = project.selection_map
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/DesaturateDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DesaturateDialog.gd
@@ -23,7 +23,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.bitmap_to_image(project.selection_bitmap)
+		var selection: Image = project.selection_image
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
@@ -26,8 +26,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_map
-		selection_tex.create_from_image(selection, 0)
+		selection_tex.create_from_image(project.selection_map, 0)
 
 	var params := {
 		"shadow_offset": offset,

--- a/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
@@ -26,7 +26,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.bitmap_to_image(project.selection_bitmap)
+		var selection: Image = project.selection_image
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
@@ -26,7 +26,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_image
+		var selection: Image = project.selection_map
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
@@ -76,9 +76,9 @@ func _commit_undo(action: String, undo_data: Dictionary, project: Project) -> vo
 			continue
 		project.undo_redo.add_undo_property(image, "data", undo_data[image])
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false, -1, -1, project)
-	project.undo_redo.add_do_method(project, "selection_bitmap_changed")
+	project.undo_redo.add_do_method(project, "selection_map_changed")
 	project.undo_redo.add_undo_method(Global, "undo_or_redo", true, -1, -1, project)
-	project.undo_redo.add_undo_method(project, "selection_bitmap_changed")
+	project.undo_redo.add_undo_method(project, "selection_map_changed")
 	project.undo_redo.commit_action()
 
 

--- a/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
@@ -61,9 +61,9 @@ func _commit_undo(action: String, undo_data: Dictionary, project: Project) -> vo
 	var redo_data := _get_undo_data(project)
 	project.undos += 1
 	project.undo_redo.create_action(action)
-	project.undo_redo.add_do_property(project, "selection_bitmap", redo_data["selection_bitmap"])
+	project.undo_redo.add_do_property(project, "selection_image", redo_data["selection_image"])
 	project.undo_redo.add_do_property(project, "selection_offset", redo_data["outline_offset"])
-	project.undo_redo.add_undo_property(project, "selection_bitmap", undo_data["selection_bitmap"])
+	project.undo_redo.add_undo_property(project, "selection_image", undo_data["selection_image"])
 	project.undo_redo.add_undo_property(project, "selection_offset", undo_data["outline_offset"])
 
 	for image in redo_data:
@@ -84,7 +84,7 @@ func _commit_undo(action: String, undo_data: Dictionary, project: Project) -> vo
 
 func _get_undo_data(project: Project) -> Dictionary:
 	var data := {}
-	data["selection_bitmap"] = project.selection_bitmap.duplicate()
+	data["selection_image"] = project.selection_image.duplicate()
 	data["outline_offset"] = project.selection_offset
 
 	var images := _get_selected_draw_images(project)
@@ -99,7 +99,7 @@ func _flip_selection(project: Project = Global.current_project) -> void:
 	if !(selection_checkbox.pressed and project.has_selection):
 		return
 
-	var bitmap_image: Image = project.bitmap_to_image(project.selection_bitmap)
+	var bitmap_image: Image = project.selection_image.duplicate()
 	var selection_rect := bitmap_image.get_used_rect()
 	var smaller_bitmap_image := bitmap_image.get_rect(selection_rect)
 
@@ -114,6 +114,4 @@ func _flip_selection(project: Project = Global.current_project) -> void:
 		Rect2(Vector2.ZERO, smaller_bitmap_image.get_size()),
 		selection_rect.position
 	)
-	var bitmap_copy: BitMap = project.selection_bitmap.duplicate()
-	bitmap_copy.create_from_image_alpha(bitmap_image)
-	project.selection_bitmap = bitmap_copy
+	project.selection_image = bitmap_image

--- a/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
@@ -83,8 +83,10 @@ func _commit_undo(action: String, undo_data: Dictionary, project: Project) -> vo
 
 
 func _get_undo_data(project: Project) -> Dictionary:
+	var bitmap_image := SelectionMap.new()
+	bitmap_image.copy_from(project.selection_image)
 	var data := {}
-	data["selection_image"] = project.selection_image.duplicate()
+	data["selection_image"] = bitmap_image
 	data["outline_offset"] = project.selection_offset
 
 	var images := _get_selected_draw_images(project)
@@ -99,7 +101,8 @@ func _flip_selection(project: Project = Global.current_project) -> void:
 	if !(selection_checkbox.pressed and project.has_selection):
 		return
 
-	var bitmap_image: Image = project.selection_image.duplicate()
+	var bitmap_image := SelectionMap.new()
+	bitmap_image.copy_from(project.selection_image)
 	var selection_rect := bitmap_image.get_used_rect()
 	var smaller_bitmap_image := bitmap_image.get_rect(selection_rect)
 

--- a/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
@@ -33,7 +33,7 @@ func _flip_image(cel: Image, affect_selection: bool, project: Project) -> void:
 		var selected := Image.new()
 		var rectangle: Rect2 = Global.canvas.selection.big_bounding_rectangle
 		if project != Global.current_project:
-			rectangle = project.selection_image.get_used_rect()
+			rectangle = project.selection_map.get_used_rect()
 		selected = cel.get_rect(rectangle)
 		selected.lock()
 		cel.lock()
@@ -61,9 +61,9 @@ func _commit_undo(action: String, undo_data: Dictionary, project: Project) -> vo
 	var redo_data := _get_undo_data(project)
 	project.undos += 1
 	project.undo_redo.create_action(action)
-	project.undo_redo.add_do_property(project, "selection_image", redo_data["selection_image"])
+	project.undo_redo.add_do_property(project, "selection_map", redo_data["selection_map"])
 	project.undo_redo.add_do_property(project, "selection_offset", redo_data["outline_offset"])
-	project.undo_redo.add_undo_property(project, "selection_image", undo_data["selection_image"])
+	project.undo_redo.add_undo_property(project, "selection_map", undo_data["selection_map"])
 	project.undo_redo.add_undo_property(project, "selection_offset", undo_data["outline_offset"])
 
 	for image in redo_data:
@@ -84,9 +84,9 @@ func _commit_undo(action: String, undo_data: Dictionary, project: Project) -> vo
 
 func _get_undo_data(project: Project) -> Dictionary:
 	var bitmap_image := SelectionMap.new()
-	bitmap_image.copy_from(project.selection_image)
+	bitmap_image.copy_from(project.selection_map)
 	var data := {}
-	data["selection_image"] = bitmap_image
+	data["selection_map"] = bitmap_image
 	data["outline_offset"] = project.selection_offset
 
 	var images := _get_selected_draw_images(project)
@@ -102,7 +102,7 @@ func _flip_selection(project: Project = Global.current_project) -> void:
 		return
 
 	var bitmap_image := SelectionMap.new()
-	bitmap_image.copy_from(project.selection_image)
+	bitmap_image.copy_from(project.selection_map)
 	var selection_rect := bitmap_image.get_used_rect()
 	var smaller_bitmap_image := bitmap_image.get_rect(selection_rect)
 
@@ -117,4 +117,4 @@ func _flip_selection(project: Project = Global.current_project) -> void:
 		Rect2(Vector2.ZERO, smaller_bitmap_image.get_size()),
 		selection_rect.position
 	)
-	project.selection_image = bitmap_image
+	project.selection_map = bitmap_image

--- a/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
@@ -33,7 +33,7 @@ func _flip_image(cel: Image, affect_selection: bool, project: Project) -> void:
 		var selected := Image.new()
 		var rectangle: Rect2 = Global.canvas.selection.big_bounding_rectangle
 		if project != Global.current_project:
-			rectangle = project.get_selection_rectangle()
+			rectangle = project.selection_image.get_used_rect()
 		selected = cel.get_rect(rectangle)
 		selected.lock()
 		cel.lock()

--- a/src/UI/Dialogs/ImageEffects/GradientDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/GradientDialog.gd
@@ -65,7 +65,7 @@ func commit_action(cel: Image, project: Project = Global.current_project) -> voi
 	var selection: Image
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		selection = project.bitmap_to_image(project.selection_bitmap)
+		selection = project.selection_image
 	else:  # This is needed to prevent a weird bug with the dithering shaders and GLES2
 		selection = Image.new()
 		selection.create(project.size.x, project.size.y, false, Image.FORMAT_L8)

--- a/src/UI/Dialogs/ImageEffects/GradientDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/GradientDialog.gd
@@ -65,7 +65,7 @@ func commit_action(cel: Image, project: Project = Global.current_project) -> voi
 	var selection: Image
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		selection = project.selection_image
+		selection = project.selection_map
 	else:  # This is needed to prevent a weird bug with the dithering shaders and GLES2
 		selection = Image.new()
 		selection.create(project.size.x, project.size.y, false, Image.FORMAT_L8)

--- a/src/UI/Dialogs/ImageEffects/GradientMapDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/GradientMapDialog.gd
@@ -18,8 +18,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_image
-		selection_tex.create_from_image(selection, 0)
+		selection_tex.create_from_image(project.selection_map, 0)
 
 	var params := {"selection": selection_tex, "map": $VBoxContainer/GradientEdit.texture}
 

--- a/src/UI/Dialogs/ImageEffects/GradientMapDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/GradientMapDialog.gd
@@ -18,7 +18,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.bitmap_to_image(project.selection_bitmap)
+		var selection: Image = project.selection_image
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {"selection": selection_tex, "map": $VBoxContainer/GradientEdit.texture}

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.gd
@@ -35,8 +35,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_map
-		selection_tex.create_from_image(selection, 0)
+		selection_tex.create_from_image(project.selection_map, 0)
 
 	var params := {
 		"hue_shift_amount": hue_slider.value / 360,

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.gd
@@ -35,7 +35,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.bitmap_to_image(project.selection_bitmap)
+		var selection: Image = project.selection_image
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.gd
@@ -35,7 +35,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_image
+		var selection: Image = project.selection_map
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/InvertColorsDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/InvertColorsDialog.gd
@@ -23,8 +23,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_map
-		selection_tex.create_from_image(selection, 0)
+		selection_tex.create_from_image(project.selection_map, 0)
 
 	var params := {
 		"red": red,

--- a/src/UI/Dialogs/ImageEffects/InvertColorsDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/InvertColorsDialog.gd
@@ -23,7 +23,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_image
+		var selection: Image = project.selection_map
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/InvertColorsDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/InvertColorsDialog.gd
@@ -23,7 +23,7 @@ func set_nodes() -> void:
 func commit_action(cel: Image, project: Project = Global.current_project) -> void:
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.bitmap_to_image(project.selection_bitmap)
+		var selection: Image = project.selection_image
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/OutlineDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/OutlineDialog.gd
@@ -36,8 +36,7 @@ func commit_action(cel: Image, project: Project = Global.current_project) -> voi
 
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_map
-		selection_tex.create_from_image(selection, 0)
+		selection_tex.create_from_image(project.selection_map, 0)
 
 	var params := {
 		"color": color,

--- a/src/UI/Dialogs/ImageEffects/OutlineDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/OutlineDialog.gd
@@ -36,7 +36,7 @@ func commit_action(cel: Image, project: Project = Global.current_project) -> voi
 
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.selection_image
+		var selection: Image = project.selection_map
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/OutlineDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/OutlineDialog.gd
@@ -36,7 +36,7 @@ func commit_action(cel: Image, project: Project = Global.current_project) -> voi
 
 	var selection_tex := ImageTexture.new()
 	if selection_checkbox.pressed and project.has_selection:
-		var selection: Image = project.bitmap_to_image(project.selection_bitmap)
+		var selection: Image = project.selection_image
 		selection_tex.create_from_image(selection, 0)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -49,7 +49,6 @@ func _about_to_show() -> void:
 	angle_hslider.value = 0
 
 
-
 func decide_pivot() -> void:
 	var size := Global.current_project.size
 	pivot = size / 2
@@ -62,7 +61,7 @@ func decide_pivot() -> void:
 			pivot.y -= 0.5
 
 	if Global.current_project.has_selection and selection_checkbox.pressed:
-		var selection_rectangle: Rect2 = Global.current_project.get_selection_rectangle()
+		var selection_rectangle: Rect2 = Global.current_project.selection_map.get_used_rect()
 		pivot = (
 			selection_rectangle.position
 			+ ((selection_rectangle.end - selection_rectangle.position) / 2)
@@ -87,10 +86,10 @@ func commit_action(cel: Image, _project: Project = Global.current_project) -> vo
 	var image := Image.new()
 	image.copy_from(cel)
 	if _project.has_selection and selection_checkbox.pressed:
-		var selection_rectangle: Rect2 = _project.get_selection_rectangle()
+		var selection_rectangle: Rect2 = _project.selection_map.get_used_rect()
 		selection_size = selection_rectangle.size
 
-		var selection: Image = _project.bitmap_to_image(_project.selection_bitmap)
+		var selection: Image = _project.selection_map
 		selection_tex.create_from_image(selection, 0)
 
 		if !_type_is_shader():

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -49,6 +49,7 @@ func _about_to_show() -> void:
 	angle_hslider.value = 0
 
 
+
 func decide_pivot() -> void:
 	var size := Global.current_project.size
 	pivot = size / 2


### PR DESCRIPTION
**Requires Godot 3.5 and above. Builds will most likely fail because of this and this PR will not be merged until Godot 3.5-stable is released and Pixelorama's workflows start using it.**

This PR replaces the BitMap that was used to store the selected state of the pixels with an LA8 Image. This massively improves performance, since we get rid of the slow bitmap-to-image conversion. Images were used anyway for the selection marching ants outline to be drawn, and for shaders to use them as masks.

I have also refactor the selection code by making a new `SelectionMap` class that extends Image, and moved some methods from Project.gd to the new class, therefore making the code cleaner and putting the methods to a more correct place.

A comparison of approximate common timings of full canvas selections using the Rectangular Selection tool, between the current and the new method.

 WxH | Rectangular Selection (current) | Rectangular Selection (new) |
| - | - | - |
| 512x512 px | 274 ms | 6 ms |
| 1024x1024 px | 1000 ms | 23 ms |
| 2048x2048 px | 3927 ms | 85 ms |
| 4096x4096 px | 15534 ms | 170 ms |

The Select by Color tool now uses a shader for faster results, and a color similarity option has been added, similar to the same color fill in the Bucket tool. The below approximate timings were tested on blank canvases. Tested on an AMD Ryzen 5 1600 CPU and a NVIDIA GTX 1060 6GB GPU, on openSUSE Tumbleweed.

 WxH | Select by Color (current) | Select by Color (new with shader) |
| - | - | - |
| 512x512 px | 410 ms | 40 ms |
| 1024x1024 px | 1602 ms | 65 ms |
| 2048x2048 px | 6376 ms | 112 ms |
| 4096x4096 px | 26360 ms | 391 ms |