### PR TITLE
Tool shortcuts should ignore macOS Command modifier.

### DIFF
--- a/src/UI/ToolButtons.gd
+++ b/src/UI/ToolButtons.gd
@@ -13,12 +13,12 @@ func _input(event: InputEvent) -> void:
 	for tool_name in Tools.tools:  # Handle tool shortcuts
 		var t: Tools.Tool = Tools.tools[tool_name]
 		if InputMap.has_action("right_" + t.shortcut + "_tool"):
-			if event.is_action_pressed("right_" + t.shortcut + "_tool") and !event.control:
+			if event.is_action_pressed("right_" + t.shortcut + "_tool") and (!event.control and !event.command):
 				# Shortcut for right button (with Alt)
 				Tools.assign_tool(t.name, BUTTON_RIGHT)
 				return
 		if InputMap.has_action("left_" + t.shortcut + "_tool"):
-			if event.is_action_pressed("left_" + t.shortcut + "_tool") and !event.control:
+			if event.is_action_pressed("left_" + t.shortcut + "_tool") and (!event.control and !event.command):
 				# Shortcut for left button
 				Tools.assign_tool(t.name, BUTTON_LEFT)
 				return


### PR DESCRIPTION
This prevents common shortcuts like CMD+S (Save), CMD+C (Copy), etc, from activating a tool.

Fixes #778 