### PR TITLE
New theme-related methods to ExtensionsAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can find Online Documentation for Pixelorama here: https://orama-interactive
 It's still work in progress so there are some pages missing. If you want to contribute, you can do so in [Pixelorama-Docs' GitHub Repository](https://github.com/Orama-Interactive/Pixelorama-Docs).
 
 ## Cloning Instructions
-Pixelorama uses Godot 3.4, so you will need to have it in order to run the project. Older versions may not work.
+Pixelorama uses Godot 3.5, so you will need to have it in order to run the project. Older versions may not work.
 As of right now, most of the code is written using GDScript, so the mono version of Godot is not required, but Pixelorama should also work with it.
 
 ## Current features:

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -192,7 +192,7 @@ func add_theme(theme: Theme) -> void:
 	themes.add_theme(theme)
 
 
-func find_theme(theme :Theme) -> int:
+func find_theme(theme: Theme) -> int:
 	var themes: BoxContainer = Global.preferences_dialog.find_node("Themes")
 	return themes.themes.find(theme)
 

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -192,7 +192,7 @@ func add_theme(theme: Theme) -> void:
 	themes.add_theme(theme)
 
 
-func find_theme(theme: Theme) -> int:
+func find_theme_index(theme: Theme) -> int:
 	var themes: BoxContainer = Global.preferences_dialog.find_node("Themes")
 	return themes.themes.find(theme)
 
@@ -201,13 +201,13 @@ func get_theme() -> Theme:
 	return Global.control.theme
 
 
-func set_theme(idx: int) -> int:
+func set_theme(idx: int) -> bool:
 	var themes: BoxContainer = Global.preferences_dialog.find_node("Themes")
 	if idx >= 0 and idx < themes.themes.size():
 		themes.buttons_container.get_child(idx).emit_signal("pressed")
-		return OK
+		return true
 	else:
-		return -1
+		return false
 
 
 func remove_theme(theme: Theme) -> void:

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -192,11 +192,6 @@ func add_theme(theme: Theme) -> void:
 	themes.add_theme(theme)
 
 
-func find_theme(theme :Theme) -> int:
-	var themes: BoxContainer = Global.preferences_dialog.find_node("Themes")
-	return themes.themes.find(theme)
-
-
 func get_theme() -> Theme:
 	return Global.control.theme
 

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -192,6 +192,11 @@ func add_theme(theme: Theme) -> void:
 	themes.add_theme(theme)
 
 
+func find_theme(theme :Theme) -> int:
+	var themes: BoxContainer = Global.preferences_dialog.find_node("Themes")
+	return themes.themes.find(theme)
+
+
 func get_theme() -> Theme:
 	return Global.control.theme
 

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -192,8 +192,22 @@ func add_theme(theme: Theme) -> void:
 	themes.add_theme(theme)
 
 
+func find_theme(theme :Theme) -> int:
+	var themes: BoxContainer = Global.preferences_dialog.find_node("Themes")
+	return themes.themes.find(theme)
+
+
 func get_theme() -> Theme:
 	return Global.control.theme
+
+
+func set_theme(idx: int) -> int:
+	var themes: BoxContainer = Global.preferences_dialog.find_node("Themes")
+	if idx >= 0 and idx < themes.themes.size():
+		themes.buttons_container.get_child(idx).emit_signal("pressed")
+		return OK
+	else:
+		return -1
 
 
 func remove_theme(theme: Theme) -> void:

--- a/src/Preferences/HandleThemes.gd
+++ b/src/Preferences/HandleThemes.gd
@@ -20,6 +20,7 @@ onready var theme_color_preview_scene = preload("res://src/Preferences/ThemeColo
 func _ready() -> void:
 	for theme in themes:
 		add_theme(theme)
+	yield(get_tree(), "idle_frame")
 
 	var theme_id: int = Global.config_cache.get_value("preferences", "theme", 0)
 	if theme_id >= themes.size():

--- a/src/UI/Dialogs/TileModeOffsetsDialog.tscn
+++ b/src/UI/Dialogs/TileModeOffsetsDialog.tscn
@@ -8,7 +8,6 @@
 blend_mode = 4
 
 [node name="TileModeOffsetsDialog" type="ConfirmationDialog"]
-visible = true
 margin_right = 301.0
 margin_bottom = 422.0
 rect_min_size = Vector2( 172, 422 )


### PR DESCRIPTION
1. Added new `set_theme` and `find_theme_index` methods to ExtensionsAPI
2. Make **HandleThemes.gd** wait in case themes are being loaded from extensions
3. Hide the accidentally visible **TileModeOffsetsDialog.tscn**
4. update readme for Godot 3.5