### PR TITLE
Added new signals

### DIFF
--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -551,75 +551,75 @@ class SignalsAPI:
 
 	# GLOBAL SIGNALS
 	# pixelorama_opened
-	func connect_pixelorama_opened(target: Object, method: String):
-		Global.pixelorama_opened.connect(Callable(target, method))
+	func connect_pixelorama_opened(callable: Callable):
+		Global.pixelorama_opened.connect(callable)
 		ExtensionsApi.add_action("pixelorama_opened")
 
-	func disconnect_pixelorama_opened(target: Object, method: String):
-		Global.pixelorama_opened.disconnect(Callable(target, method))
+	func disconnect_pixelorama_opened(callable: Callable):
+		Global.pixelorama_opened.disconnect(callable)
 		ExtensionsApi.remove_action("pixelorama_opened")
 
 	# pixelorama_about_to_close
-	func connect_pixelorama_about_to_close(target: Object, method: String):
-		Global.pixelorama_about_to_close.connect(Callable(target, method))
+	func connect_pixelorama_about_to_close(callable: Callable):
+		Global.pixelorama_about_to_close.connect(callable)
 		ExtensionsApi.add_action("pixelorama_about_to_close")
 
-	func disconnect_pixelorama_about_to_close(target: Object, method: String):
-		Global.pixelorama_about_to_close.disconnect(Callable(target, method))
+	func disconnect_pixelorama_about_to_close(callable: Callable):
+		Global.pixelorama_about_to_close.disconnect(callable)
 		ExtensionsApi.remove_action("pixelorama_about_to_close")
 
 	# project_created -> signal has argument of type "Project"
-	func connect_project_created(target: Object, method: String):
-		Global.project_created.connect(Callable(target, method))
+	func connect_project_created(callable: Callable):
+		Global.project_created.connect(callable)
 		ExtensionsApi.add_action("project_created")
 
-	func disconnect_project_created(target: Object, method: String):
-		Global.project_created.disconnect(Callable(target, method))
+	func disconnect_project_created(callable: Callable):
+		Global.project_created.disconnect(callable)
 		ExtensionsApi.remove_action("project_created")
 
 	# project_saved
-	func connect_project_about_to_save(target: Object, method: String):
-		Global.project_saved.connect(Callable(target, method))
+	func connect_project_about_to_save(callable: Callable):
+		Global.project_saved.connect(callable)
 		ExtensionsApi.add_action("project_saved")
 
-	func disconnect_project_saved(target: Object, method: String):
-		Global.project_saved.disconnect(Callable(target, method))
+	func disconnect_project_saved(callable: Callable):
+		Global.project_saved.disconnect(callable)
 		ExtensionsApi.remove_action("project_saved")
 
 	# project_changed
-	func connect_project_changed(target: Object, method: String):
-		Global.project_changed.connect(Callable(target, method))
+	func connect_project_changed(callable: Callable):
+		Global.project_changed.connect(callable)
 		ExtensionsApi.add_action("project_changed")
 
-	func disconnect_project_changed(target: Object, method: String):
-		Global.project_changed.disconnect(Callable(target, method))
+	func disconnect_project_changed(callable: Callable):
+		Global.project_changed.disconnect(callable)
 		ExtensionsApi.remove_action("project_changed")
 
 	# cel_changed
-	func connect_cel_changed(target: Object, method: String):
-		Global.cel_changed.connect(Callable(target, method))
+	func connect_cel_changed(callable: Callable):
+		Global.cel_changed.connect(callable)
 		ExtensionsApi.add_action("cel_changed")
 
-	func disconnect_cel_changed(target: Object, method: String):
-		Global.cel_changed.disconnect(Callable(target, method))
+	func disconnect_cel_changed(callable: Callable):
+		Global.cel_changed.disconnect(callable)
 		ExtensionsApi.remove_action("cel_changed")
 
 	# TOOL SIGNALs
 	# cel_changed
-	func connect_tool_color_changed(target: Object, method: String):
-		Tools.color_changed.connect(Callable(target, method))
+	func connect_tool_color_changed(callable: Callable):
+		Tools.color_changed.connect(callable)
 		ExtensionsApi.add_action("color_changed")
 
-	func disconnect_tool_color_changed(target: Object, method: String):
-		Tools.color_changed.disconnect(Callable(target, method))
+	func disconnect_tool_color_changed(callable: Callable):
+		Tools.color_changed.disconnect(callable)
 		ExtensionsApi.remove_action("color_changed")
 
 	# UPDATER SIGNALS
 	# current_cel_texture_changed
-	func connect_current_cel_texture_changed(target: Object, method: String):
-		texture_changed.connect(Callable(target, method))
+	func connect_current_cel_texture_changed(callable: Callable):
+		texture_changed.connect(callable)
 		ExtensionsApi.add_action("texture_changed")
 
-	func disconnect_current_cel_texture_changed(target: Object, method: String):
-		texture_changed.disconnect(Callable(target, method))
+	func disconnect_current_cel_texture_changed(callable: Callable):
+		texture_changed.disconnect(callable)
 		ExtensionsApi.remove_action("texture_changed")

--- a/src/Autoload/ExtensionsAPI.gd
+++ b/src/Autoload/ExtensionsAPI.gd
@@ -94,7 +94,7 @@ class GeneralAPI:
 	func get_drawing_algos() -> DrawingAlgos:
 		return DrawingAlgos
 
-	func get_shader_image_effect() -> ShaderImageEffect:
+	func get_new_shader_image_effect() -> ShaderImageEffect:
 		return ShaderImageEffect.new()
 
 	func get_extensions_node() -> Node:
@@ -549,7 +549,44 @@ class SignalsAPI:
 	func _on_texture_changed():
 		texture_changed.emit()
 
-	# Global signals
+	# GLOBAL SIGNALS
+	# pixelorama_opened
+	func connect_pixelorama_opened(target: Object, method: String):
+		Global.pixelorama_opened.connect(Callable(target, method))
+		ExtensionsApi.add_action("pixelorama_opened")
+
+	func disconnect_pixelorama_opened(target: Object, method: String):
+		Global.pixelorama_opened.disconnect(Callable(target, method))
+		ExtensionsApi.remove_action("pixelorama_opened")
+
+	# pixelorama_about_to_close
+	func connect_pixelorama_about_to_close(target: Object, method: String):
+		Global.pixelorama_about_to_close.connect(Callable(target, method))
+		ExtensionsApi.add_action("pixelorama_about_to_close")
+
+	func disconnect_pixelorama_about_to_close(target: Object, method: String):
+		Global.pixelorama_about_to_close.disconnect(Callable(target, method))
+		ExtensionsApi.remove_action("pixelorama_about_to_close")
+
+	# project_created -> signal has argument of type "Project"
+	func connect_project_created(target: Object, method: String):
+		Global.project_created.connect(Callable(target, method))
+		ExtensionsApi.add_action("project_created")
+
+	func disconnect_project_created(target: Object, method: String):
+		Global.project_created.disconnect(Callable(target, method))
+		ExtensionsApi.remove_action("project_created")
+
+	# project_saved
+	func connect_project_about_to_save(target: Object, method: String):
+		Global.project_saved.connect(Callable(target, method))
+		ExtensionsApi.add_action("project_saved")
+
+	func disconnect_project_saved(target: Object, method: String):
+		Global.project_saved.disconnect(Callable(target, method))
+		ExtensionsApi.remove_action("project_saved")
+
+	# project_changed
 	func connect_project_changed(target: Object, method: String):
 		Global.project_changed.connect(Callable(target, method))
 		ExtensionsApi.add_action("project_changed")
@@ -558,6 +595,7 @@ class SignalsAPI:
 		Global.project_changed.disconnect(Callable(target, method))
 		ExtensionsApi.remove_action("project_changed")
 
+	# cel_changed
 	func connect_cel_changed(target: Object, method: String):
 		Global.cel_changed.connect(Callable(target, method))
 		ExtensionsApi.add_action("cel_changed")
@@ -566,7 +604,8 @@ class SignalsAPI:
 		Global.cel_changed.disconnect(Callable(target, method))
 		ExtensionsApi.remove_action("cel_changed")
 
-	# Tool Signal
+	# TOOL SIGNALs
+	# cel_changed
 	func connect_tool_color_changed(target: Object, method: String):
 		Tools.color_changed.connect(Callable(target, method))
 		ExtensionsApi.add_action("color_changed")
@@ -575,7 +614,8 @@ class SignalsAPI:
 		Tools.color_changed.disconnect(Callable(target, method))
 		ExtensionsApi.remove_action("color_changed")
 
-	# updater signals
+	# UPDATER SIGNALS
+	# current_cel_texture_changed
 	func connect_current_cel_texture_changed(target: Object, method: String):
 		texture_changed.connect(Callable(target, method))
 		ExtensionsApi.add_action("texture_changed")

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -1,5 +1,8 @@
 extends Node
 
+signal pixelorama_opened
+signal pixelorama_about_to_close
+signal project_created(Project)
 signal project_changed
 signal cel_changed
 

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -302,7 +302,7 @@ func save_pxo_file(
 		Global.top_menu_container.file_menu.set_item_text(
 			Global.FileMenu.SAVE, tr("Save") + " %s" % path.get_file()
 		)
-		Global.project_saved.emit()
+		project_saved.emit()
 
 	save_project_to_recent_list(path)
 

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -1,6 +1,8 @@
 # gdlint: ignore=max-public-methods
 extends Node
 
+signal project_saved
+
 var current_save_paths: PackedStringArray = []
 ## Stores a filename of a backup file in user:// until user saves manually
 var backup_save_paths: PackedStringArray = []
@@ -300,6 +302,7 @@ func save_pxo_file(
 		Global.top_menu_container.file_menu.set_item_text(
 			Global.FileMenu.SAVE, tr("Save") + " %s" % path.get_file()
 		)
+		Global.project_saved.emit()
 
 	save_project_to_recent_list(path)
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -3,6 +3,9 @@ class_name Project
 extends RefCounted
 ## A class for project properties.
 
+signal about_to_serialize
+signal about_to_deserialize(Dictionary)
+
 var name := "":
 	set(value):
 		name = value
@@ -102,6 +105,7 @@ func _init(_frames: Array[Frame] = [], _name := tr("untitled"), _size := Vector2
 		directory_path = Global.config_cache.get_value(
 			"data", "current_dir", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP)
 		)
+	Global.project_created.emit(self)
 
 
 func remove() -> void:
@@ -256,6 +260,7 @@ func change_project() -> void:
 
 
 func serialize() -> Dictionary:
+	about_to_serialize.emit()
 	var layer_data := []
 	for layer in layers:
 		layer_data.append(layer.serialize())
@@ -336,6 +341,7 @@ func serialize() -> Dictionary:
 
 
 func deserialize(dict: Dictionary) -> void:
+	about_to_deserialize.emit(dict)
 	if dict.has("size_x") and dict.has("size_y"):
 		size.x = dict.size_x
 		size.y = dict.size_y

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -3,7 +3,7 @@ class_name Project
 extends RefCounted
 ## A class for project properties.
 
-signal about_to_serialize
+signal serialized(Dictionary)
 signal about_to_deserialize(Dictionary)
 
 var name := "":
@@ -260,7 +260,6 @@ func change_project() -> void:
 
 
 func serialize() -> Dictionary:
-	about_to_serialize.emit()
 	var layer_data := []
 	for layer in layers:
 		layer_data.append(layer.serialize())
@@ -337,6 +336,7 @@ func serialize() -> Dictionary:
 		"metadata": metadata
 	}
 
+	serialized.emit(project_data)
 	return project_data
 
 

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -67,6 +67,7 @@ func _ready() -> void:
 		OS.request_permissions()
 
 	_show_splash_screen()
+	Global.pixelorama_opened.emit()
 
 
 func _input(event: InputEvent) -> void:
@@ -347,6 +348,7 @@ func _on_QuitAndSaveDialog_confirmed() -> void:
 
 
 func _quit() -> void:
+	Global.pixelorama_about_to_close.emit()
 	# Darken the UI to denote that the application is currently exiting
 	# (it won't respond to user input in this state).
 	modulate = Color(0.5, 0.5, 0.5)


### PR DESCRIPTION
Global (also accessible directly from ExtensionAPI)

- pixelorama_opened
- pixelorama_about_to_close
- project_created(Project)

### (advanced signals for advanced users)
Project.gd:

- serialized(Dictionary)
- about_to_deserialize(Dictionary)

OpenSave:

- project_saved

### Extra:
SignalsAPI now uses Callables