### PR TITLE
Implement Columns field of imported .gpl palettes.

### DIFF
--- a/src/Autoload/Palettes.gd
+++ b/src/Autoload/Palettes.gd
@@ -525,8 +525,10 @@ func _import_image_palette(path: String, image: Image) -> Palette:
 
 	return _fill_imported_palette_with_colors(path.get_basename().get_file(), colors)
 
+
 ## Maximum allowed width of imported palettes.
 const MAX_IMPORT_PAL_WIDTH = 1 << 14
+
 
 ## Fills a new [Palette] with colors. Used when importing files. Dimensions are
 ## determined by taking colors as a one-dimensional array that is wrapped by

--- a/src/Autoload/Palettes.gd
+++ b/src/Autoload/Palettes.gd
@@ -10,6 +10,8 @@ enum NewPalettePresetType {EMPTY, FROM_CURRENT_PALETTE, FROM_CURRENT_SPRITE, FRO
 ## Color options when user creates a new palette from current sprite or selection
 enum GetColorsFrom { CURRENT_FRAME, CURRENT_CEL, ALL_FRAMES }
 const DEFAULT_PALETTE_NAME := "Default"
+## Maximum allowed width of imported palettes.
+const MAX_IMPORT_PAL_WIDTH = 1 << 14
 var palettes_write_path := Global.home_data_directory.path_join("Palettes")
 ## All available palettes
 var palettes := {}
@@ -524,10 +526,6 @@ func _import_image_palette(path: String, image: Image) -> Palette:
 				colors.append(color)
 
 	return _fill_imported_palette_with_colors(path.get_basename().get_file(), colors)
-
-
-## Maximum allowed width of imported palettes.
-const MAX_IMPORT_PAL_WIDTH = 1 << 14
 
 
 ## Fills a new [Palette] with colors. Used when importing files. Dimensions are

--- a/src/Autoload/Palettes.gd
+++ b/src/Autoload/Palettes.gd
@@ -468,7 +468,7 @@ func _import_gpl(path: String, text: String) -> Palette:
 			palette_name = line.replace("Name: ", "")
 		elif line.begins_with("Columns: "):
 			# The width of the palette.
-			line = line.trim_prefix("Columns: ")
+			line = line.trim_prefix("Columns: ").strip_edges()
 			if !line.is_valid_int():
 				continue
 			columns = line.to_int()


### PR DESCRIPTION
- Fixes Columns field being ignored when imported.
- `_fill_imported_palette_with_colors` is modified to accept an optional width parameter, which defaults to Palette.DEFAULT_WIDTH instead of a hard-coded 8.
- A maximum of width of 16384 is enforced to mitigate maliciously large values.