### PR TITLE
Update .desktop file and add new MimeInfo

### DIFF
--- a/Misc/Linux/com.orama_interactive.Pixelorama.desktop
+++ b/Misc/Linux/com.orama_interactive.Pixelorama.desktop
@@ -15,3 +15,4 @@ Icon=pixelorama
 Terminal=false
 Type=Application
 Categories=Graphics;2DGraphics;RasterGraphics;
+MimeType=image/pxo;image/png;image/bmp;image/vnd.radiance;image/jpeg;image/svg+xml;image/x-tga;image/webp;

--- a/Misc/Linux/com.orama_interactive.Pixelorama.xml
+++ b/Misc/Linux/com.orama_interactive.Pixelorama.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="image/pxo">
+    <comment>Pixelorama Project</comment>
+    <glob pattern="*.pxo"/>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
Pixelorama's .desktop file now contains all the file types it can open by default (Used by DEs to provide app suggestions in context menus).
Also adds a MimeInfo file for `.pxo`. It provides context for the format and can be used by packages to register and associate the file format with the application (like flatpak)