### PR TITLE
Fixed some issues with perspective lines and removed unneeded code from the rotate image dialog

### DIFF
--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -250,14 +250,13 @@ func _on_Indicator_draw() -> void:
 	else:
 		conversion_scale = ratio.y
 	var pivot_position := pivot * conversion_scale
-	var width = 1
-	pivot_indicator.draw_arc(pivot_position, 2, 0, 360, 360, Color.YELLOW, width)
-	pivot_indicator.draw_arc(pivot_position, 6, 0, 360, 360, Color.WHITE, width)
+	pivot_indicator.draw_arc(pivot_position, 2, 0, 360, 360, Color.YELLOW)
+	pivot_indicator.draw_arc(pivot_position, 6, 0, 360, 360, Color.WHITE)
 	pivot_indicator.draw_line(
-		pivot_position - Vector2.UP * 10, pivot_position - Vector2.DOWN * 10, Color.WHITE, width
+		pivot_position - Vector2.UP * 10, pivot_position - Vector2.DOWN * 10, Color.WHITE
 	)
 	pivot_indicator.draw_line(
-		pivot_position - Vector2.RIGHT * 10, pivot_position - Vector2.LEFT * 10, Color.WHITE, width
+		pivot_position - Vector2.RIGHT * 10, pivot_position - Vector2.LEFT * 10, Color.WHITE
 	)
 
 

--- a/src/UI/PerspectiveEditor/PerspectiveLine.gd
+++ b/src/UI/PerspectiveEditor/PerspectiveLine.gd
@@ -150,7 +150,9 @@ func _draw() -> void:
 			arc_points.append(points[1])
 
 	for point in arc_points:
-		draw_arc(point, CIRCLE_RAD * 2 / Global.camera.zoom.x, 0, 360, 360, default_color, 0.5)
+		# if we put width <= -1, then the arc line will automatically adjust itself to remain thin
+		# in 0.x this behavior was achieved at  width <= 1
+		draw_arc(point, CIRCLE_RAD * 2 / Global.camera.zoom.x, 0, 360, 360, default_color, -1)
 
 	width = LINE_WIDTH / Global.camera.zoom.x
 	if is_hidden:  # Hidden line

--- a/src/UI/PerspectiveEditor/PerspectiveLine.gd
+++ b/src/UI/PerspectiveEditor/PerspectiveLine.gd
@@ -29,9 +29,11 @@ func deserialize(data: Dictionary):
 
 func initiate(data: Dictionary, vanishing_point: Node):
 	_vanishing_point = vanishing_point
-	width = LINE_WIDTH / Global.camera.zoom.x
 	Global.canvas.add_child(self)
 	deserialize(data)
+	# a small delay is needed for Global.camera.zoom to have correct value
+	await get_tree().process_frame
+	width = LINE_WIDTH / Global.camera.zoom.x
 	refresh()
 
 
@@ -126,6 +128,7 @@ func try_rotate_scale():
 
 
 func _draw() -> void:
+	width = LINE_WIDTH / Global.camera.zoom.x
 	var mouse_point := Global.canvas.current_pixel
 	var arc_points := PackedVector2Array()
 	draw_circle(points[0], CIRCLE_RAD / Global.camera.zoom.x, default_color)  # Starting circle
@@ -152,8 +155,7 @@ func _draw() -> void:
 	for point in arc_points:
 		# if we put width <= -1, then the arc line will automatically adjust itself to remain thin
 		# in 0.x this behavior was achieved at  width <= 1
-		draw_arc(point, CIRCLE_RAD * 2 / Global.camera.zoom.x, 0, 360, 360, default_color, -1)
+		draw_arc(point, CIRCLE_RAD * 2 / Global.camera.zoom.x, 0, 360, 360, default_color)
 
-	width = LINE_WIDTH / Global.camera.zoom.x
 	if is_hidden:  # Hidden line
 		return

--- a/src/UI/PerspectiveEditor/VanishingPoint.gd
+++ b/src/UI/PerspectiveEditor/VanishingPoint.gd
@@ -76,7 +76,7 @@ func _input(_event: InputEvent):
 		Input.is_action_just_pressed("left_mouse")
 		and Global.can_draw
 		and Global.has_focus
-		and mouse_point.distance_to(start) < Global.camera.zoom.x * 8
+		and mouse_point.distance_to(start) < 8 / Global.camera.zoom.x
 	):
 		if (
 			!Rect2(Vector2.ZERO, project_size).has_point(Global.canvas.current_pixel)


### PR DESCRIPTION
These issues are not present in 0.x

1. [Rotate Image] Set `width` = -1 (default value), so the arc line will automatically adjust itself to remain thin (in 0.x this behavior was achieved at  `width` = 1 or `0.5`)
2. [Perspective lines] A small delay was needed for Global.camera.zoom to have correct value (bug was noticed when project containing perspective lines was `loaded at startup`)
3. [Perspective vanishing point] Changed a typo `Global.camera.zoom.x * 8` --> `8 / Global.camera.zoom.x` (it was probably missed during project conversion)