### PR TITLE
Limit onion skinning slider max values to 10

### DIFF
--- a/src/UI/Timeline/AnimationTimeline.tscn
+++ b/src/UI/Timeline/AnimationTimeline.tscn
@@ -885,7 +885,9 @@ unique_name_in_owner = true
 margin_left = 819.0
 margin_right = 891.0
 size_flags_horizontal = 1
+max_value = 10.0
 value = 1.0
+allow_greater = true
 suffix = "Frames"
 
 [node name="OnionSkinningFuture" type="Label" parent="OnionSkinningSettings/OnionSkinningButtons"]
@@ -899,7 +901,9 @@ unique_name_in_owner = true
 margin_left = 819.0
 margin_right = 891.0
 size_flags_horizontal = 1
+max_value = 10.0
 value = 1.0
+allow_greater = true
 suffix = "Frames"
 
 [node name="BlueRedMode" type="CheckBox" parent="OnionSkinningSettings/OnionSkinningButtons"]


### PR DESCRIPTION
Limited value sliders of past and future frames to 10 and enabled the `allow greater` option so you can still set it to values greater than 10