### PR TITLE
Fix id_map error on open_pxo_file as well as grid being wrong size

### DIFF
--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -135,9 +135,7 @@ func open_pxo_file(path: String, untitled_backup: bool = false, replace_empty: b
 
 	file.close()
 	if empty_project:
-		if dict.error == OK and dict.result.has("fps"):
-			Global.animation_timeline.fps_spinbox.value = dict.result.fps
-		Global.animation_timeline.project_changed()
+		new_project.change_project()
 	else:
 		Global.projects.append(new_project)
 		Global.tabs.current_tab = Global.tabs.get_tab_count() - 1


### PR DESCRIPTION
This fixes this error that showed up in the #698 PR when opening a pxo file (without any changes to the empty default file):
```
E 0:00:11.149   getornull: Condition "!id_map.has(p_rid.get_data())" is true. Returned: nullptr
  <C++ Source>  ./core/rid.h:151 @ getornull()
```
This was caused by Global.canvas.update() not being called

Also fixes the grid not being updated, and maybe other bugs.

Not sure if just using the Project.change_project() will cause other issues though
