### PR TITLE
Add missing translation strings and fix broken ones

### DIFF
--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -89,7 +89,7 @@ msgstr ""
 #. Hint tooltip of the "Include blended images" checkbox found in the Save project dialog.
 msgid "If enabled, the final blended images are also being stored in the pxo, for each frame.\n"
 "This makes the pxo file larger and is useful for importing by third-party software\n"
-"or CLI exporting. Loading pxo files in Pixelorama does not need this option to be enabled.\n"
+"or CLI exporting. Loading pxo files in Pixelorama does not need this option to be enabled."
 msgstr ""
 
 msgid "Import"
@@ -622,7 +622,25 @@ msgstr ""
 msgid "Export dimensions:"
 msgstr ""
 
+msgid "Save a File"
+msgstr ""
+
+msgid "Go to previous folder."
+msgstr ""
+
+msgid "Go to next folder."
+msgstr ""
+
+msgid "Go to parent folder."
+msgstr ""
+
 msgid "Path:"
+msgstr ""
+
+msgid "Refresh files."
+msgstr ""
+
+msgid "Toggle the visibility of hidden files."
 msgstr ""
 
 msgid "Directories & Files:"
@@ -632,6 +650,54 @@ msgid "Create Folder"
 msgstr ""
 
 msgid "File:"
+msgstr ""
+
+#. Found in "Open" and "Save" file dialogs. Searches all file types.
+msgid "All Files"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches all file types supported by Pixelorama.
+msgid "All Recognized"
+msgstr ""
+
+#. Found in "Open" and "Save" file dialogs. Searches Pixelorama Project files only (.pxo).
+msgid "Pixelorama Project"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches PNG files only. (Note that PNG is a file type and should remain untranslated)
+msgid "PNG Image"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches BMP files only. (Note that BMP is a file type and should remain untranslated)
+msgid "BMP Image"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches "Radiance HDR" files only. (Note that "Radiance HDR" is a file type and is better untranslated)
+msgid "Radiance HDR Image"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches JPEG files only. (Note that JPEG is a file type and should remain untranslated)
+msgid "JPEG Image"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches SVG files only. (Note that SVG is a file type and should remain untranslated)
+msgid "SVG Image"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches TGA files only. (Note that TGA is a file type and should remain untranslated)
+msgid "TGA Image"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches WebP files only. (Note that WebP is a file type and should remain untranslated)
+msgid "WebP Image"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches Pixelorama palette files only (.json).
+msgid "Pixelorama palette"
+msgstr ""
+
+#. Found in the "Open" file dialog. Searches GIMP palette files only (.gpl). (Note that GIMP is a software and should remain untranslated)
+msgid "GIMP palette"
 msgstr ""
 
 #. Found in the export dialog. It is a button that when pressed, shows more options.
@@ -1225,6 +1291,11 @@ msgid "Lasso / Free Select Tool\n\n"
 "%s for right mouse button"
 msgstr ""
 
+msgid "Select by Drawing\n\n"
+"%s for left mouse button\n"
+"%s for right mouse button"
+msgstr ""
+
 msgid "Move\n\n"
 "%s for left mouse button\n"
 "%s for right mouse button"
@@ -1244,6 +1315,10 @@ msgid "Color Picker\n\n"
 "%s for left mouse button\n"
 "%s for right mouse button\n\n"
 "Select a color from a pixel of the sprite"
+msgstr ""
+
+msgid "Crop\n\n"
+"Resize the canvas"
 msgstr ""
 
 msgid "Pencil\n\n"
@@ -1318,11 +1393,19 @@ msgstr ""
 msgid "Switch left and right colors."
 msgstr ""
 
+#. Tooltip of the average color button, found in the color picker panel. Shows the average color between the two selected.
+msgid "Average Color:"
+msgstr ""
+
 msgid "Reset the colors to their default state (black for left, white for right)"
 msgstr ""
 
 #. Tooltip of the screen color picker button found in the color picker panel.
 msgid "Pick a color from the screen."
+msgstr ""
+
+#. Tooltip of the color text field found in the color picker panel that lets users change the color by hex code or english name ("red" cannot be translated).
+msgid "Enter a hex code (\"#ff0000\") or named color (\"red\")."
 msgstr ""
 
 #. Tooltip of the button found in the color picker panel that lets users change the shape of the color picker.
@@ -1331,6 +1414,22 @@ msgstr ""
 
 #. Refers to color-related options such as sliders that set color channel values like R, G, B and A.
 msgid "Color options"
+msgstr ""
+
+#. Tooltip of the button with three dots found under color options in the color picker panel that lets users change the mode of the color picker/sliders.
+msgid "Select a picker mode."
+msgstr ""
+
+#. Checkbox found in the menu of the button with three dots found under color options in the color picker panel.
+msgid "Colorized Sliders"
+msgstr ""
+
+#. Shows saved colors in certain color picker menus.
+msgid "Swatches"
+msgstr ""
+
+#. Found under color options in the color picker panel.
+msgid "Recent Colors"
 msgstr ""
 
 msgid "Left tool"
@@ -1795,22 +1894,22 @@ msgstr ""
 msgid "Current frame as spritesheet"
 msgstr ""
 
-msgid "Jump to the first frame\n"
+msgid "Jump to the first frame"
 msgstr ""
 
-msgid "Go to the previous frame\n"
+msgid "Go to the previous frame"
 msgstr ""
 
-msgid "Play the animation backwards (from end to beginning)\n"
+msgid "Play the animation backwards (from end to beginning)"
 msgstr ""
 
-msgid "Play the animation forward (from beginning to end)\n"
+msgid "Play the animation forward (from beginning to end)"
 msgstr ""
 
-msgid "Go to the next frame\n"
+msgid "Go to the next frame"
 msgstr ""
 
-msgid "Jump to the last frame\n"
+msgid "Jump to the last frame"
 msgstr ""
 
 msgid "Timeline settings"
@@ -2926,8 +3025,25 @@ msgstr ""
 msgid "Monochrome"
 msgstr ""
 
+#. Found in the Reference Images panel when no reference image has been imported.
+msgid "When opening an image, it may be imported as a reference."
+msgstr ""
+
+#. Found in the Reference Images panel after a reference image has been imported.
+msgid "Select an image below to change its properties.\n"
+"Note that you cannot draw while a reference image is selected."
+msgstr ""
+
+#. Removes the selected reference image.
+msgid "Remove"
+msgstr ""
+
 #. A tooltip to tell users to hold the Shift key while clicking the remove button
-msgid "Hold Shift while pressing to instantly remove"
+msgid "Hold Shift while pressing to instantly remove."
+msgstr ""
+
+#. Shown in the confirmation dialog for removing a reference image.
+msgid "Are you sure you want to remove this reference image? It will not be deleted from your file system."
 msgstr ""
 
 #. Moves the reference image up in the list
@@ -2952,6 +3068,38 @@ msgstr ""
 
 #. Rotates the reference on the canvas
 msgid "Scale the selected reference image"
+msgstr ""
+
+#. Button to select no reference images in the Reference Images panel.
+msgid "none"
+msgstr ""
+
+#. Resets the Transform of the selected reference image on the canvas.
+msgid "Reset Transform"
+msgstr ""
+
+#. Position of the selected reference image on the canvas.
+msgid "Position"
+msgstr ""
+
+#. Scale of the selected reference image on the canvas.
+msgid "Scale"
+msgstr ""
+
+#. Rotation of the selected reference image on the canvas.
+msgid "Rotation"
+msgstr ""
+
+#. Toggle filter of the selected reference image on the canvas.
+msgid "Filter"
+msgstr ""
+
+#. Opacity of the selected reference image on the canvas.
+msgid "Opacity"
+msgstr ""
+
+#. Color clamping of the selected reference image on the canvas.
+msgid "Color Clamping"
 msgstr ""
 
 #. Used in checkbuttons (like on/off switches) that enable/disable something.

--- a/src/UI/ColorPickers/ColorPicker.gd
+++ b/src/UI/ColorPickers/ColorPicker.gd
@@ -92,6 +92,8 @@ func _notification(what: int) -> void:
 		await get_tree().process_frame
 		hsv_rectangle_control.custom_minimum_size = Vector2(32, 32)
 		shape_aspect_ratio.custom_minimum_size = Vector2(32, 32)
+	elif what == NOTIFICATION_TRANSLATION_CHANGED:
+		_average(left_color_rect.color, right_color_rect.color)
 
 
 func _on_color_picker_color_changed(color: Color) -> void:
@@ -150,7 +152,7 @@ func _on_expand_button_toggled(toggled_on: bool) -> void:
 func _average(color_1: Color, color_2: Color) -> void:
 	var average := (color_1 + color_2) / 2.0
 	var copy_button := average_color.get_parent() as Control
-	copy_button.tooltip_text = str("Average Color:\n#", average.to_html())
+	copy_button.tooltip_text = str(tr("Average Color:"), "\n#", average.to_html())
 	average_color.color = average
 
 

--- a/src/UI/Dialogs/ExportDialog.tscn
+++ b/src/UI/Dialogs/ExportDialog.tscn
@@ -151,7 +151,7 @@ popup/item_0/text = "Forward"
 popup/item_0/id = 0
 popup/item_1/text = "Backwards"
 popup/item_1/id = 1
-popup/item_2/text = "Ping-pong"
+popup/item_2/text = "Ping-Pong"
 popup/item_2/id = 2
 
 [node name="ResizeLabel" type="Label" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer"]

--- a/src/UI/ReferenceImages/ReferencesPanel.tscn
+++ b/src/UI/ReferenceImages/ReferencesPanel.tscn
@@ -330,7 +330,7 @@ max_value = 180.0
 
 [node name="ColorLabel" type="Label" parent="ScrollContainer/Container/ReferenceEdit/Options"]
 layout_mode = 2
-text = "Color Options"
+text = "Color options"
 
 [node name="Spacer2" type="Control" parent="ScrollContainer/Container/ReferenceEdit/Options"]
 layout_mode = 2


### PR DESCRIPTION
Adds many missing strings to `Translations.pot` and fixes a few ones that were broken either because of missing periods, differences in capitalization or because of trailing newlines (the latter seems to get automatically trimmed in tooltips during runtime, better watch out for those in the future).
I don't know if anything is lost when an existing source string is changed in crowdin, so I mostly updated the broken strings in Pixelorama instead where I could in order to match the ones in the POT.