### PR TITLE
Fixed move offsets

### DIFF
--- a/src/Tools/Move.gd
+++ b/src/Tools/Move.gd
@@ -107,7 +107,7 @@ func _snap_position(position: Vector2) -> Vector2:
 		# The part below only corrects the offset for situations when there is no selection
 		# Offsets when there is selection is controlled in _input() function
 		if !Global.current_project.has_selection:
-			var move_offset :=  Vector2.ZERO
+			var move_offset := Vector2.ZERO
 			move_offset.x = (
 				_start_pos.x
 				- int(_start_pos.x / Global.grid_width) * Global.grid_width

--- a/src/Tools/Move.gd
+++ b/src/Tools/Move.gd
@@ -24,7 +24,9 @@ func _input(event: InputEvent) -> void:
 				# The First time transform_snap_grid is enabled then _snap_position() is not called
 				# and selection had wrong offset so i chose to do selection offsetting here
 				var grid_offset = Vector2(Global.grid_offset_x, Global.grid_offset_y)
-				grid_offset = Vector2(fmod(grid_offset.x, grid_size.x), fmod(grid_offset.y, grid_size.y))
+				grid_offset = Vector2(
+					fmod(grid_offset.x, grid_size.x), fmod(grid_offset.y, grid_size.y)
+				)
 				selection_node.big_bounding_rectangle.position += grid_offset
 				selection_node.marching_ants_outline.offset += (
 					selection_node.big_bounding_rectangle.position
@@ -107,7 +109,10 @@ func _snap_position(position: Vector2) -> Vector2:
 		if !Global.current_project.has_selection:
 			var move_offset :=  Vector2.ZERO
 			move_offset.x = _start_pos.x - int(_start_pos.x/Global.grid_width) * Global.grid_width
-			move_offset.y = _start_pos.y - int(_start_pos.y/Global.grid_height) * Global.grid_height
+			move_offset.y = (
+				_start_pos.y
+				- int(_start_pos.y/Global.grid_height) * Global.grid_height
+			)
 			position += move_offset
 
 	return position
@@ -153,4 +158,3 @@ func _get_undo_data() -> Dictionary:
 		data[image] = image.data
 		image.lock()
 	return data
-

--- a/src/Tools/Move.gd
+++ b/src/Tools/Move.gd
@@ -108,10 +108,13 @@ func _snap_position(position: Vector2) -> Vector2:
 		# Offsets when there is selection is controlled in _input() function
 		if !Global.current_project.has_selection:
 			var move_offset :=  Vector2.ZERO
-			move_offset.x = _start_pos.x - int(_start_pos.x/Global.grid_width) * Global.grid_width
+			move_offset.x = (
+				_start_pos.x
+				- int(_start_pos.x / Global.grid_width) * Global.grid_width
+			)
 			move_offset.y = (
 				_start_pos.y
-				- int(_start_pos.y/Global.grid_height) * Global.grid_height
+				- int(_start_pos.y / Global.grid_height) * Global.grid_height
 			)
 			position += move_offset
 

--- a/src/Tools/Move.gd
+++ b/src/Tools/Move.gd
@@ -21,6 +21,11 @@ func _input(event: InputEvent) -> void:
 			if Global.current_project.has_selection:
 				var prev_pos = selection_node.big_bounding_rectangle.position
 				selection_node.big_bounding_rectangle.position = prev_pos.snapped(grid_size)
+				# The First time transform_snap_grid is enabled then _snap_position() is not called
+				# and selection had wrong offset so i chose to do selection offsetting here
+				var grid_offset = Vector2(Global.grid_offset_x, Global.grid_offset_y)
+				grid_offset = Vector2(fmod(grid_offset.x, grid_size.x), fmod(grid_offset.y, grid_size.y))
+				selection_node.big_bounding_rectangle.position += grid_offset
 				selection_node.marching_ants_outline.offset += (
 					selection_node.big_bounding_rectangle.position
 					- prev_pos
@@ -97,9 +102,13 @@ func _snap_position(position: Vector2) -> Vector2:
 	if _snap_to_grid:  # Snap to grid
 		var grid_size := Vector2(Global.grid_width, Global.grid_height)
 		position = position.snapped(grid_size)
-		var grid_offset = Vector2(Global.grid_offset_x, Global.grid_offset_y)
-		grid_offset = Vector2(fmod(grid_offset.x, grid_size.x), fmod(grid_offset.y, grid_size.y))
-		position += grid_offset
+		# The part below only corrects the offset for situations when there is no selection
+		# Offsets when there is selection is controlled in _input() function
+		if !Global.current_project.has_selection:
+			var move_offset :=  Vector2.ZERO
+			move_offset.x = _start_pos.x - int(_start_pos.x/Global.grid_width) * Global.grid_width
+			move_offset.y = _start_pos.y - int(_start_pos.y/Global.grid_height) * Global.grid_height
+			position += move_offset
 
 	return position
 
@@ -144,3 +153,4 @@ func _get_undo_data() -> Dictionary:
 		data[image] = image.data
 		image.lock()
 	return data
+


### PR DESCRIPTION
Okay, so i modified it a bit,
1) I separated the offsetting of selection snapping from the move snapping (selection offsetting is done in `_input()` while move offsetting is done in `_snap_position()`)
2) Selection (in move tool) follows proper snapping while The normal move snapping are just increments of grid_size (Cause there is no proper definition for move snapping, i mean for a selection there is a clear corner of selection that can snap to grid even when multiple frames are selected, BUT for simple move snapping the concept of corner becomes "blurry" especially when one considers multiple selected frames, so i chose simple increments for move snapping cause it seems more logical "
3) And the user is given ability to align snapping with grid-lines themselves 😉")

**Old Implementation:**

https://user-images.githubusercontent.com/77773850/177038603-2bd28d0f-8661-4f5a-9465-ee0aaaa429a4.mp4

**New Implementation:**

https://user-images.githubusercontent.com/77773850/177038617-55490014-0f2b-4de8-8c5d-6506ab49b78b.mp4


