### PR TITLE
[Targeted for 0.11.0] Export options to extension

### DIFF
--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -218,6 +218,7 @@ func export_processed_images(
 			var result := true
 			var details := {
 				"processed_images": processed_images,
+				"durations": durations,
 				"export_dialog": export_dialog,
 				"export_paths": export_paths,
 				"project": project

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -8,6 +8,7 @@ var panel := PanelAPI.new()
 var theme := ThemeAPI.new()
 var tools := ToolAPI.new()
 var project := ProjectAPI.new()
+var exports := ExportAPI.new()
 var signals := SignalsAPI.new()
 
 # This fail-safe below is designed to work ONLY if Pixelorama is launched in Godot Editor
@@ -363,6 +364,52 @@ class ProjectAPI:
 			OpenSave.open_image_at_cel(image, layer, frame)
 		else:
 			print("cel at frame ", frame, ", layer ", layer, " is not a PixelCel")
+
+
+class ExportAPI:
+	var ExportTab := Export.ExportTab
+
+	func add_export_option(
+		format_info: Dictionary, exporter_generator, tab := ExportTab.IMAGE, is_animated := true
+	) -> int:
+		# separate enum name and file name
+		var extension = ""
+		var format_name = ""
+		if format_info.has("extension"):
+			extension = format_info["extension"]
+		if format_info.has("description"):
+			format_name = format_info["description"].to_upper().replace(" ", "_")
+		#  add enum
+		var id = Export.add_file_format(format_name)
+		#  add exporter generator
+		Export.custom_exporter_generators.merge({id: [exporter_generator, extension]})
+		#  add to animated (or not)
+		if is_animated:
+			Export.animated_formats.append(id)
+		#  add to export dialog
+		match tab:
+			ExportTab.IMAGE:
+				Global.export_dialog.image_exports.append(id)
+			ExportTab.SPRITESHEET:
+				Global.export_dialog.spritesheet_exports.append(id)
+			_:  # Both
+				Global.export_dialog.image_exports.append(id)
+				Global.export_dialog.spritesheet_exports.append(id)
+		ExtensionsApi.add_action("add_exporter")
+		return id
+
+	func remove_export_option(id: int):
+		if Export.custom_exporter_generators.has(id):
+			# remove enum
+			Export.remove_file_format(id)
+			# remove exporter generator
+			Export.custom_exporter_generators.erase(id)
+			#  remove from animated (or not)
+			Export.animated_formats.erase(id)
+			#  add to export dialog
+			Global.export_dialog.image_exports.erase(id)
+			Global.export_dialog.spritesheet_exports.erase(id)
+			ExtensionsApi.remove_action("add_exporter")
 
 
 class SignalsAPI:

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -367,6 +367,7 @@ class ProjectAPI:
 
 
 class ExportAPI:
+	# gdlint: ignore=class-variable-name
 	var ExportTab := Export.ExportTab
 
 	func add_export_option(

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -380,10 +380,20 @@ class ExportAPI:
 			extension = format_info["extension"]
 		if format_info.has("description"):
 			format_name = format_info["description"].to_upper().replace(" ", "_")
-		if format_name in Export.FileFormat:  # Format of the same type is already added
-			return -1
-		#  add enum
-		var id = Export.add_file_format(format_name)
+		# change format name if another one uses the same name
+		for i in range(Export.FileFormat.size()):
+			var test_name = format_name
+			if i != 0:
+				test_name = str(test_name, "_", i)
+			if !Export.FileFormat.keys().has(test_name):
+				format_name = test_name
+				break
+		#  add to FileFormat enum
+		var id := Export.FileFormat.size()
+		for i in Export.FileFormat.size():  # use an empty id if it's available
+			if !Export.FileFormat.values().has(i):
+				id = i
+		Export.FileFormat.merge({format_name: id})
 		#  add exporter generator
 		Export.custom_exporter_generators.merge({id: [exporter_generator, extension]})
 		#  add to animated (or not)

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -380,6 +380,8 @@ class ExportAPI:
 			extension = format_info["extension"]
 		if format_info.has("description"):
 			format_name = format_info["description"].to_upper().replace(" ", "_")
+		if format_name in Export.FileFormat:  # Format of the same type is already added
+			return -1
 		#  add enum
 		var id = Export.add_file_format(format_name)
 		#  add exporter generator

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -6,6 +6,10 @@ signal resume_export_function
 var preview_current_frame := 0
 var preview_frames := []
 
+# allow custom exporters to be added
+var image_exports := [Export.FileFormat.PNG, Export.FileFormat.GIF, Export.FileFormat.APNG]
+var spritesheet_exports := [Export.FileFormat.PNG]
+
 onready var tabs: Tabs = $VBoxContainer/Tabs
 onready var checker: ColorRect = $"%TransparentChecker"
 onready var previews: GridContainer = $"%Previews"
@@ -91,15 +95,6 @@ func set_preview() -> void:
 			for i in range(Export.processed_images.size()):
 				add_image_preview(Export.processed_images[i], i + 1)
 
-	if Global.current_project.file_format == Export.FileFormat.GIF:
-		$"%GifWarning".visible = true
-	else:
-		$"%GifWarning".visible = false
-
-
-func _on_GifWarning_meta_clicked(meta) -> void:
-	OS.shell_open(meta)
-
 
 func add_image_preview(image: Image, canvas_number: int = -1) -> void:
 	var container := create_preview_container()
@@ -164,11 +159,9 @@ func remove_previews() -> void:
 func set_file_format_selector() -> void:
 	match Export.current_tab:
 		Export.ExportTab.IMAGE:
-			_set_file_format_selector_suitable_file_formats(
-				[Export.FileFormat.PNG, Export.FileFormat.GIF, Export.FileFormat.APNG]
-			)
+			_set_file_format_selector_suitable_file_formats(image_exports)
 		Export.ExportTab.SPRITESHEET:
-			_set_file_format_selector_suitable_file_formats([Export.FileFormat.PNG])
+			_set_file_format_selector_suitable_file_formats(spritesheet_exports)
 
 
 # Updates the suitable list of file formats. First is preferred.

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -95,6 +95,11 @@ func set_preview() -> void:
 			for i in range(Export.processed_images.size()):
 				add_image_preview(Export.processed_images[i], i + 1)
 
+	if Global.current_project.file_format == Export.FileFormat.GIF:
+		$"%GifWarning".visible = true
+	else:
+		$"%GifWarning".visible = false
+
 
 func add_image_preview(image: Image, canvas_number: int = -1) -> void:
 	var container := create_preview_container()

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -101,6 +101,10 @@ func set_preview() -> void:
 		$"%GifWarning".visible = false
 
 
+func _on_GifWarning_meta_clicked(meta) -> void:
+	OS.shell_open(meta)
+
+
 func add_image_preview(image: Image, canvas_number: int = -1) -> void:
 	var container := create_preview_container()
 	var preview := create_preview_rect()


### PR DESCRIPTION
Continuation of #810
A Looooong awaited feature to be added to the ExtensionsApi
You can now add custom export options using extensions. but wait!!!, there's more.... they can also contain gdnative!

The main reason why gdnative wasn't being loaded was that the libraries (the ones that end with with .so, .dll,  etc...), can't be loaded from a virtual file system (e.g .pck) so what the workaround is to simply place the libraries in a github repo and download them through HttpRequest (it can be a one-time process)

So now that i've figured out the issue and created an example extension (which was the condition in the original PR)

https://github.com/Orama-Interactive/Pixelorama/assets/77773850/1f05f564-bc06-4600-a6f9-c74b192961e2