### PR TITLE
Fixed Move Tool with Group Cel Selected and Deleting Cel Content on a Linked Cel

### DIFF
--- a/src/Tools/Move.gd
+++ b/src/Tools/Move.gd
@@ -156,6 +156,8 @@ func _get_undo_data() -> Dictionary:
 			var cel: PixelCel = frame.cels[project.current_layer]
 			cels.append(cel)
 	for cel in cels:
+		if not cel is PixelCel:
+			continue
 		var image: Image = cel.image
 		image.unlock()
 		data[image] = image.data

--- a/src/UI/Timeline/CelButton.gd
+++ b/src/UI/Timeline/CelButton.gd
@@ -187,7 +187,7 @@ func _delete_cel_content() -> void:
 		project.undo_redo.add_do_method(cel, "set_content", empty_content)
 		project.undo_redo.add_undo_method(cel, "set_content", old_content)
 	else:
-		for linked_cel in cel.link_set:
+		for linked_cel in cel.link_set["cels"]:
 			project.undo_redo.add_do_method(linked_cel, "set_content", empty_content)
 			project.undo_redo.add_undo_method(linked_cel, "set_content", old_content)
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false, frame, layer, project)


### PR DESCRIPTION
Fixes:
- Crash when using the move tool with a GroupCel selected, _with a PixelLayer as the current layer_
- Deleting content on a linked cel (via the cel button's right click menu, or middle clicking on it)