### PR TITLE
Added supported_api_versions parameter

### DIFF
--- a/src/Preferences/HandleExtensions.gd
+++ b/src/Preferences/HandleExtensions.gd
@@ -156,7 +156,10 @@ func _add_extension(file_name: String) -> void:
 		var supported_api_versions = extension_json["supported_api_versions"]
 		if typeof(supported_api_versions) == TYPE_ARRAY:
 			if !supported_api_versions.has(ExtensionsApi.get_api_version()):
-				var err_text = "The extension %s will not work on this version of Pixelorama \n" % file_name_no_ext
+				var err_text = (
+					"The extension %s will not work on this version of Pixelorama \n"
+					% file_name_no_ext
+				)
 				var required_text = "Requires Api : %s" % str(supported_api_versions)
 				Global.error_dialog.set_text(str(err_text, required_text))
 				Global.error_dialog.popup_centered()

--- a/src/Preferences/HandleExtensions.gd
+++ b/src/Preferences/HandleExtensions.gd
@@ -152,6 +152,18 @@ func _add_extension(file_name: String) -> void:
 		print("No JSON data found.")
 		return
 
+	if extension_json.has("supported_api_versions"):
+		var supported_api_versions = extension_json["supported_api_versions"]
+		if typeof(supported_api_versions) == TYPE_ARRAY:
+			if !supported_api_versions.has(ExtensionsApi.get_api_version()):
+				var err_text = "The extension %s will not work on this version of Pixelorama \n" % file_name_no_ext
+				var required_text = "Requires Api : %s" % str(supported_api_versions)
+				Global.error_dialog.set_text(str(err_text, required_text))
+				Global.error_dialog.popup_centered()
+				Global.dialog_open(true)
+				print("Incompatible API")
+				return
+
 	var extension := Extension.new()
 	extension.serialize(extension_json)
 	extensions[file_name] = extension

--- a/src/Preferences/HandleExtensions.gd
+++ b/src/Preferences/HandleExtensions.gd
@@ -155,7 +155,7 @@ func _add_extension(file_name: String) -> void:
 	if extension_json.has("supported_api_versions"):
 		var supported_api_versions = extension_json["supported_api_versions"]
 		if typeof(supported_api_versions) == TYPE_ARRAY:
-			if !supported_api_versions.has(ExtensionsApi.get_api_version()):
+			if !ExtensionsApi.get_api_version() in supported_api_versions:
 				var err_text = (
 					"The extension %s will not work on this version of Pixelorama \n"
 					% file_name_no_ext


### PR DESCRIPTION
This will implement a new parameter called `supported_api_versions`
Note that the extension will still work without this parameter in `extension.json` but if it is included, then pixelorama will do an additional check if it's current api is present in the `supported_api_versions`

an example of extension.json containing this parameter is given below (this extension will now only work on pixelorama Api versions 1 and 2). So in case Api version 3 contains breaking changes it will simply show an error dialog instead of a BIG LOUD CRASH
```swift
{
"author": "Variable",
"description": "Test the new Api",
"display_name": "TestAPI",
"license": "MIT",
"name": "TestAPI",
"nodes": [ "Main.tscn" ],
"version": "0.1",
"supported_api_versions": [1, 2]
}
```