### PR TITLE
[0.x] Fix cel3d compatibility when transferring project from 1.0 to 0.x

### DIFF
--- a/src/Classes/Cel3D.gd
+++ b/src/Classes/Cel3D.gd
@@ -232,18 +232,14 @@ func convert_1x_to_0x(dict: Dictionary) -> void:
 				object_info["mesh_radius"] *= 2
 				object_info["mesh_height"] *= 2
 			2:  # CAPSULE
-				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
-#				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.LEFT, deg2rad(90))
-				var euler = object_info["transform"].basis.get_euler()
-				# the 3 lines below resets all rotations
-				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.RIGHT, euler.x)
-				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.UP, euler.y)
-				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.FORWARD, euler.z)
-				# set new transformations (Todo: i haven't found how to do it yet)
+				object_info["transform"] = object_info["transform"].scaled(-(Vector3.ONE / 2))
+				var basis = object_info["transform"].basis
+				var new_transform: Transform = Transform(basis.x, -basis.z, -basis.y, origin)
+				object_info["transform"] = new_transform
 				object_info["transform"].origin = origin
 				object_info["mesh_radius"] *= 2
 				object_info["mesh_mid_height"] = (
-					object_info["mesh_height"] - object_info["mesh_radius"]
+					object_info["mesh_height"] - (object_info["mesh_radius"] / 2)
 				)
 			3:  # CYLINDER
 				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)

--- a/src/Classes/Cel3D.gd
+++ b/src/Classes/Cel3D.gd
@@ -177,6 +177,9 @@ func serialize() -> Dictionary:
 
 
 func deserialize(dict: Dictionary) -> void:
+	if dict.has("pxo_version"):
+		if dict["pxo_version"] == 3:  # It's a 1.x project convert it to 0.x format
+			convert_1x_to_0x(dict)
 	.deserialize(dict)
 	scene_properties = dict["scene_properties"]
 	var objects_copy = dict["object_properties"]
@@ -193,6 +196,59 @@ func deserialize(dict: Dictionary) -> void:
 	deserialize_scene_properties()
 	for object in object_properties:
 		_add_object_node(object)
+
+
+## Used to convert 3d cels found in projects exported from a 0.x version to 1.x
+func convert_1x_to_0x(dict: Dictionary) -> void:
+	# Converting the scene dictionary
+	var scene_dict: Dictionary = dict["scene_properties"]
+	scene_dict["camera_transform"] = str2var(
+		scene_dict["camera_transform"].replace("Transform3D", "Transform")
+	)
+	scene_dict["camera_projection"] = str2var(scene_dict["camera_projection"])
+	scene_dict["camera_fov"] = str2var(scene_dict["camera_fov"])
+	scene_dict["camera_size"] = str2var(scene_dict["camera_size"])
+	scene_dict["ambient_light_color"] = str2var(scene_dict["ambient_light_color"])
+	scene_dict["ambient_light_energy"] = str2var(scene_dict["ambient_light_energy"])
+	# Converting the objects dictionary
+	var objects_copy: Dictionary = dict["object_properties"]
+	for object_id_as_str in objects_copy.keys():
+		objects_copy[object_id_as_str] = str2var(
+			objects_copy[object_id_as_str].replace("Transform3D", "Transform")
+		)
+		# we are using a separate variable to make it easy to write
+		var object_info: Dictionary = objects_copy[object_id_as_str]
+		# Special operations to adjust gizmo
+		match object_info["type"]:
+			0:  # BOX
+				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["mesh_size"] *= 2
+			1:  # SPHERE
+				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["mesh_radius"] *= 2
+				object_info["mesh_height"] *= 2
+			2:  # CAPSULE
+				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.RIGHT, deg2rad(-90))
+				object_info["mesh_radius"] *= 2
+				object_info["mesh_mid_height"] = (
+					object_info["mesh_height"] - object_info["mesh_radius"]
+				)
+			3:  # CYLINDER
+				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["mesh_height"] *= 2
+				object_info["mesh_bottom_radius"] *= 2
+				object_info["mesh_top_radius"] *= 2
+			4:  # PRISM
+				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["mesh_size"] *= 2
+			6:  # PLANE
+				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["mesh_sizev2"] *= 2
+			_:
+				if not "shadow_color" in object_info.keys():
+					object_info["shadow_color"] = Color.black
+		objects_copy[object_id_as_str] = objects_copy[object_id_as_str]
 
 
 func on_remove() -> void:

--- a/src/Classes/Cel3D.gd
+++ b/src/Classes/Cel3D.gd
@@ -239,7 +239,8 @@ func convert_1x_to_0x(dict: Dictionary) -> void:
 				object_info["transform"].origin = origin
 				object_info["mesh_radius"] *= 2
 				object_info["mesh_mid_height"] = (
-					object_info["mesh_height"] - (object_info["mesh_radius"] / 2)
+					object_info["mesh_height"]
+					- (object_info["mesh_radius"] / 2)
 				)
 			3:  # CYLINDER
 				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)

--- a/src/Classes/Cel3D.gd
+++ b/src/Classes/Cel3D.gd
@@ -219,31 +219,45 @@ func convert_1x_to_0x(dict: Dictionary) -> void:
 		# we are using a separate variable to make it easy to write
 		var object_info: Dictionary = objects_copy[object_id_as_str]
 		# Special operations to adjust gizmo
+		# take note of origin
+		var origin = object_info["transform"].origin
 		match object_info["type"]:
 			0:  # BOX
 				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["transform"].origin = origin
 				object_info["mesh_size"] *= 2
 			1:  # SPHERE
 				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["transform"].origin = origin
 				object_info["mesh_radius"] *= 2
 				object_info["mesh_height"] *= 2
 			2:  # CAPSULE
 				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
-				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.RIGHT, deg2rad(-90))
+#				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.LEFT, deg2rad(90))
+				var euler = object_info["transform"].basis.get_euler()
+				# the 3 lines below resets all rotations
+				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.RIGHT, euler.x)
+				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.UP, euler.y)
+				object_info["transform"].basis = object_info["transform"].basis.rotated(Vector3.FORWARD, euler.z)
+				# set new transformations (Todo: i haven't found how to do it yet)
+				object_info["transform"].origin = origin
 				object_info["mesh_radius"] *= 2
 				object_info["mesh_mid_height"] = (
 					object_info["mesh_height"] - object_info["mesh_radius"]
 				)
 			3:  # CYLINDER
 				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["transform"].origin = origin
 				object_info["mesh_height"] *= 2
 				object_info["mesh_bottom_radius"] *= 2
 				object_info["mesh_top_radius"] *= 2
 			4:  # PRISM
 				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["transform"].origin = origin
 				object_info["mesh_size"] *= 2
 			6:  # PLANE
 				object_info["transform"] = object_info["transform"].scaled(Vector3.ONE / 2)
+				object_info["transform"].origin = origin
 				object_info["mesh_sizev2"] *= 2
 			_:
 				if not "shadow_color" in object_info.keys():

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -380,6 +380,8 @@ func deserialize(dict: Dictionary) -> void:
 						cels.append(GroupCel.new())
 					Global.LayerTypes.THREE_D:
 						cels.append(Cel3D.new(size, true))
+				if dict.has("pxo_version"):
+					cel["pxo_version"] = dict["pxo_version"]
 				cels[cel_i].deserialize(cel)
 				_deserialize_metadata(cels[cel_i], cel)
 				cel_i += 1


### PR DESCRIPTION
3d cels should be backwards compatible now as well in case user decides to switch back to 0.x for it's lighting