### PR TITLE
Fix top color picking

### DIFF
--- a/src/Tools/ColorPicker.gd
+++ b/src/Tools/ColorPicker.gd
@@ -77,7 +77,7 @@ func _pick_color(position: Vector2) -> void:
 			var curr_frame: Frame = project.frames[project.current_frame]
 			for layer in project.layers.size():
 				var idx = (project.layers.size() - 1) - layer
-				if project.layers[idx].can_layer_get_drawn():
+				if project.layers[idx].is_visible_in_hierarchy():
 					image = curr_frame.cels[idx].get_image()
 					image.lock()
 					color = image.get_pixelv(position)

--- a/src/Tools/Draw.gd
+++ b/src/Tools/Draw.gd
@@ -690,7 +690,7 @@ func _pick_color(position: Vector2) -> void:
 	var curr_frame: Frame = project.frames[project.current_frame]
 	for layer in project.layers.size():
 		var idx = (project.layers.size() - 1) - layer
-		if project.layers[idx].can_layer_get_drawn():
+		if project.layers[idx].is_visible_in_hierarchy():
 			image = curr_frame.cels[idx].get_image()
 			image.lock()
 			color = image.get_pixelv(position)


### PR DESCRIPTION
The "Current layer" mode was able to pick-colors from a locked layer, while the "Top Color" mode was not;
this will fix that issue (i only needed to see if layer was visible or not)