### PR TITLE
Update opacity across selected frames

### DIFF
--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -869,15 +869,12 @@ func _on_MergeDownLayer_pressed() -> void:
 
 func _on_OpacitySlider_value_changed(value: float) -> void:
 	var new_opacity := value / 100
-	var current_frame: Frame = Global.current_project.frames[Global.current_project.current_frame]
 	var current_layer_idx := Global.current_project.current_layer
-	# Ensure current frame is updated.
-	var cel: BaseCel = current_frame.cels[current_layer_idx]
-	cel.opacity = new_opacity
 	# Also update all selected frames.
 	for idx_pair in Global.current_project.selected_cels:
 		if idx_pair[1] == current_layer_idx:
-			cel = Global.current_project.frames[idx_pair[0]].cels[current_layer_idx]
+			var frame: Frame = Global.current_project.frames[idx_pair[0]]
+			var cel: BaseCel = frame.cels[current_layer_idx]
 			cel.opacity = new_opacity
 	Global.canvas.update()
 

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -867,10 +867,18 @@ func _on_MergeDownLayer_pressed() -> void:
 	project.undo_redo.commit_action()
 
 
-func _on_OpacitySlider_value_changed(value) -> void:
+func _on_OpacitySlider_value_changed(value: float) -> void:
+	var new_opacity := value / 100
 	var current_frame: Frame = Global.current_project.frames[Global.current_project.current_frame]
-	var cel: BaseCel = current_frame.cels[Global.current_project.current_layer]
-	cel.opacity = value / 100
+	var current_layer_idx := Global.current_project.current_layer
+	# Ensure current frame is updated.
+	var cel: BaseCel = current_frame.cels[current_layer_idx]
+	cel.opacity = new_opacity
+	# Also update all selected frames.
+	for idx_pair in Global.current_project.selected_cels:
+		if idx_pair[1] == current_layer_idx:
+			cel = Global.current_project.frames[idx_pair[0]].cels[current_layer_idx]
+			cel.opacity = new_opacity
 	Global.canvas.update()
 
 


### PR DESCRIPTION
This causes the opacity slider to update all selected frames of the current layer rather than just the current frame.
This is useful because opacity is treated independently of cel linking, so without an option like this it's hard to work with layers you want to have one global opacity.

An example of this is if you have, say, a "noise layer" on your sprite (i.e. import noise from some other application, cut it to fit the sprite, then adjust opacity to taste). This is useful for adding a bit of texture. But combining a noise layer with animation is awkward because the opacity is per-frame, so you have to have everything setup at the start or individually adjust each layer.