### PR TITLE
Video exporting by calling FFMPEG externally

### DIFF
--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -19,6 +19,10 @@ var animated_formats := [
 	FileFormat.WEBM
 ]
 
+var ffmpeg_formats := [
+	FileFormat.MP4, FileFormat.AVI, FileFormat.OGV, FileFormat.MKV, FileFormat.WEBM
+]
+
 ## A dictionary of custom exporter generators (received from extensions)
 var custom_file_formats := {}
 var custom_exporter_generators := {}
@@ -364,7 +368,7 @@ func export_video(export_paths: PackedStringArray) -> void:
 		"-y", "-f", "concat", "-i", input_file_path, export_paths[0]
 	]
 	var output := []
-	OS.execute("ffmpeg", ffmpeg_execute, output, true)
+	OS.execute(Global.ffmpeg_path, ffmpeg_execute, output, true)
 	print(output)
 	var temp_dir := DirAccess.open(TEMP_PATH)
 	for file in temp_dir.get_files():
@@ -475,7 +479,7 @@ func file_format_description(format_enum: int) -> String:
 		FileFormat.MKV:
 			return "Matroska Video"
 		FileFormat.WEBM:
-			return "WebM video"
+			return "WebM Video"
 		_:
 			# If a file format description is not found, try generating one
 			for key in custom_file_formats.keys():
@@ -491,7 +495,16 @@ func is_single_file_format(project := Global.current_project) -> bool:
 
 
 func is_using_ffmpeg(format: FileFormat) -> bool:
-	return format >= FileFormat.MP4 and format <= FileFormat.WEBM
+	return ffmpeg_formats.has(format)
+
+
+func is_ffmpeg_installed() -> bool:
+	if Global.ffmpeg_path.is_empty():
+		return false
+	var ffmpeg_executed := OS.execute(Global.ffmpeg_path, [])
+	if ffmpeg_executed == 0 or ffmpeg_executed == 1:
+		return true
+	return false
 
 
 func _create_export_path(multifile: bool, project: Project, frame := 0) -> String:

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -371,6 +371,11 @@ func export_video(export_paths: PackedStringArray) -> bool:
 	]
 	var output := []
 	var success := OS.execute(Global.ffmpeg_path, ffmpeg_execute, output, true)
+	print(output)
+	var temp_dir := DirAccess.open(TEMP_PATH)
+	for file in temp_dir.get_files():
+		temp_dir.remove(file)
+	DirAccess.remove_absolute(TEMP_PATH)
 	if success < 0 or success > 1:
 		var fail_text := """Video failed to export. Make sure you have FFMPEG installed
 			and have set the correct path in the preferences."""
@@ -378,11 +383,6 @@ func export_video(export_paths: PackedStringArray) -> bool:
 		Global.error_dialog.popup_centered()
 		Global.dialog_open(true)
 		return false
-	print(output)
-	var temp_dir := DirAccess.open(TEMP_PATH)
-	for file in temp_dir.get_files():
-		temp_dir.remove(file)
-	DirAccess.remove_absolute(TEMP_PATH)
 	return true
 
 

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -4,13 +4,19 @@ enum ExportTab { IMAGE = 0, SPRITESHEET = 1 }
 enum Orientation { ROWS = 0, COLUMNS = 1 }
 enum AnimationDirection { FORWARD = 0, BACKWARDS = 1, PING_PONG = 2 }
 ## See file_format_string, file_format_description, and ExportDialog.gd
-enum FileFormat { PNG, WEBP, JPEG, GIF, APNG, MP4, AVI, OGV, MKV }
+enum FileFormat { PNG, WEBP, JPEG, GIF, APNG, MP4, AVI, OGV, MKV, WEBM }
 
 const TEMP_PATH := "user://tmp"
 
 ## List of animated formats
 var animated_formats := [
-	FileFormat.GIF, FileFormat.APNG, FileFormat.MP4, FileFormat.AVI, FileFormat.OGV, FileFormat.MKV
+	FileFormat.GIF,
+	FileFormat.APNG,
+	FileFormat.MP4,
+	FileFormat.AVI,
+	FileFormat.OGV,
+	FileFormat.MKV,
+	FileFormat.WEBM
 ]
 
 ## A dictionary of custom exporter generators (received from extensions)
@@ -437,6 +443,8 @@ func file_format_string(format_enum: int) -> String:
 			return ".ogv"
 		FileFormat.MKV:
 			return ".mkv"
+		FileFormat.WEBM:
+			return ".webm"
 		_:
 			# If a file format description is not found, try generating one
 			if custom_exporter_generators.has(format_enum):
@@ -466,6 +474,8 @@ func file_format_description(format_enum: int) -> String:
 			return "OGV Video"
 		FileFormat.MKV:
 			return "Matroska Video"
+		FileFormat.WEBM:
+			return "WebM video"
 		_:
 			# If a file format description is not found, try generating one
 			for key in custom_file_formats.keys():
@@ -481,7 +491,7 @@ func is_single_file_format(project := Global.current_project) -> bool:
 
 
 func is_using_ffmpeg(format: FileFormat) -> bool:
-	return format >= FileFormat.MP4 and format <= FileFormat.MKV
+	return format >= FileFormat.MP4 and format <= FileFormat.WEBM
 
 
 func _create_export_path(multifile: bool, project: Project, frame := 0) -> String:

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -131,6 +131,8 @@ var show_y_symmetry_axis := false
 var open_last_project := false
 ## Found in Preferences. If [code]true[/code], asks for permission to quit on exit.
 var quit_confirmation := false
+## Found in Preferences. Refers to the ffmpeg location path.
+var ffmpeg_path := ""
 ## Found in Preferences. If [code]true[/code], the zoom is smooth.
 var smooth_zoom := true
 ## Found in Preferences. If [code]true[/code], the zoom is restricted to integral multiples of 100%.

--- a/src/Preferences/PreferencesDialog.gd
+++ b/src/Preferences/PreferencesDialog.gd
@@ -7,6 +7,7 @@ var preferences: Array[Preference] = [
 	Preference.new(
 		"quit_confirmation", "Startup/StartupContainer/QuitConfirmation", "button_pressed"
 	),
+	Preference.new("ffmpeg_path", "Startup/StartupContainer/FFMPEGPath", "text"),
 	Preference.new("shrink", "%ShrinkSlider", "value"),
 	Preference.new("font_size", "Interface/InterfaceOptions/FontSizeSlider", "value"),
 	Preference.new("dim_on_popup", "Interface/InterfaceOptions/DimCheckBox", "button_pressed"),
@@ -200,6 +201,10 @@ func _ready() -> void:
 				)
 			"selected":
 				node.item_selected.connect(
+					_on_Preference_value_changed.bind(pref, restore_default_button)
+				)
+			"text":
+				node.text_changed.connect(
 					_on_Preference_value_changed.bind(pref, restore_default_button)
 				)
 

--- a/src/Preferences/PreferencesDialog.tscn
+++ b/src/Preferences/PreferencesDialog.tscn
@@ -90,6 +90,13 @@ layout_mode = 2
 mouse_default_cursor_shape = 2
 text = "On"
 
+[node name="FFMPEGPathLabel" type="Label" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Startup/StartupContainer"]
+layout_mode = 2
+text = "FFMPEG path"
+
+[node name="FFMPEGPath" type="LineEdit" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Startup/StartupContainer"]
+layout_mode = 2
+
 [node name="Language" type="VBoxContainer" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide"]
 visible = false
 layout_mode = 2

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -257,9 +257,9 @@ func update_dimensions_label() -> void:
 
 func open_path_validation_alert_popup(path_or_name: int = -1) -> void:
 	# 0 is invalid path, 1 is invalid name
-	var error_text := "DirAccess path and file name are not valid!"
+	var error_text := "Directory path and file name are not valid!"
 	if path_or_name == 0:
-		error_text = "DirAccess path is not valid!"
+		error_text = "Directory path is not valid!"
 	elif path_or_name == 1:
 		error_text = "File name is not valid!"
 

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -193,6 +193,12 @@ func set_file_format_selector() -> void:
 	match Export.current_tab:
 		Export.ExportTab.IMAGE:
 			_set_file_format_selector_suitable_file_formats(image_exports)
+			if Export.is_ffmpeg_installed():
+				for format in Export.ffmpeg_formats:
+					file_format_options.set_item_disabled(format, false)
+			else:
+				for format in Export.ffmpeg_formats:
+					file_format_options.set_item_disabled(format, true)
 		Export.ExportTab.SPRITESHEET:
 			_set_file_format_selector_suitable_file_formats(spritesheet_exports)
 

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -15,6 +15,9 @@ var image_exports: Array[Export.FileFormat] = [
 	Export.FileFormat.GIF,
 	Export.FileFormat.APNG,
 	Export.FileFormat.MP4,
+	Export.FileFormat.AVI,
+	Export.FileFormat.OGV,
+	Export.FileFormat.MKV,
 ]
 var spritesheet_exports: Array[Export.FileFormat] = [
 	Export.FileFormat.PNG, Export.FileFormat.WEBP, Export.FileFormat.JPEG

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -18,6 +18,7 @@ var image_exports: Array[Export.FileFormat] = [
 	Export.FileFormat.AVI,
 	Export.FileFormat.OGV,
 	Export.FileFormat.MKV,
+	Export.FileFormat.WEBM,
 ]
 var spritesheet_exports: Array[Export.FileFormat] = [
 	Export.FileFormat.PNG, Export.FileFormat.WEBP, Export.FileFormat.JPEG

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -13,7 +13,8 @@ var image_exports: Array[Export.FileFormat] = [
 	Export.FileFormat.WEBP,
 	Export.FileFormat.JPEG,
 	Export.FileFormat.GIF,
-	Export.FileFormat.APNG
+	Export.FileFormat.APNG,
+	Export.FileFormat.MP4,
 ]
 var spritesheet_exports: Array[Export.FileFormat] = [
 	Export.FileFormat.PNG, Export.FileFormat.WEBP, Export.FileFormat.JPEG


### PR DESCRIPTION
This PR implements the ability to export projects to video formats (mp4, avi, ogv, mkv & webm) using FFMPEG. **FFMPEG itself is NOT bundled in Pixelorama, and thus needs to be downloaded as a stand-alone software. Then, you need to insert the file path of FFMPEG's binary in Pixelorama's preferences.** ~~I have only tested it on Linux so far.~~ EDIT: Should also work on Windows. In the future we could look into bundling it with GDExtension, if the licenses are compatible. Otherwise, I suppose it could be in the form of an extension.

It works by saving all of the frames as png files in a temp folder, then FFMPEG is called to convert the png files into a video, taking into account the project's fps and the delay of each individual frame. Then, the temporary png files are being deleted.

Implements #658.

Ideas for the future (outside the scope of this PR):
- Perhaps it might be a good idea to use FFMPEG for gif and apng exporting as well, as it is a lot faster than using GDScript.
- The ability to use FFMPEG to create videos from the recorder panel. 
- Allow users to change the video codecs used for each container.
- Use FFMPEG to import videos and gif files as individual frames.

This feature could work well if we implement audio support in the timeline (#897), allowing people to use Pixelorama as a fully fledged tool to create animations.

[3d cube spin 8x.webm](https://github.com/Orama-Interactive/Pixelorama/assets/35376950/ca880619-bfe7-4f1f-b1f7-4919cb7f8ed2)


A .webm video exporting directly from Pixelorama.
