### PR TITLE
Changed Recent Projects Behavior

### DIFF
--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -747,7 +747,7 @@ func save_project_to_recent_list(path: String) -> void:
 		return
 
 	if top_menu_container.recent_projects.has(path):
-		return
+		top_menu_container.recent_projects.erase(path)
 
 	if top_menu_container.recent_projects.size() >= 5:
 		top_menu_container.recent_projects.pop_front()

--- a/src/UI/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer.gd
@@ -82,7 +82,9 @@ func _setup_recent_projects_submenu(item: String) -> void:
 
 
 func update_recent_projects_submenu() -> void:
-	for project in recent_projects:
+	var reversed_recent_projects = recent_projects.duplicate()
+	reversed_recent_projects.invert()
+	for project in reversed_recent_projects:
 		recent_projects_submenu.add_item(project.get_file())
 
 
@@ -394,7 +396,9 @@ func _export_file() -> void:
 
 
 func _on_recent_projects_submenu_id_pressed(id: int) -> void:
-	Global.control.load_recent_project_file(recent_projects[id])
+	var reversed_recent_projects = recent_projects.duplicate()
+	reversed_recent_projects.invert()
+	Global.control.load_recent_project_file(reversed_recent_projects[id])
 
 
 func edit_menu_id_pressed(id: int) -> void:


### PR DESCRIPTION
Implements the second half of #735

> These are great ideas. Another small oddity I found, is on the recent projects menu. At the moment, the list shows the most recent project at the bottom instead of the top.

1. Makes the most recent project appear at the top.
2. When you open a project already in the recent projects list if it would then be moved to the most recent spot on the list (idea by [@mrtripie](https://github.com/mrtripie))

https://user-images.githubusercontent.com/77773850/191276790-9bceefca-ad03-4f0f-aa1c-63a00706e9c4.mp4

