### PR TITLE
Set alignment of the LineEdit Node for file name in Export Dialog to Left

### DIFF
--- a/src/UI/Dialogs/ExportDialog.tscn
+++ b/src/UI/Dialogs/ExportDialog.tscn
@@ -272,7 +272,6 @@ margin_right = 382.0
 margin_bottom = 52.0
 size_flags_horizontal = 3
 text = "untitled"
-align = 2
 caret_blink = true
 caret_blink_speed = 0.5
 


### PR DESCRIPTION
The LineEdit node for file name in Export Dialog seems to behave weirdly when the Align property is set to Right, as is shown in the gif:

![before](https://github.com/Orama-Interactive/Pixelorama/assets/37259613/fe7d1ad1-cddf-4d84-b259-b65454fbbe50)

In the picture, I pressed Backspace once per time, but at the second time, 2 charactors disappeared together with the caret.
The cause of the bug remains uncleared, but simply setting the Align property to Left solves the problem like this:

![after](https://github.com/Orama-Interactive/Pixelorama/assets/37259613/70bd6d41-ab6c-4ccd-8baf-b63b44cfac2d)

## Changes
* The LineEdit for file name in Export Dialog now aligns on the left side  