### PR TITLE
Allow user to move Palettes to Trash/Recycle Bin instead of deleting them permanently

### DIFF
--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -130,6 +130,10 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
+#. When you move something to recycle bin
+msgid "Move to Trash"
+msgstr ""
+
 msgid "New Brush"
 msgstr ""
 

--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -130,6 +130,9 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
+msgid "Delete Permanently"
+msgstr ""
+
 #. When you move something to recycle bin
 msgid "Move to Trash"
 msgstr ""

--- a/src/Autoload/Palettes.gd
+++ b/src/Autoload/Palettes.gd
@@ -213,13 +213,16 @@ func current_palette_edit(palette_name: String, comment: String, width: int, hei
 	palettes[palette_path] = current_palette
 
 
-func _delete_palette(path: String) -> void:
-	OS.move_to_trash(path)
+func _delete_palette(path: String, permanent := true) -> void:
+	if permanent:
+		DirAccess.remove_absolute(path)
+	else:
+		OS.move_to_trash(path)
 	palettes.erase(path)
 
 
-func current_palete_delete() -> void:
-	_delete_palette(current_palette.resource_path)
+func current_palete_delete(permanent := true) -> void:
+	_delete_palette(current_palette.resource_path, permanent)
 
 	if palettes.size() > 0:
 		select_palette(palettes.keys()[0])

--- a/src/Autoload/Palettes.gd
+++ b/src/Autoload/Palettes.gd
@@ -214,7 +214,7 @@ func current_palette_edit(palette_name: String, comment: String, width: int, hei
 
 
 func _delete_palette(path: String) -> void:
-	DirAccess.open(path).remove(path)
+	OS.move_to_trash(path)
 	palettes.erase(path)
 
 

--- a/src/Palette/CreatePaletteDialog.tscn
+++ b/src/Palette/CreatePaletteDialog.tscn
@@ -3,16 +3,18 @@
 [ext_resource type="Script" path="res://src/Palette/CreatePaletteDialog.gd" id="1"]
 
 [node name="CreatePaletteDialog" type="ConfirmationDialog"]
+title = "Create a new palette"
+size = Vector2i(325, 437)
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchors_preset = -1
 anchor_left = 0.000793701
 anchor_right = 0.000793701
-offset_left = 7.76189
+offset_left = 7.74205
 offset_top = 8.0
-offset_right = 291.762
-offset_bottom = 401.0
+offset_right = 316.742
+offset_bottom = 388.0
 
 [node name="PaletteMetadata" type="GridContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -118,12 +120,18 @@ layout_mode = 2
 size_flags_vertical = 7
 theme_override_colors/font_color = Color(1, 0.603922, 0.603922, 1)
 text = "Palette with the same name and path already exists!"
+horizontal_alignment = 1
+vertical_alignment = 2
+autowrap_mode = 3
 
 [node name="EnterNameWarning" type="Label" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 7
 theme_override_colors/font_color = Color(1, 0.603922, 0.603922, 1)
 text = "Palette name is required!"
+horizontal_alignment = 1
+vertical_alignment = 2
+autowrap_mode = 3
 
 [connection signal="confirmed" from="." to="." method="_on_CreatePaletteDialog_confirmed"]
 [connection signal="visibility_changed" from="." to="." method="_on_CreatePaletteDialog_visibility_changed"]

--- a/src/Palette/EditPaletteDialog.gd
+++ b/src/Palette/EditPaletteDialog.gd
@@ -16,7 +16,7 @@ var old_name := ""
 @onready var comment_input := $VBoxContainer/PaletteMetadata/Comment
 @onready var width_input := $VBoxContainer/PaletteMetadata/Width
 @onready var height_input := $VBoxContainer/PaletteMetadata/Height
-@onready var path_input := $VBoxContainer/PaletteMetadata/Path3D
+@onready var path_input := $VBoxContainer/PaletteMetadata/Path
 
 @onready var size_reduced_warning := $VBoxContainer/SizeReducedWarning
 @onready var already_exists_warning := $VBoxContainer/AlreadyExistsWarning
@@ -79,7 +79,7 @@ func _on_EditPaletteDialog_confirmed() -> void:
 func _on_EditPaletteDialog_custom_action(action: String) -> void:
 	if action == DELETE_ACTION:
 		hide()
-		deleted.emit(deleted)
+		emit_signal("deleted")
 
 
 func _on_size_value_changed(_value):

--- a/src/Palette/EditPaletteDialog.gd
+++ b/src/Palette/EditPaletteDialog.gd
@@ -21,7 +21,7 @@ var old_name := ""
 
 @onready var size_reduced_warning := $VBoxContainer/SizeReducedWarning
 @onready var already_exists_warning := $VBoxContainer/AlreadyExistsWarning
-@onready var delete_confirmation: AcceptDialog = $DeleteConfirmation
+@onready var delete_confirmation := $DeleteConfirmation
 
 
 func _ready() -> void:

--- a/src/Palette/EditPaletteDialog.gd
+++ b/src/Palette/EditPaletteDialog.gd
@@ -79,7 +79,7 @@ func _on_EditPaletteDialog_confirmed() -> void:
 func _on_EditPaletteDialog_custom_action(action: String) -> void:
 	if action == DELETE_ACTION:
 		hide()
-		emit_signal("deleted")
+		deleted.emit()
 
 
 func _on_size_value_changed(_value):

--- a/src/Palette/EditPaletteDialog.gd
+++ b/src/Palette/EditPaletteDialog.gd
@@ -27,7 +27,7 @@ var old_name := ""
 func _ready() -> void:
 	# Add delete button to edit palette dialog
 	add_button(tr("Delete"), false, DELETE_ACTION)
-	delete_confirmation.add_button("Move to Trash", false, BIN_ACTION)
+	delete_confirmation.add_button(tr("Move to Trash"), false, BIN_ACTION)
 
 
 func open(current_palette: Palette) -> void:

--- a/src/Palette/EditPaletteDialog.gd
+++ b/src/Palette/EditPaletteDialog.gd
@@ -5,6 +5,7 @@ signal saved(name, comment, width, height)
 signal deleted
 
 const DELETE_ACTION := "delete"
+const BIN_ACTION := "trash"
 
 # Keeps original size of edited palette
 var origin_width := 0
@@ -20,11 +21,13 @@ var old_name := ""
 
 @onready var size_reduced_warning := $VBoxContainer/SizeReducedWarning
 @onready var already_exists_warning := $VBoxContainer/AlreadyExistsWarning
+@onready var delete_confirmation: AcceptDialog = $DeleteConfirmation
 
 
 func _ready() -> void:
 	# Add delete button to edit palette dialog
 	add_button(tr("Delete"), false, DELETE_ACTION)
+	delete_confirmation.add_button("Move to Trash", false, BIN_ACTION)
 
 
 func open(current_palette: Palette) -> void:
@@ -78,8 +81,20 @@ func _on_EditPaletteDialog_confirmed() -> void:
 
 func _on_EditPaletteDialog_custom_action(action: String) -> void:
 	if action == DELETE_ACTION:
+		delete_confirmation.popup_centered()
+
+
+func _on_delete_confirmation_confirmed() -> void:
+	deleted.emit(true)
+	delete_confirmation.hide()
+	hide()
+
+
+func _on_delete_confirmation_custom_action(action: StringName) -> void:
+	if action == BIN_ACTION:
+		deleted.emit(false)
+		delete_confirmation.hide()
 		hide()
-		deleted.emit()
 
 
 func _on_size_value_changed(_value):

--- a/src/Palette/EditPaletteDialog.tscn
+++ b/src/Palette/EditPaletteDialog.tscn
@@ -3,6 +3,8 @@
 [ext_resource type="Script" path="res://src/Palette/EditPaletteDialog.gd" id="1"]
 
 [node name="EditPaletteDialog" type="ConfirmationDialog"]
+title = "Edit Palette"
+size = Vector2i(409, 535)
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
@@ -12,10 +14,11 @@ anchor_bottom = 1.0
 offset_left = 8.0
 offset_top = 8.0
 offset_right = -8.0
-offset_bottom = -36.0
+offset_bottom = -49.0
 
 [node name="PaletteMetadata" type="GridContainer" parent="VBoxContainer"]
 layout_mode = 2
+size_flags_vertical = 3
 columns = 2
 
 [node name="NameLabel" type="Label" parent="VBoxContainer/PaletteMetadata"]
@@ -31,12 +34,14 @@ size_flags_horizontal = 3
 [node name="CommentLabel" type="Label" parent="VBoxContainer/PaletteMetadata"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
+size_flags_vertical = 0
 text = "Comment:"
 
 [node name="Comment" type="TextEdit" parent="VBoxContainer/PaletteMetadata"]
 custom_minimum_size = Vector2(0, 75)
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_vertical = 3
 
 [node name="WidthLabel" type="Label" parent="VBoxContainer/PaletteMetadata"]
 layout_mode = 2
@@ -64,9 +69,9 @@ value = 1.0
 
 [node name="PathLabel" type="Label" parent="VBoxContainer/PaletteMetadata"]
 layout_mode = 2
-text = "Path3D:"
+text = "Path:"
 
-[node name="Path3D" type="TextEdit" parent="VBoxContainer/PaletteMetadata"]
+[node name="Path" type="TextEdit" parent="VBoxContainer/PaletteMetadata"]
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -75,11 +80,17 @@ size_flags_horizontal = 3
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 0.603922, 0.603922, 1)
 text = "Reducing palette size will reset positions of colors. Colors that don't fit in new palette size will be lost!"
+horizontal_alignment = 1
+vertical_alignment = 2
+autowrap_mode = 3
 
 [node name="AlreadyExistsWarning" type="Label" parent="VBoxContainer"]
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 0.603922, 0.603922, 1)
 text = "Palette with the same name and path already exists!"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 3
 
 [connection signal="confirmed" from="." to="." method="_on_EditPaletteDialog_confirmed"]
 [connection signal="custom_action" from="." to="." method="_on_EditPaletteDialog_custom_action"]

--- a/src/Palette/EditPaletteDialog.tscn
+++ b/src/Palette/EditPaletteDialog.tscn
@@ -92,7 +92,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 autowrap_mode = 3
 
-[node name="DeleteConfirmation" type="AcceptDialog" parent="."]
+[node name="DeleteConfirmation" type="ConfirmationDialog" parent="."]
 size = Vector2i(445, 105)
 ok_button_text = "Delete Permanently"
 

--- a/src/Palette/EditPaletteDialog.tscn
+++ b/src/Palette/EditPaletteDialog.tscn
@@ -4,7 +4,7 @@
 
 [node name="EditPaletteDialog" type="ConfirmationDialog"]
 title = "Edit Palette"
-size = Vector2i(409, 535)
+size = Vector2i(409, 559)
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
@@ -92,9 +92,29 @@ horizontal_alignment = 1
 vertical_alignment = 1
 autowrap_mode = 3
 
+[node name="DeleteConfirmation" type="AcceptDialog" parent="."]
+size = Vector2i(445, 105)
+ok_button_text = "Delete Permanently"
+
+[node name="Label" type="Label" parent="DeleteConfirmation"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Delete Palette?"
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [connection signal="confirmed" from="." to="." method="_on_EditPaletteDialog_confirmed"]
 [connection signal="custom_action" from="." to="." method="_on_EditPaletteDialog_custom_action"]
 [connection signal="visibility_changed" from="." to="." method="_on_EditPaletteDialog_visibility_changed"]
 [connection signal="text_changed" from="VBoxContainer/PaletteMetadata/Name" to="." method="_on_Name_text_changed"]
 [connection signal="value_changed" from="VBoxContainer/PaletteMetadata/Width" to="." method="_on_size_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/PaletteMetadata/Height" to="." method="_on_size_value_changed"]
+[connection signal="confirmed" from="DeleteConfirmation" to="." method="_on_delete_confirmation_confirmed"]
+[connection signal="custom_action" from="DeleteConfirmation" to="." method="_on_delete_confirmation_custom_action"]

--- a/src/Palette/PalettePanel.gd
+++ b/src/Palette/PalettePanel.gd
@@ -215,8 +215,8 @@ func _on_HiddenColorPickerButton_popup_closed():
 	Palettes.current_palette_set_color(edited_swatch_index, edited_swatch_color)
 
 
-func _on_EditPaletteDialog_deleted() -> void:
-	Palettes.current_palete_delete()
+func _on_EditPaletteDialog_deleted(permanent: bool) -> void:
+	Palettes.current_palete_delete(permanent)
 	setup_palettes_selector()
 	redraw_current_palette()
 

--- a/src/UI/ReferenceImages/ReferenceImageButton.gd
+++ b/src/UI/ReferenceImages/ReferenceImageButton.gd
@@ -7,11 +7,11 @@ var _ignore_spinbox_changes := false
 
 func _ready():
 	if OS.get_name() == "Web":
-		$Interior/PathHeader/Path3D.visible = false
+		$Interior/PathHeader/Path.visible = false
 		$Interior/PathHeader/PathHTML.text = element.image_path
 	else:
 		$Interior/PathHeader/PathHTML.visible = false
-		$Interior/PathHeader/Path3D.text = element.image_path
+		$Interior/PathHeader/Path.text = element.image_path
 
 	if !element.texture:
 		$Interior/PreviewAndOptions/PreviewPanel/Warning.text = "Image not found!"
@@ -79,7 +79,7 @@ func _on_Opacity_value_changed(value: float):
 
 
 func _on_Path_pressed() -> void:
-	OS.shell_open($Interior/PathHeader/Path3D.text.get_base_dir())
+	OS.shell_open($Interior/PathHeader/Path.text.get_base_dir())
 
 
 func _on_Silhouette_toggled(button_pressed: bool) -> void:

--- a/src/UI/ReferenceImages/ReferenceImageButton.tscn
+++ b/src/UI/ReferenceImages/ReferenceImageButton.tscn
@@ -19,7 +19,7 @@ layout_mode = 2
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="Path3D" type="LinkButton" parent="Interior/PathHeader"]
+[node name="Path" type="LinkButton" parent="Interior/PathHeader"]
 modulate = Color(0.552941, 1, 0.298039, 1)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -117,7 +117,7 @@ layout_mode = 2
 theme_override_colors/font_color = Color(1, 0.266667, 0.266667, 1)
 text = "Remove"
 
-[connection signal="pressed" from="Interior/PathHeader/Path3D" to="." method="_on_Path_pressed"]
+[connection signal="pressed" from="Interior/PathHeader/Path" to="." method="_on_Path_pressed"]
 [connection signal="value_changed" from="Interior/PreviewAndOptions/Options/Position/X" to="." method="_on_X_value_changed"]
 [connection signal="value_changed" from="Interior/PreviewAndOptions/Options/Position/Y" to="." method="_on_Y_value_changed"]
 [connection signal="value_changed" from="Interior/PreviewAndOptions/Options/Scale" to="." method="_on_Scale_value_changed"]


### PR DESCRIPTION
Some additional changes that I thought be added to this pull request.

1. Fix deleted signal emitted wrongly
   - it was written as `deleted.emit(deleted)` which did not seem to be working so i changed it to `deleted.emit()`

2. Fix create and edit palette dialog UI
    - Dialog titles of `CreatePaletteDialog.tscn` and `EditPaletteDialog.tscn`
    - Label Autowrap and alignment to match how they were in v0.11.2 (In `CreatePaletteDialog.tscn` and `EditPaletteDialog.tscn`)
    - a minor ui change in `EditPaletteDialog.tscn` that allows comment to expand vertically

3. fix path nodes renamed to path3d by godot project converter
    - `ReferenceImageButton.tscn` and `EditPaletteDialog.tscn`