### PR TITLE
Improve cel3d Gizmos

### DIFF
--- a/src/UI/Canvas/Gizmos3D.gd
+++ b/src/UI/Canvas/Gizmos3D.gd
@@ -8,6 +8,7 @@ const GIZMO_WIDTH := 1.1
 const SCALE_CIRCLE_LENGTH := 8
 const SCALE_CIRCLE_RADIUS := 1
 const CHAR_SCALE := 0.16
+const DISAPPEAR_THRESHOLD := 1  ## length of arrow below which system wont draw it (for cleaner UI)
 
 var always_visible := {}  ## Key = Cel3DObject, Value = Texture2D
 var points_per_object := {}  ## Key = Cel3DObject, Value = PackedVector2Array
@@ -46,18 +47,18 @@ func get_hovering_gizmo(pos: Vector2) -> int:
 	var rot_y_offset := Geometry2D.offset_polyline(gizmo_rot_y, 1)[0]
 	var rot_z_offset := Geometry2D.offset_polyline(gizmo_rot_z, 1)[0]
 
-	if Geometry2D.point_is_inside_triangle(pos, gizmo_pos_x[0], gizmo_pos_x[1], gizmo_pos_x[2]):
-		return Cel3DObject.Gizmos.X_POS
-	elif Geometry2D.point_is_inside_triangle(pos, gizmo_pos_y[0], gizmo_pos_y[1], gizmo_pos_y[2]):
-		return Cel3DObject.Gizmos.Y_POS
-	elif Geometry2D.point_is_inside_triangle(pos, gizmo_pos_z[0], gizmo_pos_z[1], gizmo_pos_z[2]):
-		return Cel3DObject.Gizmos.Z_POS
-	elif Geometry2D.is_point_in_circle(pos, proj_right_local_scale, SCALE_CIRCLE_RADIUS):
+	if Geometry2D.is_point_in_circle(pos, proj_right_local_scale, SCALE_CIRCLE_RADIUS):
 		return Cel3DObject.Gizmos.X_SCALE
 	elif Geometry2D.is_point_in_circle(pos, proj_up_local_scale, SCALE_CIRCLE_RADIUS):
 		return Cel3DObject.Gizmos.Y_SCALE
 	elif Geometry2D.is_point_in_circle(pos, proj_back_local_scale, SCALE_CIRCLE_RADIUS):
 		return Cel3DObject.Gizmos.Z_SCALE
+	elif Geometry2D.point_is_inside_triangle(pos, gizmo_pos_x[0], gizmo_pos_x[1], gizmo_pos_x[2]):
+		return Cel3DObject.Gizmos.X_POS
+	elif Geometry2D.point_is_inside_triangle(pos, gizmo_pos_y[0], gizmo_pos_y[1], gizmo_pos_y[2]):
+		return Cel3DObject.Gizmos.Y_POS
+	elif Geometry2D.point_is_inside_triangle(pos, gizmo_pos_z[0], gizmo_pos_z[1], gizmo_pos_z[2]):
+		return Cel3DObject.Gizmos.Z_POS
 	elif Geometry2D.is_point_in_polygon(pos, rot_x_offset):
 		return Cel3DObject.Gizmos.X_ROT
 	elif Geometry2D.is_point_in_polygon(pos, rot_y_offset):
@@ -197,12 +198,15 @@ func _draw() -> void:
 				continue
 			draw_set_transform(gizmos_origin, 0, draw_scale)
 			# Draw position arrows
-			draw_line(Vector2.ZERO, proj_right_local, Color.RED)
-			draw_line(Vector2.ZERO, proj_up_local, Color.GREEN)
-			draw_line(Vector2.ZERO, proj_back_local, Color.BLUE)
-			_draw_arrow(gizmo_pos_x, Color.RED)
-			_draw_arrow(gizmo_pos_y, Color.GREEN)
-			_draw_arrow(gizmo_pos_z, Color.BLUE)
+			if proj_right_local.length() > DISAPPEAR_THRESHOLD:
+				draw_line(Vector2.ZERO, proj_right_local, Color.RED)
+				_draw_arrow(gizmo_pos_x, Color.RED)
+			if proj_up_local.length() > DISAPPEAR_THRESHOLD:
+				draw_line(Vector2.ZERO, proj_up_local, Color.GREEN)
+				_draw_arrow(gizmo_pos_y, Color.GREEN)
+			if proj_back_local.length() > DISAPPEAR_THRESHOLD:
+				draw_line(Vector2.ZERO, proj_back_local, Color.BLUE)
+				_draw_arrow(gizmo_pos_z, Color.BLUE)
 
 			# Draw rotation curves
 			draw_polyline(gizmo_rot_x, Color.RED, GIZMO_WIDTH)
@@ -227,7 +231,8 @@ func _draw() -> void:
 			draw_multiline(points, hovered_color, 1.0)
 
 
-func _resize_vector(v: Vector2, l: float) -> Vector2:
+## resizes the vector [param v] by amount [param l] but clamps the resized length to original length
+func _resize_vector(v: Vector2, l: float, max_length := 0) -> Vector2:
 	return (v.normalized() * l).limit_length(v.length())
 
 
@@ -244,6 +249,9 @@ func _find_curve(a: Vector2, b: Vector2) -> PackedVector2Array:
 
 
 func _find_arrow(a: Vector2, tilt := 0.5) -> PackedVector2Array:
+	# The middle point of line between b and c will now touch the
+	# starting point instead of the original "a" vector
+	a -= Vector2(0, 1).rotated(a.angle() + PI / 2) * 2
 	var b := a + Vector2(-tilt, 1).rotated(a.angle() + PI / 2) * 2
 	var c := a + Vector2(tilt, 1).rotated(a.angle() + PI / 2) * 2
 	return PackedVector2Array([a, b, c])


### PR DESCRIPTION
- The axis arrow will disappear if it comes very close to the origin to make the gizmos more cleaner.
- The axis arrows will always remain ahead of the scale circle
- If both arrow and scale icon end up being in the same place then the scale function will take priority

https://github.com/Orama-Interactive/Pixelorama/assets/77773850/cc327196-c78c-4da4-a432-eecb7f8ab825

