### PR TITLE
[Targeted for 0.11.0] Make Onion skin update live with the "Move" tool

### DIFF
--- a/src/UI/Canvas/OnionSkinning.gd
+++ b/src/UI/Canvas/OnionSkinning.gd
@@ -35,8 +35,9 @@ func _draw() -> void:
 					if not (layer.name.to_lower().ends_with("_io")):
 						color.a = 0.6 / i
 						if [change, layer_i] in project.selected_cels:
-							var move_preview_location = Global.canvas.move_preview_location
-							draw_texture(cel.image_texture, move_preview_location, color)
+							draw_texture(
+								cel.image_texture, Global.canvas.move_preview_location, color
+							)
 						else:
 							draw_texture(cel.image_texture, Vector2.ZERO, color)
 				layer_i += 1

--- a/src/UI/Canvas/OnionSkinning.gd
+++ b/src/UI/Canvas/OnionSkinning.gd
@@ -8,6 +8,7 @@ var rate := Global.onion_skinning_past_rate
 
 
 func _draw() -> void:
+	var project = Global.current_project
 	if !Global.onion_skinning:
 		return
 	rate = Global.onion_skinning_past_rate if type == PAST else Global.onion_skinning_future_rate
@@ -18,21 +19,25 @@ func _draw() -> void:
 	var position_tmp := position
 	var scale_tmp := scale
 	if Global.mirror_view:
-		position_tmp.x += Global.current_project.size.x
+		position_tmp.x += project.size.x
 		scale_tmp.x = -1
 	draw_set_transform(position_tmp, rotation, scale_tmp)
 
 	for i in range(1, rate + 1):
-		var change: int = Global.current_project.current_frame
+		var change: int = project.current_frame
 		change += i if type == FUTURE else -i
-		if change == clamp(change, 0, Global.current_project.frames.size() - 1):
+		if change == clamp(change, 0, project.frames.size() - 1):
 			var layer_i := 0
-			for cel in Global.current_project.frames[change].cels:
-				var layer: BaseLayer = Global.current_project.layers[layer_i]
+			for cel in project.frames[change].cels:
+				var layer: BaseLayer = project.layers[layer_i]
 				if layer.is_visible_in_hierarchy():
 					# Ignore layer if it has the "_io" suffix in its name (case in-sensitive)
 					if not (layer.name.to_lower().ends_with("_io")):
 						color.a = 0.6 / i
-						draw_texture(cel.image_texture, Vector2.ZERO, color)
+						if [change, layer_i] in project.selected_cels:
+							var move_preview_location = Global.canvas.move_preview_location
+							draw_texture(cel.image_texture, move_preview_location, color)
+						else:
+							draw_texture(cel.image_texture, Vector2.ZERO, color)
 				layer_i += 1
 	draw_set_transform(position, rotation, scale)


### PR DESCRIPTION
While using the "Move" tool, the onion skin will move it's past and future frames accordingly if they are in selected cels to give a better idea of where it will land,
(NOTE: selections will still work as it did previously i-e update onion shin after transformation is confirmed)

https://github.com/Orama-Interactive/Pixelorama/assets/77773850/e82b180b-c175-4c54-8e7c-ceada8ca1fd6

