### PR TITLE
removed initial angle quick rotation buttons

### DIFF
--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -238,19 +238,6 @@ func _on_quick_change_angle_pressed(angle_value: int) -> void:
 	angle_hslider.value = new_angle
 
 
-func _on_quick_change_init_angle_pressed(angle_value: int) -> void:
-	var current_angle := init_angle_hslider.value
-	var new_angle := current_angle + angle_value
-	if angle_value == 0:
-		new_angle = 0
-
-	if new_angle < 0:
-		new_angle = new_angle + 360
-	elif new_angle >= 360:
-		new_angle = new_angle - 360
-	init_angle_hslider.value = new_angle
-
-
 func _on_Centre_pressed() -> void:
 	decide_pivot()
 

--- a/src/UI/Dialogs/ImageEffects/RotateImage.tscn
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.tscn
@@ -21,13 +21,13 @@ margin_bottom = -36.0
 
 [node name="AspectRatioContainer" type="AspectRatioContainer" parent="VBoxContainer"]
 margin_right = 326.0
-margin_bottom = 200.0
+margin_bottom = 222.0
 size_flags_vertical = 3
 
 [node name="Preview" type="TextureRect" parent="VBoxContainer/AspectRatioContainer"]
-margin_left = 63.0
-margin_right = 263.0
-margin_bottom = 200.0
+margin_left = 52.0
+margin_right = 274.0
+margin_bottom = 222.0
 rect_min_size = Vector2( 200, 200 )
 expand = true
 stretch_mode = 5
@@ -40,15 +40,15 @@ margin_right = 0.0
 margin_bottom = 0.0
 
 [node name="Indicator" type="Control" parent="VBoxContainer/AspectRatioContainer"]
-margin_left = 63.0
-margin_right = 263.0
-margin_bottom = 200.0
+margin_left = 52.0
+margin_right = 274.0
+margin_bottom = 222.0
 mouse_default_cursor_shape = 2
 
 [node name="LiveSettings" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 204.0
+margin_top = 226.0
 margin_right = 326.0
-margin_bottom = 228.0
+margin_bottom = 250.0
 alignment = 1
 
 [node name="LiveCheckbox" type="CheckBox" parent="VBoxContainer/LiveSettings"]
@@ -86,9 +86,9 @@ editable = false
 suffix = "msec"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 232.0
+margin_top = 254.0
 margin_right = 326.0
-margin_bottom = 252.0
+margin_bottom = 274.0
 
 [node name="Label" type="Label" parent="VBoxContainer/HBoxContainer2"]
 margin_top = 3.0
@@ -105,14 +105,14 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
-margin_top = 256.0
+margin_top = 278.0
 margin_right = 326.0
-margin_bottom = 260.0
+margin_bottom = 282.0
 
 [node name="TitleButtons" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 264.0
+margin_top = 286.0
 margin_right = 326.0
-margin_bottom = 288.0
+margin_bottom = 310.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TitleButtons"]
 margin_top = 5.0
@@ -155,14 +155,14 @@ mouse_default_cursor_shape = 2
 text = "Center"
 
 [node name="HSeparator2" type="HSeparator" parent="VBoxContainer"]
-margin_top = 292.0
+margin_top = 314.0
 margin_right = 326.0
-margin_bottom = 296.0
+margin_bottom = 318.0
 
 [node name="AngleOptions" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 300.0
+margin_top = 322.0
 margin_right = 326.0
-margin_bottom = 324.0
+margin_bottom = 346.0
 
 [node name="Label" type="Label" parent="VBoxContainer/AngleOptions"]
 margin_top = 5.0
@@ -191,9 +191,9 @@ max_value = 359.0
 suffix = "°"
 
 [node name="QuickRotations" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 328.0
+margin_top = 350.0
 margin_right = 326.0
-margin_bottom = 348.0
+margin_bottom = 370.0
 alignment = 1
 
 [node name="Deduct90" type="Button" parent="VBoxContainer/QuickRotations"]
@@ -233,7 +233,7 @@ text = "+90"
 
 [node name="SmearOptions" type="VBoxContainer" parent="VBoxContainer"]
 visible = false
-margin_top = 352.0
+margin_top = 376.0
 margin_right = 326.0
 margin_bottom = 454.0
 
@@ -312,56 +312,15 @@ max_value = 359.0
 value = 359.0
 suffix = "°"
 
-[node name="QuickRotations" type="HBoxContainer" parent="VBoxContainer/SmearOptions"]
-margin_top = 82.0
-margin_right = 326.0
-margin_bottom = 102.0
-alignment = 1
-
-[node name="Deduct90" type="Button" parent="VBoxContainer/SmearOptions/QuickRotations"]
-margin_left = 76.0
-margin_right = 109.0
-margin_bottom = 20.0
-mouse_default_cursor_shape = 2
-text = "-90"
-
-[node name="Deduct45" type="Button" parent="VBoxContainer/SmearOptions/QuickRotations"]
-margin_left = 113.0
-margin_right = 146.0
-margin_bottom = 20.0
-mouse_default_cursor_shape = 2
-text = "-45"
-
-[node name="Zero" type="Button" parent="VBoxContainer/SmearOptions/QuickRotations"]
-margin_left = 150.0
-margin_right = 170.0
-margin_bottom = 20.0
-mouse_default_cursor_shape = 2
-text = "0"
-
-[node name="Add45" type="Button" parent="VBoxContainer/SmearOptions/QuickRotations"]
-margin_left = 174.0
-margin_right = 210.0
-margin_bottom = 20.0
-mouse_default_cursor_shape = 2
-text = "+45"
-
-[node name="Add90" type="Button" parent="VBoxContainer/SmearOptions/QuickRotations"]
-margin_left = 214.0
-margin_right = 250.0
-margin_bottom = 20.0
-mouse_default_cursor_shape = 2
-text = "+90"
-
 [node name="HSeparator3" type="HSeparator" parent="VBoxContainer"]
-margin_top = 458.0
+margin_top = 374.0
 margin_right = 326.0
-margin_bottom = 462.0
+margin_bottom = 378.0
 
 [node name="OptionsContainer" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 466.0
+margin_top = 382.0
 margin_right = 326.0
-margin_bottom = 490.0
+margin_bottom = 406.0
 
 [node name="SelectionCheckBox" type="CheckBox" parent="VBoxContainer/OptionsContainer"]
 margin_right = 160.0
@@ -400,9 +359,4 @@ selected = 0
 [connection signal="value_changed" from="VBoxContainer/SmearOptions/Tolerance/ToleranceSpinBox" to="." method="_on_ToleranceSpinBox_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/SmearOptions/AngleOptions/InitialAngleHSlider" to="." method="_on_InitialAngleHSlider_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/SmearOptions/AngleOptions/InitialAngleSpinBox" to="." method="_on_InitialAngleSpinBox_value_changed"]
-[connection signal="pressed" from="VBoxContainer/SmearOptions/QuickRotations/Deduct90" to="." method="_on_quick_change_init_angle_pressed" binds= [ -90 ]]
-[connection signal="pressed" from="VBoxContainer/SmearOptions/QuickRotations/Deduct45" to="." method="_on_quick_change_init_angle_pressed" binds= [ -45 ]]
-[connection signal="pressed" from="VBoxContainer/SmearOptions/QuickRotations/Zero" to="." method="_on_quick_change_init_angle_pressed" binds= [ 0 ]]
-[connection signal="pressed" from="VBoxContainer/SmearOptions/QuickRotations/Add45" to="." method="_on_quick_change_init_angle_pressed" binds= [ 45 ]]
-[connection signal="pressed" from="VBoxContainer/SmearOptions/QuickRotations/Add90" to="." method="_on_quick_change_init_angle_pressed" binds= [ 90 ]]
 [connection signal="timeout" from="WaitApply" to="." method="_on_WaitApply_timeout"]


### PR DESCRIPTION
This pull is an attempt to make Rotate dialog UI a bit cleaner by removing the quick rotation buttons for "initial angle" cause they may not have much use anyway

![Screenshot_from_2022-07-28_12-49-08](https://user-images.githubusercontent.com/77773850/181575413-f0c2add0-53aa-431a-be42-d56870514254.png)
