### PR TITLE
Reference Images

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -124,6 +124,16 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://src/Classes/Project.gd"
 }, {
+"base": "Sprite",
+"class": "ReferenceImage",
+"language": "GDScript",
+"path": "res://src/UI/Canvas/ReferenceImage.gd"
+}, {
+"base": "VBoxContainer",
+"class": "ReferencesPanel",
+"language": "GDScript",
+"path": "res://src/UI/ReferencesPanel.gd"
+}, {
 "base": "Image",
 "class": "SelectionMap",
 "language": "GDScript",
@@ -183,6 +193,8 @@ _global_script_class_icons={
 "PixelCel": "",
 "PixelLayer": "",
 "Project": "",
+"ReferenceImage": "",
+"ReferencesPanel": "",
 "SelectionMap": "",
 "SelectionTool": "",
 "ShaderImageEffect": "",

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -172,6 +172,8 @@ onready var brushes_popup: Popup = control.find_node("BrushesPopup")
 onready var patterns_popup: Popup = control.find_node("PatternsPopup")
 onready var palette_panel: PalettePanel = control.find_node("Palettes")
 
+onready var references_panel: ReferencesPanel = control.find_node("References")
+
 onready var top_menu_container: Panel = control.find_node("TopMenuContainer")
 onready var rotation_level_button: Button = control.find_node("RotationLevel")
 onready var rotation_level_spinbox: SpinBox = control.find_node("RotationSpinbox")

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -595,6 +595,7 @@ func open_image_as_new_layer(image: Image, file_name: String, frame_index := 0) 
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.commit_action()
 
+
 func import_reference_image_from_path(path: String):
 	var project: Project = Global.current_project
 	var ri := ReferenceImage.new()
@@ -602,6 +603,7 @@ func import_reference_image_from_path(path: String):
 	ri.deserialize({"image_path": path})
 	Global.canvas.add_child(ri)
 	project.change_project()
+
 
 func set_new_imported_tab(project: Project, path: String) -> void:
 	var prev_project_empty: bool = Global.current_project.is_empty()

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -595,6 +595,13 @@ func open_image_as_new_layer(image: Image, file_name: String, frame_index := 0) 
 	project.undo_redo.add_do_method(Global, "undo_or_redo", false)
 	project.undo_redo.commit_action()
 
+func import_reference_image_from_path(path: String):
+	var project: Project = Global.current_project
+	var ri := ReferenceImage.new()
+	ri.project = project
+	ri.deserialize({"image_path": path})
+	Global.canvas.add_child(ri)
+	project.change_project()
 
 func set_new_imported_tab(project: Project, path: String) -> void:
 	var prev_project_empty: bool = Global.current_project.is_empty()

--- a/src/Main.tscn
+++ b/src/Main.tscn
@@ -66,14 +66,12 @@ __meta__ = {
 [node name="OpenSprite" parent="Dialogs" instance=ExtResource( 12 )]
 window_title = "Open File(s)"
 mode = 1
-show_hidden_files = true
 
 [node name="SaveSprite" parent="Dialogs" instance=ExtResource( 11 )]
 margin_left = 108.0
 margin_top = 40.0
 margin_right = 623.0
 margin_bottom = 388.0
-show_hidden_files = true
 
 [node name="SaveSpriteHTML5" parent="Dialogs" instance=ExtResource( 8 )]
 

--- a/src/Main.tscn
+++ b/src/Main.tscn
@@ -66,12 +66,14 @@ __meta__ = {
 [node name="OpenSprite" parent="Dialogs" instance=ExtResource( 12 )]
 window_title = "Open File(s)"
 mode = 1
+show_hidden_files = true
 
 [node name="SaveSprite" parent="Dialogs" instance=ExtResource( 11 )]
 margin_left = 108.0
 margin_top = 40.0
 margin_right = 623.0
 margin_bottom = 388.0
+show_hidden_files = true
 
 [node name="SaveSpriteHTML5" parent="Dialogs" instance=ExtResource( 8 )]
 

--- a/src/UI/Canvas/ReferenceImage.gd
+++ b/src/UI/Canvas/ReferenceImage.gd
@@ -1,0 +1,73 @@
+class_name ReferenceImage
+extends Sprite
+# A class describing a reference image
+
+var project = Global.current_project
+
+var image_path: String = ""
+
+signal properties_changed()
+
+func _ready() -> void:
+	project.reference_images.append(self)
+
+func change_properties():
+	emit_signal("properties_changed")
+
+# Resets the position and scale of the reference image.
+func position_reset():
+	position = project.size / 2.0
+	if texture != null:
+		scale = Vector2.ONE * min(project.size.x / texture.get_width(), project.size.y / texture.get_height())
+	else:
+		scale = Vector2.ONE
+
+# Serialize details of the reference image.
+func serialize():
+	return {
+		"x": position.x,
+		"y": position.y,
+		"scale_x": scale.x,
+		"scale_y": scale.y,
+		"modulate_r": modulate.r,
+		"modulate_g": modulate.g,
+		"modulate_b": modulate.b,
+		"modulate_a": modulate.a,
+		"image_path": image_path
+	}
+
+# Load details of the reference image from a dictionary.
+# Be aware that new ReferenceImages are created via deserialization.
+# This is because deserialization sets up some nice defaults.
+func deserialize(d: Dictionary):
+	modulate = Color(1, 1, 1, 0.5)
+	if d.has("image_path"):
+		# Note that reference images are referred to by path.
+		# These images may be rather big.
+		# Also
+		image_path = d["image_path"]
+		var img = Image.new()
+		if img.load(image_path) == OK:
+			var itex = ImageTexture.new()
+			# don't do FLAG_REPEAT - it could cause visual issues
+			itex.create_from_image(img, Texture.FLAG_MIPMAPS | Texture.FLAG_FILTER)
+			texture = itex
+	# Now that the image may have been established...
+	position_reset()
+	if d.has("x"):
+		position.x = d["x"]
+	if d.has("y"):
+		position.y = d["y"]
+	if d.has("scale_x"):
+		scale.x = d["scale_x"]
+	if d.has("scale_y"):
+		scale.y = d["scale_y"]
+	if d.has("modulate_r"):
+		modulate.r = d["modulate_r"]
+	if d.has("modulate_g"):
+		modulate.g = d["modulate_g"]
+	if d.has("modulate_b"):
+		modulate.b = d["modulate_b"]
+	if d.has("modulate_a"):
+		modulate.a = d["modulate_a"]
+	change_properties()

--- a/src/UI/Canvas/ReferenceImage.gd
+++ b/src/UI/Canvas/ReferenceImage.gd
@@ -2,25 +2,32 @@ class_name ReferenceImage
 extends Sprite
 # A class describing a reference image
 
+signal properties_changed
+
 var project = Global.current_project
 
 var image_path: String = ""
 
-signal properties_changed()
 
 func _ready() -> void:
 	project.reference_images.append(self)
 
+
 func change_properties():
 	emit_signal("properties_changed")
+
 
 # Resets the position and scale of the reference image.
 func position_reset():
 	position = project.size / 2.0
 	if texture != null:
-		scale = Vector2.ONE * min(project.size.x / texture.get_width(), project.size.y / texture.get_height())
+		scale = (
+			Vector2.ONE
+			* min(project.size.x / texture.get_width(), project.size.y / texture.get_height())
+		)
 	else:
 		scale = Vector2.ONE
+
 
 # Serialize details of the reference image.
 func serialize():
@@ -35,6 +42,7 @@ func serialize():
 		"modulate_a": modulate.a,
 		"image_path": image_path
 	}
+
 
 # Load details of the reference image from a dictionary.
 # Be aware that new ReferenceImages are created via deserialization.

--- a/src/UI/Dialogs/PreviewDialog.gd
+++ b/src/UI/Dialogs/PreviewDialog.gd
@@ -7,6 +7,7 @@ enum ImageImportOptions {
 	NEW_FRAME,
 	REPLACE_CEL,
 	NEW_LAYER,
+	NEW_REFERENCE_IMAGE,
 	PALETTE,
 	BRUSH,
 	PATTERN
@@ -49,6 +50,7 @@ func _on_PreviewDialog_about_to_show() -> void:
 	import_options.add_item("New frame")
 	import_options.add_item("Replace cel")
 	import_options.add_item("New layer")
+	import_options.add_item("New reference image")
 	import_options.add_item("New palette")
 	import_options.add_item("New brush")
 	import_options.add_item("New pattern")
@@ -140,6 +142,9 @@ func _on_PreviewDialog_confirmed() -> void:
 		elif current_import_option == ImageImportOptions.NEW_LAYER:
 			var frame_index: int = new_layer_options.get_node("AtFrameSpinbox").value - 1
 			OpenSave.open_image_as_new_layer(image, path.get_basename().get_file(), frame_index)
+
+		elif current_import_option == ImageImportOptions.NEW_REFERENCE_IMAGE:
+			OpenSave.import_reference_image_from_path(path)
 
 		elif current_import_option == ImageImportOptions.PALETTE:
 			Palettes.import_palette_from_path(path)

--- a/src/UI/ReferenceImageButton.gd
+++ b/src/UI/ReferenceImageButton.gd
@@ -18,6 +18,8 @@ func _update_properties():
 	$Interior/Options/Scale.value = element.scale.x * 100
 	$Interior/Options/X.value = element.position.x
 	$Interior/Options/Y.value = element.position.y
+	$Interior/Options/X.max_value = element.project.size.x
+	$Interior/Options/Y.max_value = element.project.size.y
 	$Interior/Options2/Opacity.value = element.modulate.a * 100
 	_ignore_spinbox_changes = false
 

--- a/src/UI/ReferenceImageButton.gd
+++ b/src/UI/ReferenceImageButton.gd
@@ -4,10 +4,12 @@ extends Container
 var element: ReferenceImage
 var _ignore_spinbox_changes = false
 
+
 func _ready():
 	$Interior/Path.text = element.image_path
 	element.connect("properties_changed", self, "_update_properties")
 	_update_properties()
+
 
 func _update_properties():
 	# This is because otherwise a little dance will occur.
@@ -19,9 +21,11 @@ func _update_properties():
 	$Interior/Options2/Opacity.value = element.modulate.a * 100
 	_ignore_spinbox_changes = false
 
+
 func _on_Reset_pressed():
 	element.position_reset()
 	element.change_properties()
+
 
 func _on_Remove_pressed():
 	var index = Global.current_project.reference_images.find(element)
@@ -31,6 +35,7 @@ func _on_Remove_pressed():
 		Global.current_project.reference_images.remove(index)
 		Global.current_project.change_project()
 
+
 func _on_Scale_value_changed(value):
 	if _ignore_spinbox_changes:
 		return
@@ -38,17 +43,20 @@ func _on_Scale_value_changed(value):
 	element.scale.y = value / 100
 	element.change_properties()
 
+
 func _on_X_value_changed(value):
 	if _ignore_spinbox_changes:
 		return
 	element.position.x = value
 	element.change_properties()
 
+
 func _on_Y_value_changed(value):
 	if _ignore_spinbox_changes:
 		return
 	element.position.y = value
 	element.change_properties()
+
 
 func _on_Opacity_value_changed(value):
 	if _ignore_spinbox_changes:

--- a/src/UI/ReferenceImageButton.gd
+++ b/src/UI/ReferenceImageButton.gd
@@ -1,0 +1,57 @@
+extends Container
+# UI to handle reference image editing.
+
+var element: ReferenceImage
+var _ignore_spinbox_changes = false
+
+func _ready():
+	$Interior/Path.text = element.image_path
+	element.connect("properties_changed", self, "_update_properties")
+	_update_properties()
+
+func _update_properties():
+	# This is because otherwise a little dance will occur.
+	# This also breaks non-uniform scales (not supported UI-wise, but...)
+	_ignore_spinbox_changes = true
+	$Interior/Options/Scale.value = element.scale.x * 100
+	$Interior/Options/X.value = element.position.x
+	$Interior/Options/Y.value = element.position.y
+	$Interior/Options2/Opacity.value = element.modulate.a * 100
+	_ignore_spinbox_changes = false
+
+func _on_Reset_pressed():
+	element.position_reset()
+	element.change_properties()
+
+func _on_Remove_pressed():
+	var index = Global.current_project.reference_images.find(element)
+	if index != -1:
+		queue_free()
+		element.queue_free()
+		Global.current_project.reference_images.remove(index)
+		Global.current_project.change_project()
+
+func _on_Scale_value_changed(value):
+	if _ignore_spinbox_changes:
+		return
+	element.scale.x = value / 100
+	element.scale.y = value / 100
+	element.change_properties()
+
+func _on_X_value_changed(value):
+	if _ignore_spinbox_changes:
+		return
+	element.position.x = value
+	element.change_properties()
+
+func _on_Y_value_changed(value):
+	if _ignore_spinbox_changes:
+		return
+	element.position.y = value
+	element.change_properties()
+
+func _on_Opacity_value_changed(value):
+	if _ignore_spinbox_changes:
+		return
+	element.modulate.a = value / 100
+	element.change_properties()

--- a/src/UI/ReferenceImageButton.tscn
+++ b/src/UI/ReferenceImageButton.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://src/UI/ReferenceImageButton.gd" type="Script" id=1]
+[ext_resource path="res://src/UI/Nodes/ValueSlider.tscn" type="PackedScene" id=2]
 
 [node name="ReferenceImageButton" type="PanelContainer"]
 anchor_right = 1.0
@@ -13,17 +14,18 @@ script = ExtResource( 1 )
 [node name="Interior" type="VBoxContainer" parent="."]
 margin_left = 7.0
 margin_top = 7.0
-margin_right = 338.0
+margin_right = 304.0
 margin_bottom = 132.0
 
 [node name="Path" type="Label" parent="Interior"]
-margin_right = 331.0
+margin_right = 297.0
 margin_bottom = 14.0
 size_flags_horizontal = 3
+autowrap = true
 
 [node name="Options" type="HBoxContainer" parent="Interior"]
 margin_top = 18.0
-margin_right = 331.0
+margin_right = 297.0
 margin_bottom = 42.0
 
 [node name="Label2" type="Label" parent="Interior/Options"]
@@ -32,38 +34,34 @@ margin_right = 56.0
 margin_bottom = 19.0
 text = "Position:"
 
-[node name="X" type="SpinBox" parent="Interior/Options"]
+[node name="X" parent="Interior/Options" instance=ExtResource( 2 )]
 margin_left = 60.0
-margin_right = 134.0
-margin_bottom = 24.0
+margin_right = 122.0
 allow_greater = true
 allow_lesser = true
 
-[node name="Y" type="SpinBox" parent="Interior/Options"]
-margin_left = 138.0
-margin_right = 212.0
-margin_bottom = 24.0
+[node name="Y" parent="Interior/Options" instance=ExtResource( 2 )]
+margin_left = 126.0
+margin_right = 189.0
 allow_greater = true
 allow_lesser = true
 
 [node name="Label" type="Label" parent="Interior/Options"]
-margin_left = 216.0
+margin_left = 193.0
 margin_top = 5.0
-margin_right = 253.0
+margin_right = 230.0
 margin_bottom = 19.0
 text = "Scale:"
 
-[node name="Scale" type="SpinBox" parent="Interior/Options"]
-margin_left = 257.0
-margin_right = 331.0
-margin_bottom = 24.0
-value = 100.0
+[node name="Scale" parent="Interior/Options" instance=ExtResource( 2 )]
+margin_left = 234.0
+margin_right = 297.0
 allow_greater = true
 allow_lesser = true
 
 [node name="Options2" type="HBoxContainer" parent="Interior"]
 margin_top = 46.0
-margin_right = 331.0
+margin_right = 297.0
 margin_bottom = 70.0
 
 [node name="Label" type="Label" parent="Interior/Options2"]
@@ -72,23 +70,19 @@ margin_right = 53.0
 margin_bottom = 19.0
 text = "Opacity:"
 
-[node name="Opacity" type="SpinBox" parent="Interior/Options2"]
+[node name="Opacity" parent="Interior/Options2" instance=ExtResource( 2 )]
 margin_left = 57.0
-margin_right = 131.0
-margin_bottom = 24.0
-value = 100.0
-allow_greater = true
-allow_lesser = true
+margin_right = 177.0
 
 [node name="Reset" type="Button" parent="Interior/Options2"]
-margin_left = 135.0
-margin_right = 183.0
+margin_left = 181.0
+margin_right = 229.0
 margin_bottom = 24.0
 text = "Reset"
 
 [node name="Remove" type="Button" parent="Interior/Options2"]
-margin_left = 187.0
-margin_right = 251.0
+margin_left = 233.0
+margin_right = 297.0
 margin_bottom = 24.0
 text = "Remove"
 

--- a/src/UI/ReferenceImageButton.tscn
+++ b/src/UI/ReferenceImageButton.tscn
@@ -1,0 +1,100 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/UI/ReferenceImageButton.gd" type="Script" id=1]
+
+[node name="ReferenceImageButton" type="PanelContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -969.0
+margin_bottom = -581.0
+size_flags_horizontal = 3
+script = ExtResource( 1 )
+
+[node name="Interior" type="VBoxContainer" parent="."]
+margin_left = 7.0
+margin_top = 7.0
+margin_right = 338.0
+margin_bottom = 132.0
+
+[node name="Path" type="Label" parent="Interior"]
+margin_right = 331.0
+margin_bottom = 14.0
+size_flags_horizontal = 3
+
+[node name="Options" type="HBoxContainer" parent="Interior"]
+margin_top = 18.0
+margin_right = 331.0
+margin_bottom = 42.0
+
+[node name="Label2" type="Label" parent="Interior/Options"]
+margin_top = 5.0
+margin_right = 56.0
+margin_bottom = 19.0
+text = "Position:"
+
+[node name="X" type="SpinBox" parent="Interior/Options"]
+margin_left = 60.0
+margin_right = 134.0
+margin_bottom = 24.0
+allow_greater = true
+allow_lesser = true
+
+[node name="Y" type="SpinBox" parent="Interior/Options"]
+margin_left = 138.0
+margin_right = 212.0
+margin_bottom = 24.0
+allow_greater = true
+allow_lesser = true
+
+[node name="Label" type="Label" parent="Interior/Options"]
+margin_left = 216.0
+margin_top = 5.0
+margin_right = 253.0
+margin_bottom = 19.0
+text = "Scale:"
+
+[node name="Scale" type="SpinBox" parent="Interior/Options"]
+margin_left = 257.0
+margin_right = 331.0
+margin_bottom = 24.0
+value = 100.0
+allow_greater = true
+allow_lesser = true
+
+[node name="Options2" type="HBoxContainer" parent="Interior"]
+margin_top = 46.0
+margin_right = 331.0
+margin_bottom = 70.0
+
+[node name="Label" type="Label" parent="Interior/Options2"]
+margin_top = 5.0
+margin_right = 53.0
+margin_bottom = 19.0
+text = "Opacity:"
+
+[node name="Opacity" type="SpinBox" parent="Interior/Options2"]
+margin_left = 57.0
+margin_right = 131.0
+margin_bottom = 24.0
+value = 100.0
+allow_greater = true
+allow_lesser = true
+
+[node name="Reset" type="Button" parent="Interior/Options2"]
+margin_left = 135.0
+margin_right = 183.0
+margin_bottom = 24.0
+text = "Reset"
+
+[node name="Remove" type="Button" parent="Interior/Options2"]
+margin_left = 187.0
+margin_right = 251.0
+margin_bottom = 24.0
+text = "Remove"
+
+[connection signal="value_changed" from="Interior/Options/X" to="." method="_on_X_value_changed"]
+[connection signal="value_changed" from="Interior/Options/Y" to="." method="_on_Y_value_changed"]
+[connection signal="value_changed" from="Interior/Options/Scale" to="." method="_on_Scale_value_changed"]
+[connection signal="value_changed" from="Interior/Options2/Opacity" to="." method="_on_Opacity_value_changed"]
+[connection signal="pressed" from="Interior/Options2/Reset" to="." method="_on_Reset_pressed"]
+[connection signal="pressed" from="Interior/Options2/Remove" to="." method="_on_Remove_pressed"]

--- a/src/UI/ReferencesPanel.gd
+++ b/src/UI/ReferencesPanel.gd
@@ -1,0 +1,29 @@
+class_name ReferencesPanel
+extends VBoxContainer
+# Panel for reference image management
+
+onready var list = $"Scroll/List"
+
+func project_changed():
+	for c in list.get_children():
+		c.queue_free()
+	# Just do this here because I'm not sure where it's done.
+	# By all means, change this!
+	for ref in Global.canvas.get_children():
+		if ref is ReferenceImage:
+			ref.visible = false
+	# And update.
+	for ref in Global.current_project.reference_images:
+		ref.visible = true
+		var l = preload("res://src/UI/ReferenceImageButton.tscn").instance()
+		l.element = ref
+		list.add_child(l)
+
+func _on_Button_pressed():
+	var ri := ReferenceImage.new()
+	ri.project = Global.current_project
+	ri.deserialize({
+		"image_path": $TextEdit.text
+	})
+	Global.canvas.add_child(ri)
+	Global.current_project.change_project()

--- a/src/UI/ReferencesPanel.gd
+++ b/src/UI/ReferencesPanel.gd
@@ -4,6 +4,7 @@ extends VBoxContainer
 
 onready var list = $"Scroll/List"
 
+
 func project_changed():
 	for c in list.get_children():
 		c.queue_free()

--- a/src/UI/ReferencesPanel.gd
+++ b/src/UI/ReferencesPanel.gd
@@ -18,12 +18,3 @@ func project_changed():
 		var l = preload("res://src/UI/ReferenceImageButton.tscn").instance()
 		l.element = ref
 		list.add_child(l)
-
-func _on_Button_pressed():
-	var ri := ReferenceImage.new()
-	ri.project = Global.current_project
-	ri.deserialize({
-		"image_path": $TextEdit.text
-	})
-	Global.canvas.add_child(ri)
-	Global.current_project.change_project()

--- a/src/UI/ReferencesPanel.tscn
+++ b/src/UI/ReferencesPanel.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/UI/ReferencesPanel.gd" type="Script" id=1]
+
+[node name="References" type="VBoxContainer"]
+script = ExtResource( 1 )
+
+[node name="Label" type="Label" parent="."]
+margin_right = 383.0
+margin_bottom = 14.0
+text = "When opening an image, it may be imported as a reference."
+
+[node name="Scroll" type="ScrollContainer" parent="."]
+margin_top = 18.0
+margin_right = 383.0
+margin_bottom = 18.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="List" type="VBoxContainer" parent="Scroll"]
+margin_right = 383.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Button" type="Button" parent="."]
+margin_top = 22.0
+margin_right = 383.0
+margin_bottom = 42.0
+text = "temp add"
+
+[node name="TextEdit" type="LineEdit" parent="."]
+margin_top = 46.0
+margin_right = 383.0
+margin_bottom = 70.0
+
+[connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]

--- a/src/UI/ReferencesPanel.tscn
+++ b/src/UI/ReferencesPanel.tscn
@@ -6,18 +6,19 @@
 script = ExtResource( 1 )
 
 [node name="Label" type="Label" parent="."]
-margin_right = 383.0
-margin_bottom = 14.0
+margin_right = 1.0
+margin_bottom = 1000.0
 text = "When opening an image, it may be imported as a reference."
+autowrap = true
 
 [node name="Scroll" type="ScrollContainer" parent="."]
-margin_top = 18.0
-margin_right = 383.0
-margin_bottom = 18.0
+margin_top = 1004.0
+margin_right = 1.0
+margin_bottom = 1004.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="List" type="VBoxContainer" parent="Scroll"]
-margin_right = 383.0
+margin_right = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/src/UI/ReferencesPanel.tscn
+++ b/src/UI/ReferencesPanel.tscn
@@ -21,16 +21,3 @@ size_flags_vertical = 3
 margin_right = 383.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-
-[node name="Button" type="Button" parent="."]
-margin_top = 22.0
-margin_right = 383.0
-margin_bottom = 42.0
-text = "temp add"
-
-[node name="TextEdit" type="LineEdit" parent="."]
-margin_top = 46.0
-margin_right = 383.0
-margin_bottom = 70.0
-
-[connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]

--- a/src/UI/UI.tscn
+++ b/src/UI/UI.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=47 format=2]
+[gd_scene load_steps=48 format=2]
 
 [ext_resource path="res://src/UI/Tools.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/UI/Canvas/CanvasPreview.tscn" type="PackedScene" id=2]
@@ -10,6 +10,7 @@
 [ext_resource path="res://src/Shaders/Greyscale.gdshader" type="Shader" id=8]
 [ext_resource path="res://src/Shaders/TransparentChecker.shader" type="Shader" id=9]
 [ext_resource path="res://src/UI/GlobalToolOptions.tscn" type="PackedScene" id=10]
+[ext_resource path="res://src/UI/ReferencesPanel.tscn" type="PackedScene" id=11]
 [ext_resource path="res://addons/dockable_container/layout.gd" type="Script" id=14]
 [ext_resource path="res://src/UI/CanvasPreviewContainer.tscn" type="PackedScene" id=16]
 [ext_resource path="res://src/UI/ColorPickers.tscn" type="PackedScene" id=17]
@@ -33,7 +34,7 @@ shader_param/size = Vector2( 100, 100 )
 [sub_resource type="Resource" id=1]
 resource_name = "Tabs"
 script = ExtResource( 36 )
-names = PoolStringArray( "Tools" )
+names = PoolStringArray( "Tools", "References" )
 current_tab = 0
 
 [sub_resource type="Resource" id=8]
@@ -223,20 +224,20 @@ margin_bottom = -4.0
 [node name="Main Canvas" type="VBoxContainer" parent="DockableContainer"]
 margin_left = 60.0
 margin_top = 8.0
-margin_right = 938.0
-margin_bottom = 532.0
+margin_right = 1063.0
+margin_bottom = 642.5
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 0
 
 [node name="TabsContainer" type="PanelContainer" parent="DockableContainer/Main Canvas"]
-margin_right = 878.0
+margin_right = 1003.0
 margin_bottom = 38.0
 
 [node name="Tabs" type="Tabs" parent="DockableContainer/Main Canvas/TabsContainer"]
 margin_left = 7.0
 margin_top = 7.0
-margin_right = 871.0
+margin_right = 996.0
 margin_bottom = 31.0
 tab_align = 0
 tab_close_display_policy = 2
@@ -245,7 +246,7 @@ script = ExtResource( 3 )
 
 [node name="HorizontalRuler" type="Button" parent="DockableContainer/Main Canvas"]
 margin_top = 38.0
-margin_right = 878.0
+margin_right = 1003.0
 margin_bottom = 58.0
 rect_min_size = Vector2( 0, 16 )
 focus_mode = 0
@@ -256,15 +257,15 @@ script = ExtResource( 6 )
 
 [node name="ViewportandVerticalRuler" type="HBoxContainer" parent="DockableContainer/Main Canvas"]
 margin_top = 58.0
-margin_right = 878.0
-margin_bottom = 524.0
+margin_right = 1003.0
+margin_bottom = 634.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 0
 
 [node name="VerticalRuler" type="Button" parent="DockableContainer/Main Canvas/ViewportandVerticalRuler"]
 margin_right = 16.0
-margin_bottom = 466.0
+margin_bottom = 576.0
 rect_min_size = Vector2( 16, 0 )
 focus_mode = 0
 mouse_default_cursor_shape = 15
@@ -276,8 +277,8 @@ script = ExtResource( 4 )
 
 [node name="ViewportContainer" type="ViewportContainer" parent="DockableContainer/Main Canvas/ViewportandVerticalRuler"]
 margin_left = 16.0
-margin_right = 878.0
-margin_bottom = 466.0
+margin_right = 1003.0
+margin_bottom = 576.0
 focus_mode = 2
 mouse_default_cursor_shape = 3
 size_flags_horizontal = 3
@@ -286,7 +287,7 @@ stretch = true
 script = ExtResource( 23 )
 
 [node name="Viewport" type="Viewport" parent="DockableContainer/Main Canvas/ViewportandVerticalRuler/ViewportContainer"]
-size = Vector2( 862, 466 )
+size = Vector2( 987, 576 )
 handle_input_locally = false
 usage = 0
 render_target_update_mode = 3
@@ -339,30 +340,31 @@ script = ExtResource( 7 )
 
 [node name="Animation Timeline" parent="DockableContainer" instance=ExtResource( 18 )]
 margin_left = 60.0
-margin_top = 556.0
-margin_right = 938.0
+margin_top = 666.5
+margin_right = 1063.0
 margin_bottom = 716.0
 
 [node name="Canvas Preview" parent="DockableContainer" instance=ExtResource( 16 )]
-margin_left = 958.0
+margin_left = 1083.0
 margin_top = 8.0
 margin_right = 1276.0
 margin_bottom = 98.0
 
 [node name="Color Pickers" parent="DockableContainer" instance=ExtResource( 17 )]
+margin_left = 1083.0
 margin_top = 122.0
 margin_bottom = 168.0
 
 [node name="Global Tool Options" parent="DockableContainer" instance=ExtResource( 10 )]
-margin_left = 958.0
+margin_left = 1083.0
 margin_top = 192.0
 margin_right = 1276.0
 margin_bottom = 242.0
 
 [node name="Left Tool Options" type="ScrollContainer" parent="DockableContainer"]
-margin_left = 958.0
+margin_left = 1083.0
 margin_top = 266.0
-margin_right = 1107.0
+margin_right = 1169.5
 margin_bottom = 592.0
 rect_min_size = Vector2( 72, 72 )
 __meta__ = {
@@ -370,31 +372,35 @@ __meta__ = {
 }
 
 [node name="LeftPanelContainer" type="PanelContainer" parent="DockableContainer/Left Tool Options"]
-margin_right = 149.0
-margin_bottom = 326.0
+margin_right = 130.0
+margin_bottom = 314.0
 rect_min_size = Vector2( 130, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Right Tool Options" type="ScrollContainer" parent="DockableContainer"]
-margin_left = 1127.0
+margin_left = 1189.5
 margin_top = 266.0
 margin_right = 1276.0
 margin_bottom = 592.0
 rect_min_size = Vector2( 72, 72 )
 
 [node name="RightPanelContainer" type="PanelContainer" parent="DockableContainer/Right Tool Options"]
-margin_right = 149.0
-margin_bottom = 326.0
+margin_right = 130.0
+margin_bottom = 314.0
 rect_min_size = Vector2( 130, 0 )
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Palettes" parent="DockableContainer" instance=ExtResource( 20 )]
-margin_left = 958.0
+margin_left = 1083.0
 margin_top = 616.0
 margin_right = 1276.0
 margin_bottom = 716.0
+
+[node name="References" parent="DockableContainer" instance=ExtResource( 11 )]
+margin_right = 33.0
+margin_bottom = 14.0
 
 [connection signal="item_rect_changed" from="DockableContainer/Main Canvas" to="." method="_on_main_canvas_item_rect_changed"]
 [connection signal="visibility_changed" from="DockableContainer/Main Canvas" to="." method="_on_main_canvas_visibility_changed"]


### PR DESCRIPTION
Affects #565.

Usecase:

A friend of mine was looking for a pixel editor that was, well, not the one we've all heard of, and considers high-resolution reference images to be critical to her rotoscoping workflow.

Images:

![image](https://user-images.githubusercontent.com/22304167/198360535-888b1224-a795-4604-9fd5-2a455133dcef.png)

Usage:

+ `New reference image` is a new image open type.
+ Reference images are not stored in the project file due to size reasons.
+ Reference images may be scaled and positioned in project space in a newly added panel (currently appearing as a tab of Tools, which is unfortunate)

TODO:

+ Figure out how to make it work with the UI layout
+ Anything I forgot (it appears that Pixelorama code requires changing things in a lot of places, and it's possible I forgot something)

Rationale of implementation decisions:

Layers were not used as the state of the code makes this difficult.

Neither `BaseCel` or `BaseLayer` are capable of providing custom render logic (which seems odd - even if GroupCel did nothing as part of what appears to be a general 'flattening' of cels, it would still be pertinent to have the cels perform rendering by themselves given the clear intent of the design)

In addition, the assumption would be that reference layers probably do not want to be disposable cels (as a new blank frame would cause the reference image to disappear, which is not necessarily wanted)

Guides on the other hand have complete control of their rendering, and therefore I chose the design of guides as the basis of the feature.

Reference images are expected to be large and probably in a format such as PNG or JPEG. Therefore reference images are linked by absolute file path. This is up for potential change but doing so could be hazardous.

It's unclear how exactly changes are expected to propagate - I presently assume `project_changed` is the global "anything important was modified" function, and this appears to work reliably enough.
