### PR TITLE
Add support for InputEventMouseMotion.pen_inverted

### DIFF
--- a/src/Autoload/Tools.gd
+++ b/src/Autoload/Tools.gd
@@ -492,12 +492,20 @@ func handle_draw(position: Vector2i, event: InputEvent) -> void:
 	elif event.is_action_released("activate_left_tool") and _active_button == MOUSE_BUTTON_LEFT:
 		_slots[_active_button].tool_node.draw_end(draw_pos)
 		_active_button = -1
-	elif ((event.is_action_pressed("activate_right_tool") and _active_button == -1 and not pen_inverted)
-			or (event.is_action_pressed("activate_left_tool") and _active_button == -1 and pen_inverted)):
+	elif (
+		(
+			event.is_action_pressed("activate_right_tool")
+			and _active_button == -1
+			and not pen_inverted
+		)
+		or (event.is_action_pressed("activate_left_tool") and _active_button == -1 and pen_inverted)
+	):
 		_active_button = MOUSE_BUTTON_RIGHT
 		_slots[_active_button].tool_node.draw_start(draw_pos)
-	elif ((event.is_action_released("activate_right_tool") and _active_button == MOUSE_BUTTON_RIGHT)
-			or (event.is_action_released("activate_left_tool") and _active_button == MOUSE_BUTTON_RIGHT)):
+	elif (
+		(event.is_action_released("activate_right_tool") and _active_button == MOUSE_BUTTON_RIGHT)
+		or (event.is_action_released("activate_left_tool") and _active_button == MOUSE_BUTTON_RIGHT)
+	):
 		_slots[_active_button].tool_node.draw_end(draw_pos)
 		_active_button = -1
 
@@ -514,7 +522,7 @@ func handle_draw(position: Vector2i, event: InputEvent) -> void:
 		pressure_buf.push_front(pen_pressure)
 		pen_pressure = remap(pen_pressure, pen_pressure_min, pen_pressure_max, 0.0, 1.0)
 		pen_pressure = clampf(pen_pressure, 0.0, 1.0)
-		
+
 		pen_inverted = event.pen_inverted
 
 		mouse_velocity = event.velocity.length() / mouse_velocity_max

--- a/src/UI/ToolsPanel/ToolButtons.gd
+++ b/src/UI/ToolsPanel/ToolButtons.gd
@@ -1,10 +1,13 @@
 extends FlowContainer
 
 
+var pen_inverted := false
+
 func _input(event: InputEvent) -> void:
-	if not Global.has_focus or not Global.can_draw:
-		return
 	if event is InputEventMouseMotion:
+		pen_inverted = event.pen_inverted
+		return
+	if not Global.has_focus or not Global.can_draw:
 		return
 	for action in ["undo", "redo"]:
 		if event.is_action_pressed(action):
@@ -29,6 +32,6 @@ func _input(event: InputEvent) -> void:
 func _on_Tool_pressed(tool_pressed: BaseButton) -> void:
 	var button := -1
 	button = MOUSE_BUTTON_LEFT if Input.is_action_just_released("left_mouse") else button
-	button = MOUSE_BUTTON_RIGHT if Input.is_action_just_released("right_mouse") else button
+	button = MOUSE_BUTTON_RIGHT if Input.is_action_just_released("right_mouse") or (pen_inverted and Input.is_action_just_released("left_mouse")) else button
 	if button != -1:
 		Tools.assign_tool(tool_pressed.name, button)

--- a/src/UI/ToolsPanel/ToolButtons.gd
+++ b/src/UI/ToolsPanel/ToolButtons.gd
@@ -1,7 +1,7 @@
 extends FlowContainer
 
-
 var pen_inverted := false
+
 
 func _input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
@@ -32,6 +32,13 @@ func _input(event: InputEvent) -> void:
 func _on_Tool_pressed(tool_pressed: BaseButton) -> void:
 	var button := -1
 	button = MOUSE_BUTTON_LEFT if Input.is_action_just_released("left_mouse") else button
-	button = MOUSE_BUTTON_RIGHT if Input.is_action_just_released("right_mouse") or (pen_inverted and Input.is_action_just_released("left_mouse")) else button
+	button = (
+		MOUSE_BUTTON_RIGHT
+		if (
+			Input.is_action_just_released("right_mouse")
+			or (pen_inverted and Input.is_action_just_released("left_mouse"))
+		)
+		else button
+	)
 	if button != -1:
 		Tools.assign_tool(tool_pressed.name, button)


### PR DESCRIPTION
This PR adds support for stylus erasers, both for drawing and choosing tools.  This may be supported on some styli by inverting them as the property name suggests, or by holding a button while drawing with the nib.