### PR TITLE
Fix certain strings not updating when language changes

### DIFF
--- a/src/Palette/EditPaletteDialog.gd
+++ b/src/Palette/EditPaletteDialog.gd
@@ -32,9 +32,9 @@ var old_name := ""
 func _ready() -> void:
 	export_file_dialog.use_native_dialog = Global.use_native_file_dialogs
 	# Add delete and export buttons to edit palette dialog
-	add_button(tr("Delete"), false, DELETE_ACTION)
-	add_button(tr("Export"), false, EXPORT_ACTION)
-	delete_confirmation.add_button(tr("Move to Trash"), false, BIN_ACTION)
+	add_button("Delete", false, DELETE_ACTION)
+	add_button("Export", false, EXPORT_ACTION)
+	delete_confirmation.add_button("Move to Trash", false, BIN_ACTION)
 
 
 func open(current_palette: Palette) -> void:

--- a/src/Preferences/ExtensionsPreferences.gd
+++ b/src/Preferences/ExtensionsPreferences.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
 		_extension_loaded(extension, extension_name)
 	extensions.extension_loaded.connect(_extension_loaded)
 	extensions.extension_uninstalled.connect(_extension_uninstalled)
-	delete_confirmation.add_button(tr("Move to Trash"), false, Extensions.BIN_ACTION)
+	delete_confirmation.add_button("Move to Trash", false, Extensions.BIN_ACTION)
 	if OS.get_name() == "Web":
 		$HBoxContainer/AddExtensionButton.disabled = true
 		$HBoxContainer/OpenFolderButton.visible = false

--- a/src/UI/Timeline/CelButton.gd
+++ b/src/UI/Timeline/CelButton.gd
@@ -29,6 +29,13 @@ func _ready() -> void:
 		transparent_checker.visible = false
 
 
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_TRANSLATION_CHANGED:
+		tooltip_text = (
+			tr("Frame: %s, Layer: %s") % [frame + 1, Global.current_project.layers[layer].name]
+		)
+
+
 func cel_switched(force_stylebox_change := false) -> void:
 	z_index = 1 if button_pressed else 0
 	var current_theme := Global.control.theme

--- a/src/UI/TopMenuContainer/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer/TopMenuContainer.gd
@@ -94,9 +94,22 @@ func _ready() -> void:
 	_setup_help_menu()
 
 
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_TRANSLATION_CHANGED and Global.current_project != null:
+		_update_file_menu_buttons(Global.current_project)
+
+
 func _project_switched() -> void:
 	var project := Global.current_project
 	edit_menu.set_item_disabled(Global.EditMenu.NEW_BRUSH, not project.has_selection)
+	_update_file_menu_buttons(project)
+	for j in Tiles.MODE.values():
+		tile_mode_submenu.set_item_checked(j, j == project.tiles.mode)
+
+	_update_current_frame_mark()
+
+
+func _update_file_menu_buttons(project: Project) -> void:
 	if project.export_directory_path.is_empty():
 		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save"))
 	else:
@@ -109,10 +122,6 @@ func _project_switched() -> void:
 			file_menu.set_item_text(Global.FileMenu.EXPORT, tr("Export") + f_name)
 	else:
 		file_menu.set_item_text(Global.FileMenu.EXPORT, tr("Export"))
-	for j in Tiles.MODE.values():
-		tile_mode_submenu.set_item_checked(j, j == project.tiles.mode)
-
-	_update_current_frame_mark()
 
 
 func _update_current_frame_mark() -> void:


### PR DESCRIPTION
Currently, a few buttons and labels in Pixelorama aren't getting updated when changing languages, they just remain at the language the program started up with or only update when changing projects.

For the example below: I set the language to Greek, restarted the program and then switched the language back to English.
![image](https://github.com/user-attachments/assets/25e4aa3e-b6e5-4609-839e-b801de064106)
Other than these buttons in the File menu, there are different places where this also happens (see the changes included).

Here's how this PR fixes it:
- For the simple strings, all that was needed to do was remove the `tr()` when setting them up as they need to stay in English for `TranslationServer` to work with them.
- For the strings that have formatting (that is, strings that can only be partially translated, like the Save button above which has the project's name in it), `TranslationServer` cannot do the automatic translations, so it was needed to add code to retranslate them manually whenever the language is changed.

**Note:** The issue is still present in `FileDialog`s, but in that case it's a problem with Godot and it seems like it was already fixed in 4.3.