### PR TITLE
Change the file format of pxo to be a ZIP

### DIFF
--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -82,7 +82,14 @@ msgstr ""
 msgid "Save as..."
 msgstr ""
 
-msgid "Use ZSTD Compression"
+#. Checkbox found in the Save project dialog. If enabled, the final blended images are being stored also in the pxo, for each frame.
+msgid "Include blended images"
+msgstr ""
+
+#. Hint tooltip of the "Include blended images" checkbox found in the Save project dialog.
+msgid "If enabled, the final blended images are also being stored in the pxo, for each frame.\n"
+"This makes the pxo file larger and is useful for importing by third-party software\n"
+"or CLI exporting. Loading pxo files in Pixelorama does not need this option to be enabled.\n"
 msgstr ""
 
 msgid "Import"

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -113,19 +113,6 @@ func handle_loading_aimg(path: String, frames: Array) -> void:
 
 
 func open_pxo_file(path: String, untitled_backup := false, replace_empty := true) -> void:
-	var file := FileAccess.open_compressed(path, FileAccess.READ, FileAccess.COMPRESSION_ZSTD)
-	if FileAccess.get_open_error() == ERR_FILE_UNRECOGNIZED:
-		# If the file is not compressed open it raw (pre-v0.7)
-		file = FileAccess.open(path, FileAccess.READ)
-	var err := FileAccess.get_open_error()
-	if err != OK:
-		Global.error_dialog.set_text(
-			tr("File failed to open. Error code %s (%s)") % [err, error_string(err)]
-		)
-		Global.error_dialog.popup_centered()
-		Global.dialog_open(true)
-		return
-
 	var empty_project := Global.current_project.is_empty() and replace_empty
 	var new_project: Project
 	if empty_project:
@@ -136,50 +123,72 @@ func open_pxo_file(path: String, untitled_backup := false, replace_empty := true
 		new_project.name = path.get_file()
 	else:
 		new_project = Project.new([], path.get_file())
-
-	var first_line := file.get_line()
-	var test_json_conv := JSON.new()
-	var error := test_json_conv.parse(first_line)
-	if error != OK:
-		print("Error, corrupt pxo file")
-		file.close()
+	var zip_reader := ZIPReader.new()
+	var err := zip_reader.open(path)
+	if err == FAILED:
+		var success := open_v0_pxo_file(path, new_project)
+		if not success:
+			return
+	elif err != OK:
+		Global.error_dialog.set_text(
+			tr("File failed to open. Error code %s (%s)") % [err, error_string(err)]
+		)
+		Global.error_dialog.popup_centered()
+		Global.dialog_open(true)
 		return
 	else:
+		var data_json := zip_reader.read_file("data.json").get_string_from_utf8()
+		var test_json_conv := JSON.new()
+		var error := test_json_conv.parse(data_json)
+		if error != OK:
+			print("Error, corrupt pxo file")
+			zip_reader.close()
+			return
 		var result = test_json_conv.get_data()
 		if typeof(result) != TYPE_DICTIONARY:
 			print("Error, json parsed result is: %s" % typeof(result))
-			file.close()
+			zip_reader.close()
 			return
 
 		new_project.deserialize(result)
-		for frame in new_project.frames:
-			for cel in frame.cels:
-				cel.load_image_data_from_pxo(file, new_project.size)
-
-		if result.has("brushes"):
-			for brush in result.brushes:
-				var b_width = brush.size_x
-				var b_height = brush.size_y
-				var buffer := file.get_buffer(b_width * b_height * 4)
+		for frame_index in new_project.frames.size():
+			var frame := new_project.frames[frame_index]
+			for cel_index in frame.cels.size():
+				var cel := frame.cels[cel_index]
+				if not cel is PixelCel:
+					continue
+				var image_data := zip_reader.read_file(
+					"image_data/frames/%s/layer_%s" % [frame_index + 1, cel_index + 1]
+				)
 				var image := Image.create_from_data(
-					b_width, b_height, false, Image.FORMAT_RGBA8, buffer
+					new_project.size.x, new_project.size.y, false, Image.FORMAT_RGBA8, image_data
+				)
+				cel.image_changed(image)
+		if result.has("brushes"):
+			var brush_index := 0
+			for brush in result.brushes:
+				var b_width: int = brush.size_x
+				var b_height: int = brush.size_y
+				var image_data := zip_reader.read_file("image_data/brushes/brush_%s" % brush_index)
+				var image := Image.create_from_data(
+					b_width, b_height, false, Image.FORMAT_RGBA8, image_data
 				)
 				new_project.brushes.append(image)
 				Brushes.add_project_brush(image)
-
+				brush_index += 1
 		if result.has("tile_mask") and result.has("has_mask"):
 			if result.has_mask:
 				var t_width = result.tile_mask.size_x
 				var t_height = result.tile_mask.size_y
-				var buffer := file.get_buffer(t_width * t_height * 4)
+				var image_data := zip_reader.read_file("image_data/tile_map")
 				var image := Image.create_from_data(
-					t_width, t_height, false, Image.FORMAT_RGBA8, buffer
+					t_width, t_height, false, Image.FORMAT_RGBA8, image_data
 				)
 				new_project.tiles.tile_mask = image
 			else:
 				new_project.tiles.reset_mask()
+		zip_reader.close()
 
-	file.close()
 	if empty_project:
 		new_project.change_project()
 		Global.project_changed.emit()
@@ -206,6 +215,73 @@ func open_pxo_file(path: String, untitled_backup := false, replace_empty := true
 		Global.top_menu_container.file_menu.set_item_text(Global.FileMenu.EXPORT, tr("Export"))
 
 	save_project_to_recent_list(path)
+
+
+func open_v0_pxo_file(path: String, new_project: Project) -> bool:
+	var file := FileAccess.open_compressed(path, FileAccess.READ, FileAccess.COMPRESSION_ZSTD)
+	if FileAccess.get_open_error() == ERR_FILE_UNRECOGNIZED:
+		# If the file is not compressed open it raw (pre-v0.7)
+		file = FileAccess.open(path, FileAccess.READ)
+	var err := FileAccess.get_open_error()
+	if err != OK:
+		Global.error_dialog.set_text(
+			tr("File failed to open. Error code %s (%s)") % [err, error_string(err)]
+		)
+		Global.error_dialog.popup_centered()
+		Global.dialog_open(true)
+		return false
+
+	var first_line := file.get_line()
+	var test_json_conv := JSON.new()
+	var error := test_json_conv.parse(first_line)
+	if error != OK:
+		print("Error, corrupt pxo file")
+		file.close()
+		return false
+
+	var result = test_json_conv.get_data()
+	if typeof(result) != TYPE_DICTIONARY:
+		print("Error, json parsed result is: %s" % typeof(result))
+		file.close()
+		return false
+
+	new_project.deserialize(result)
+	for frame in new_project.frames:
+		for cel in frame.cels:
+			if cel is PixelCel:
+				var buffer := file.get_buffer(new_project.size.x * new_project.size.y * 4)
+				var image := Image.create_from_data(
+					new_project.size.x, new_project.size.y, false, Image.FORMAT_RGBA8, buffer
+				)
+				cel.image_changed(image)
+			elif cel is Cel3D:
+				# Don't do anything with it, just read it so that the file can move on
+				var buffer := file.get_buffer(new_project.size.x * new_project.size.y * 4)
+
+	if result.has("brushes"):
+		for brush in result.brushes:
+			var b_width = brush.size_x
+			var b_height = brush.size_y
+			var buffer := file.get_buffer(b_width * b_height * 4)
+			var image := Image.create_from_data(
+				b_width, b_height, false, Image.FORMAT_RGBA8, buffer
+			)
+			new_project.brushes.append(image)
+			Brushes.add_project_brush(image)
+
+	if result.has("tile_mask") and result.has("has_mask"):
+		if result.has_mask:
+			var t_width = result.tile_mask.size_x
+			var t_height = result.tile_mask.size_y
+			var buffer := file.get_buffer(t_width * t_height * 4)
+			var image := Image.create_from_data(
+				t_width, t_height, false, Image.FORMAT_RGBA8, buffer
+			)
+			new_project.tiles.tile_mask = image
+		else:
+			new_project.tiles.reset_mask()
+	file.close()
+	return true
 
 
 func save_pxo_file(path: String, autosave: bool, project := Global.current_project) -> bool:
@@ -258,7 +334,7 @@ func save_pxo_file(path: String, autosave: bool, project := Global.current_proje
 	for frame in project.frames:
 		var blended_image := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
 		DrawingAlgos.blend_layers(blended_image, frame, Vector2i.ZERO, project)
-		zip_packer.start_file("image_data/final_image_%s" % frame_index)
+		zip_packer.start_file("image_data/final_images/%s" % frame_index)
 		zip_packer.write_file(blended_image.get_data())
 		zip_packer.close_file()
 		var cel_index := 1

--- a/src/Classes/BaseCel.gd
+++ b/src/Classes/BaseCel.gd
@@ -78,11 +78,6 @@ func deserialize(dict: Dictionary) -> void:
 	opacity = dict["opacity"]
 
 
-## Used to save cel image/thumbnail during saving of a pxo file.
-func save_image_data_to_pxo(_file: FileAccess) -> void:
-	return
-
-
 ## Used to load cel image/thumbnail during loading of a pxo file.
 func load_image_data_from_pxo(_file: FileAccess, _project_size: Vector2i) -> void:
 	return

--- a/src/Classes/BaseCel.gd
+++ b/src/Classes/BaseCel.gd
@@ -78,11 +78,6 @@ func deserialize(dict: Dictionary) -> void:
 	opacity = dict["opacity"]
 
 
-## Used to load cel image/thumbnail during loading of a pxo file.
-func load_image_data_from_pxo(_file: FileAccess, _project_size: Vector2i) -> void:
-	return
-
-
 ## Used to perform cleanup after a cel is removed.
 func on_remove() -> void:
 	pass

--- a/src/Classes/Cel3D.gd
+++ b/src/Classes/Cel3D.gd
@@ -289,11 +289,6 @@ func on_remove() -> void:
 	if is_instance_valid(viewport):
 		viewport.queue_free()
 
-
-func save_image_data_to_pxo(file: FileAccess) -> void:
-	file.store_buffer(get_image().get_data())
-
-
 ## Don't do anything with it, just read it so that the file can move on
 func load_image_data_from_pxo(file: FileAccess, project_size: Vector2i) -> void:
 	file.get_buffer(project_size.x * project_size.y * 4)

--- a/src/Classes/Cel3D.gd
+++ b/src/Classes/Cel3D.gd
@@ -289,10 +289,6 @@ func on_remove() -> void:
 	if is_instance_valid(viewport):
 		viewport.queue_free()
 
-## Don't do anything with it, just read it so that the file can move on
-func load_image_data_from_pxo(file: FileAccess, project_size: Vector2i) -> void:
-	file.get_buffer(project_size.x * project_size.y * 4)
-
 
 func instantiate_cel_button() -> Node:
 	return Global.cel_3d_button_node.instantiate()

--- a/src/Classes/PixelCel.gd
+++ b/src/Classes/PixelCel.gd
@@ -57,14 +57,6 @@ func update_texture() -> void:
 	super.update_texture()
 
 
-func load_image_data_from_pxo(file: FileAccess, project_size: Vector2i) -> void:
-	var buffer := file.get_buffer(project_size.x * project_size.y * 4)
-	image = Image.create_from_data(
-		project_size.x, project_size.y, false, Image.FORMAT_RGBA8, buffer
-	)
-	image_changed(image)
-
-
 func instantiate_cel_button() -> Node:
 	return Global.pixel_cel_button_node.instantiate()
 

--- a/src/Classes/PixelCel.gd
+++ b/src/Classes/PixelCel.gd
@@ -57,10 +57,6 @@ func update_texture() -> void:
 	super.update_texture()
 
 
-func save_image_data_to_pxo(file: FileAccess) -> void:
-	file.store_buffer(image.get_data())
-
-
 func load_image_data_from_pxo(file: FileAccess, project_size: Vector2i) -> void:
 	var buffer := file.get_buffer(project_size.x * project_size.y * 4)
 	image = Image.create_from_data(

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -40,7 +40,16 @@ func _ready() -> void:
 	Global.save_sprites_dialog.current_dir = Global.config_cache.get_value(
 		"data", "current_dir", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP)
 	)
-
+	var include_blended := CheckBox.new()
+	include_blended.name = "IncludeBlended"
+	include_blended.text = "Include blended images"
+	include_blended.tooltip_text = """
+If enabled, the final blended images are also being stored in the pxo, for each frame.
+This makes the pxo file larger and is useful for importing by third-party software
+or CLI exporting. Loading pxo files in Pixelorama does not need this option to be enabled.
+"""
+	include_blended.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+	Global.save_sprites_dialog.get_vbox().add_child(include_blended)
 	# FIXME: OS.get_system_dir does not grab the correct directory for Ubuntu Touch.
 	# Additionally, AppArmor policies prevent the app from writing to the /home
 	# directory. Until the proper AppArmor policies are determined to write to these
@@ -274,7 +283,10 @@ func _on_SaveSprite_file_selected(path: String) -> void:
 
 
 func save_project(path: String) -> void:
-	var success = OpenSave.save_pxo_file(path, false)
+	var include_blended: bool = (
+		Global.save_sprites_dialog.get_vbox().get_node("IncludeBlended").button_pressed
+	)
+	var success := OpenSave.save_pxo_file(path, false, include_blended)
 	if success:
 		Global.open_sprites_dialog.current_dir = path.get_base_dir()
 		Global.config_cache.set_value("data", "current_dir", path.get_base_dir())

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -50,14 +50,6 @@ func _ready() -> void:
 	if OS.has_feature("clickable"):
 		Global.open_sprites_dialog.current_dir = OS.get_user_data_dir()
 		Global.save_sprites_dialog.current_dir = OS.get_user_data_dir()
-
-	var zstd_checkbox := CheckBox.new()
-	zstd_checkbox.name = "ZSTDCompression"
-	zstd_checkbox.button_pressed = true
-	zstd_checkbox.text = "Use ZSTD Compression"
-	zstd_checkbox.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
-	Global.save_sprites_dialog.get_vbox().add_child(zstd_checkbox)
-
 	_handle_backup()
 
 	_handle_cmdline_arguments()
@@ -282,10 +274,7 @@ func _on_SaveSprite_file_selected(path: String) -> void:
 
 
 func save_project(path: String) -> void:
-	var zstd: bool = (
-		Global.save_sprites_dialog.get_vbox().get_node("ZSTDCompression").button_pressed
-	)
-	var success = OpenSave.save_pxo_file(path, false, zstd)
+	var success = OpenSave.save_pxo_file(path, false)
 	if success:
 		Global.open_sprites_dialog.current_dir = path.get_base_dir()
 		Global.config_cache.set_value("data", "current_dir", path.get_base_dir())
@@ -300,7 +289,7 @@ func _on_SaveSpriteHTML5_confirmed() -> void:
 	)
 	file_name += ".pxo"
 	var path := "user://".path_join(file_name)
-	OpenSave.save_pxo_file(path, false, false)
+	OpenSave.save_pxo_file(path, false)
 
 
 func _on_open_sprite_visibility_changed() -> void:


### PR DESCRIPTION
Implements #939, solution 1. This PR makes .pxo files be .zip files in disguise, i.e., changing the extension from pxo to zip actually lets you open the file in a archive manager and view its content. Breaks forward compatibility with 0.x, meaning that pxo files exported with 1.x will not be able to be imported in 0.x. The opposite is true, however, pxos made with 0.x can be imported in 1.x.

Also provides an option to include the final blended images of each layer for easier importing by other software, and exporting with CLI, when it gets implemented. The option is disabled by default so save disk space and to reduce saving time.

The main reasons I think this solution is better than going with SQLite is that Godot already supports zip packing and reading, while SQLite would require a GDExtension which could be troublesome for cross-platform support, such as Web, and the second reason is that zips should be easier to import by other software. Any Godot 4-made software/addons can read zip files, for example.

Most project files seem to be smaller as zips compared to the previous pxo format. A 200x128 project with 15 layers and 159 frames when exported to the previous pxo format, with ZSTD compression, takes 3.1MB of space. The same project takes just 1.6MB as a zip, and 2.2MB as a zip when the final blended images are included. However, both loading and saving seems to be taking longer than the previous format. Saving could perhaps get optimized by just overwriting only the files that have new changes, and not remaking the entire file from scratch, but that's something for the future. This optimization is something that couldn't have been done so easily with the previous format, if at all.

The structure of the zip is the following (files are in _italic_, the rest are directories):

root
├── image_data
│   ├── frames
│   │   └── 1
│   │    |   └── _layer_1_
│   │    |   └── _layer_2_
│   │    |   └── _layer_3_... etc for each layer
│   │   └── 2
│   │   └── 3... etc for each frame
│   └── brushes
│   │   └── _brush_1_ (etc for each project brush)
│   └── final_images (only included if "Include blended images" is enabled when saving)
│   │   └── _1_
│   │   └── _2_
│   │   └── _3_... etc for each frame
│   └── _tile_mask_
├── _data.json_

Note that saving doesn't currently work on the Web version due to https://github.com/godotengine/godot/issues/85564.