### PR TITLE
Reference UI improvements

### DIFF
--- a/src/UI/Canvas/ReferenceImage.gd
+++ b/src/UI/Canvas/ReferenceImage.gd
@@ -10,6 +10,7 @@ var image_path: String = ""
 
 var filter = false
 
+
 func _ready() -> void:
 	project.reference_images.append(self)
 

--- a/src/UI/Canvas/ReferenceImage.gd
+++ b/src/UI/Canvas/ReferenceImage.gd
@@ -8,6 +8,7 @@ var project = Global.current_project
 
 var image_path: String = ""
 
+var filter = false
 
 func _ready() -> void:
 	project.reference_images.append(self)
@@ -40,6 +41,7 @@ func serialize():
 		"modulate_g": modulate.g,
 		"modulate_b": modulate.b,
 		"modulate_a": modulate.a,
+		"filter": filter,
 		"image_path": image_path
 	}
 
@@ -58,7 +60,7 @@ func deserialize(d: Dictionary):
 		if img.load(image_path) == OK:
 			var itex = ImageTexture.new()
 			# don't do FLAG_REPEAT - it could cause visual issues
-			itex.create_from_image(img, Texture.FLAG_MIPMAPS | Texture.FLAG_FILTER)
+			itex.create_from_image(img, Texture.FLAG_MIPMAPS)
 			texture = itex
 	# Now that the image may have been established...
 	position_reset()
@@ -78,4 +80,6 @@ func deserialize(d: Dictionary):
 		modulate.b = d["modulate_b"]
 	if d.has("modulate_a"):
 		modulate.a = d["modulate_a"]
+	if d.has("filter"):
+		filter = d["filter"]
 	change_properties()

--- a/src/UI/ReferenceImageButton.gd
+++ b/src/UI/ReferenceImageButton.gd
@@ -84,8 +84,9 @@ func _on_Path_pressed() -> void:
 
 func _on_ApplyFilter_toggled(button_pressed: bool) -> void:
 	element.filter = button_pressed
-	if element.filter:
-		element.texture.flags = Texture.FLAG_MIPMAPS | Texture.FLAG_FILTER
-	else:
-		element.texture.flags = Texture.FLAG_MIPMAPS
+	if element.texture:
+		if element.filter:
+			element.texture.flags = Texture.FLAG_MIPMAPS | Texture.FLAG_FILTER
+		else:
+			element.texture.flags = Texture.FLAG_MIPMAPS
 	element.change_properties()

--- a/src/UI/ReferenceImageButton.gd
+++ b/src/UI/ReferenceImageButton.gd
@@ -6,7 +6,13 @@ var _ignore_spinbox_changes = false
 
 
 func _ready():
-	$Interior/PathHeader/Path.text = element.image_path
+	if OS.get_name() == "HTML5":
+		$Interior/PathHeader/Path.visible = false
+		$Interior/PathHeader/PathHTML.text = element.image_path
+	else:
+		$Interior/PathHeader/PathHTML.visible = false
+		$Interior/PathHeader/Path.text = element.image_path
+
 	if !element.texture:
 		$Interior/PreviewAndOptions/PreviewPanel/Warning.text = "Image Not Found!!!"
 	else:

--- a/src/UI/ReferenceImageButton.gd
+++ b/src/UI/ReferenceImageButton.gd
@@ -6,7 +6,11 @@ var _ignore_spinbox_changes = false
 
 
 func _ready():
-	$Interior/Path.text = element.image_path
+	$Interior/PathHeader/Path.text = element.image_path
+	if !element.texture:
+		$Interior/PreviewAndOptions/PreviewPanel/Warning.text = "Image Not Found!!!"
+	else:
+		$Interior/PreviewAndOptions/PreviewPanel/Preview.texture = element.texture
 	element.connect("properties_changed", self, "_update_properties")
 	_update_properties()
 
@@ -15,12 +19,13 @@ func _update_properties():
 	# This is because otherwise a little dance will occur.
 	# This also breaks non-uniform scales (not supported UI-wise, but...)
 	_ignore_spinbox_changes = true
-	$Interior/Options/Scale.value = element.scale.x * 100
-	$Interior/Options/X.value = element.position.x
-	$Interior/Options/Y.value = element.position.y
-	$Interior/Options/X.max_value = element.project.size.x
-	$Interior/Options/Y.max_value = element.project.size.y
-	$Interior/Options2/Opacity.value = element.modulate.a * 100
+	$Interior/PreviewAndOptions/Options/Scale.value = element.scale.x * 100
+	$Interior/PreviewAndOptions/Options/Position/X.value = element.position.x
+	$Interior/PreviewAndOptions/Options/Position/Y.value = element.position.y
+	$Interior/PreviewAndOptions/Options/Position/X.max_value = element.project.size.x
+	$Interior/PreviewAndOptions/Options/Position/Y.max_value = element.project.size.y
+	$Interior/PreviewAndOptions/Options/Opacity.value = element.modulate.a * 100
+	$Interior/OtherOptions/ApplyFilter.pressed = element.filter
 	_ignore_spinbox_changes = false
 
 
@@ -64,4 +69,17 @@ func _on_Opacity_value_changed(value):
 	if _ignore_spinbox_changes:
 		return
 	element.modulate.a = value / 100
+	element.change_properties()
+
+
+func _on_Path_pressed() -> void:
+	OS.shell_open($Interior/PathHeader/Path.text.get_base_dir())
+
+
+func _on_ApplyFilter_toggled(button_pressed: bool) -> void:
+	element.filter = button_pressed
+	if element.filter:
+		element.texture.flags = Texture.FLAG_MIPMAPS | Texture.FLAG_FILTER
+	else:
+		element.texture.flags = Texture.FLAG_MIPMAPS
 	element.change_properties()

--- a/src/UI/ReferenceImageButton.tscn
+++ b/src/UI/ReferenceImageButton.tscn
@@ -24,13 +24,20 @@ custom_constants/separation = 0
 
 [node name="Path" type="LinkButton" parent="Interior/PathHeader"]
 modulate = Color( 0.552941, 1, 0.298039, 1 )
-margin_right = 148.0
+margin_right = 99.0
 margin_bottom = 14.0
 size_flags_horizontal = 3
 underline = 1
 
+[node name="PathHTML" type="Label" parent="Interior/PathHeader"]
+self_modulate = Color( 0.552941, 1, 0.298039, 1 )
+margin_left = 99.0
+margin_right = 198.0
+margin_bottom = 14.0
+size_flags_horizontal = 3
+
 [node name="HSeparator" type="HSeparator" parent="Interior/PathHeader"]
-margin_left = 148.0
+margin_left = 198.0
 margin_right = 297.0
 margin_bottom = 14.0
 size_flags_horizontal = 3

--- a/src/UI/ReferenceImageButton.tscn
+++ b/src/UI/ReferenceImageButton.tscn
@@ -15,80 +15,143 @@ script = ExtResource( 1 )
 margin_left = 7.0
 margin_top = 7.0
 margin_right = 304.0
-margin_bottom = 132.0
+margin_bottom = 133.0
 
-[node name="Path" type="Label" parent="Interior"]
+[node name="PathHeader" type="HBoxContainer" parent="Interior"]
+margin_right = 297.0
+margin_bottom = 14.0
+custom_constants/separation = 0
+
+[node name="Path" type="LinkButton" parent="Interior/PathHeader"]
+modulate = Color( 0.552941, 1, 0.298039, 1 )
+margin_right = 148.0
+margin_bottom = 14.0
+size_flags_horizontal = 3
+underline = 1
+
+[node name="HSeparator" type="HSeparator" parent="Interior/PathHeader"]
+margin_left = 148.0
 margin_right = 297.0
 margin_bottom = 14.0
 size_flags_horizontal = 3
-autowrap = true
 
-[node name="Options" type="HBoxContainer" parent="Interior"]
+[node name="PreviewAndOptions" type="HBoxContainer" parent="Interior"]
 margin_top = 18.0
 margin_right = 297.0
-margin_bottom = 42.0
+margin_bottom = 98.0
 
-[node name="Label2" type="Label" parent="Interior/Options"]
+[node name="Options" type="GridContainer" parent="Interior/PreviewAndOptions"]
+margin_right = 213.0
+margin_bottom = 80.0
+size_flags_horizontal = 3
+columns = 2
+
+[node name="PosLabel" type="Label" parent="Interior/PreviewAndOptions/Options"]
 margin_top = 5.0
 margin_right = 56.0
 margin_bottom = 19.0
 text = "Position:"
+align = 2
 
-[node name="X" parent="Interior/Options" instance=ExtResource( 2 )]
+[node name="Position" type="HBoxContainer" parent="Interior/PreviewAndOptions/Options"]
 margin_left = 60.0
-margin_right = 122.0
+margin_right = 213.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+
+[node name="X" parent="Interior/PreviewAndOptions/Options/Position" instance=ExtResource( 2 )]
+margin_right = 74.0
 allow_greater = true
 allow_lesser = true
 
-[node name="Y" parent="Interior/Options" instance=ExtResource( 2 )]
-margin_left = 126.0
-margin_right = 189.0
+[node name="Y" parent="Interior/PreviewAndOptions/Options/Position" instance=ExtResource( 2 )]
+margin_left = 78.0
+margin_right = 153.0
 allow_greater = true
 allow_lesser = true
 
-[node name="Label" type="Label" parent="Interior/Options"]
-margin_left = 193.0
-margin_top = 5.0
-margin_right = 230.0
-margin_bottom = 19.0
+[node name="ScaleLabel" type="Label" parent="Interior/PreviewAndOptions/Options"]
+margin_top = 33.0
+margin_right = 56.0
+margin_bottom = 47.0
 text = "Scale:"
+align = 2
 
-[node name="Scale" parent="Interior/Options" instance=ExtResource( 2 )]
-margin_left = 234.0
-margin_right = 297.0
+[node name="Scale" parent="Interior/PreviewAndOptions/Options" instance=ExtResource( 2 )]
+margin_left = 60.0
+margin_top = 28.0
+margin_right = 213.0
+margin_bottom = 52.0
 allow_greater = true
 allow_lesser = true
 
-[node name="Options2" type="HBoxContainer" parent="Interior"]
-margin_top = 46.0
-margin_right = 297.0
-margin_bottom = 70.0
-
-[node name="Label" type="Label" parent="Interior/Options2"]
-margin_top = 5.0
-margin_right = 53.0
-margin_bottom = 19.0
+[node name="OpacityLabel" type="Label" parent="Interior/PreviewAndOptions/Options"]
+margin_top = 61.0
+margin_right = 56.0
+margin_bottom = 75.0
 text = "Opacity:"
+align = 2
 
-[node name="Opacity" parent="Interior/Options2" instance=ExtResource( 2 )]
-margin_left = 57.0
+[node name="Opacity" parent="Interior/PreviewAndOptions/Options" instance=ExtResource( 2 )]
+margin_left = 60.0
+margin_top = 56.0
+margin_right = 213.0
+margin_bottom = 80.0
+
+[node name="PreviewPanel" type="Panel" parent="Interior/PreviewAndOptions"]
+margin_left = 217.0
+margin_right = 297.0
+margin_bottom = 80.0
+rect_min_size = Vector2( 80, 80 )
+
+[node name="Warning" type="Label" parent="Interior/PreviewAndOptions/PreviewPanel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+align = 1
+valign = 1
+autowrap = true
+
+[node name="Preview" type="TextureRect" parent="Interior/PreviewAndOptions/PreviewPanel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 2.0
+margin_top = 2.0
+margin_right = -2.0
+margin_bottom = -2.0
+expand = true
+
+[node name="OtherOptions" type="HBoxContainer" parent="Interior"]
+margin_top = 102.0
+margin_right = 297.0
+margin_bottom = 126.0
+alignment = 2
+
+[node name="ApplyFilter" type="CheckBox" parent="Interior/OtherOptions"]
+margin_left = 76.0
 margin_right = 177.0
+margin_bottom = 24.0
+hint_tooltip = "Uses a magnifying filter, to enable smooth zooming in of the texture."
+text = "Apply Filter"
+align = 1
 
-[node name="Reset" type="Button" parent="Interior/Options2"]
+[node name="Reset" type="Button" parent="Interior/OtherOptions"]
 margin_left = 181.0
 margin_right = 229.0
 margin_bottom = 24.0
 text = "Reset"
 
-[node name="Remove" type="Button" parent="Interior/Options2"]
+[node name="Remove" type="Button" parent="Interior/OtherOptions"]
 margin_left = 233.0
 margin_right = 297.0
 margin_bottom = 24.0
+custom_colors/font_color = Color( 1, 0.266667, 0.266667, 1 )
 text = "Remove"
 
-[connection signal="value_changed" from="Interior/Options/X" to="." method="_on_X_value_changed"]
-[connection signal="value_changed" from="Interior/Options/Y" to="." method="_on_Y_value_changed"]
-[connection signal="value_changed" from="Interior/Options/Scale" to="." method="_on_Scale_value_changed"]
-[connection signal="value_changed" from="Interior/Options2/Opacity" to="." method="_on_Opacity_value_changed"]
-[connection signal="pressed" from="Interior/Options2/Reset" to="." method="_on_Reset_pressed"]
-[connection signal="pressed" from="Interior/Options2/Remove" to="." method="_on_Remove_pressed"]
+[connection signal="pressed" from="Interior/PathHeader/Path" to="." method="_on_Path_pressed"]
+[connection signal="value_changed" from="Interior/PreviewAndOptions/Options/Position/X" to="." method="_on_X_value_changed"]
+[connection signal="value_changed" from="Interior/PreviewAndOptions/Options/Position/Y" to="." method="_on_Y_value_changed"]
+[connection signal="value_changed" from="Interior/PreviewAndOptions/Options/Scale" to="." method="_on_Scale_value_changed"]
+[connection signal="value_changed" from="Interior/PreviewAndOptions/Options/Opacity" to="." method="_on_Opacity_value_changed"]
+[connection signal="toggled" from="Interior/OtherOptions/ApplyFilter" to="." method="_on_ApplyFilter_toggled"]
+[connection signal="pressed" from="Interior/OtherOptions/Reset" to="." method="_on_Reset_pressed"]
+[connection signal="pressed" from="Interior/OtherOptions/Remove" to="." method="_on_Remove_pressed"]


### PR DESCRIPTION
Improved the Reference image panel UI
This pull includes:

1. Better alignment of Position, Scale, Opacity Sliders
2. The text of "Remove" button is Red
3. Clicking on the "Path" now opens the folder in which reference image is placed (disabled for HTML)
4. A new Image Preview
5. A new option to enable or disable filter (Filter is off by default)
6. A warning appears if the image is not found

### Before
![Screenshot from 2022-12-06 16-29-30](https://user-images.githubusercontent.com/77773850/205900923-bbb251bc-da49-492e-8d6b-aef319233646.png)

### After
![Screenshot from 2022-12-06 16-31-03](https://user-images.githubusercontent.com/77773850/205900987-0d033377-57a1-4816-9a29-682df8c17269.png)