### PR TITLE
Add setting for Godots low processor usage mode

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -475,7 +475,7 @@ var fps_limit := 0:
 ## Found in Preferences. Affects the per_pixel_transparency project setting.
 ## If [code]true[/code], it allows for the window to be transparent.
 ## This affects performance, so keep it [code]false[/code] if you don't need it.
-var update_continuously := true:
+var update_continuously := false:
 	set(value):
 		update_continuously = value
 		OS.low_processor_usage_mode = !value

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -475,12 +475,10 @@ var fps_limit := 0:
 ## Found in Preferences. Affects the per_pixel_transparency project setting.
 ## If [code]true[/code], it allows for the window to be transparent.
 ## This affects performance, so keep it [code]false[/code] if you don't need it.
-var low_processor_usage := true:
+var update_continuously := true:
 	set(value):
-		if value == low_processor_usage:
-			return
-		low_processor_usage = value
-		OS.low_processor_usage_mode = value
+		update_continuously = value
+		OS.low_processor_usage_mode = !value
 var window_transparency := false:
 	set(value):
 		if value == window_transparency:
@@ -686,7 +684,6 @@ func _init() -> void:
 	if ProjectSettings.get_setting("display/window/tablet_driver") == "winink":
 		tablet_driver = 1
 	single_window_mode = ProjectSettings.get_setting("display/window/subwindows/embed_subwindows")
-	low_processor_usage = ProjectSettings.get_setting("application/run/low_processor_mode")
 	window_transparency = ProjectSettings.get_setting(
 		"display/window/per_pixel_transparency/allowed"
 	)

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -475,6 +475,12 @@ var fps_limit := 0:
 ## Found in Preferences. Affects the per_pixel_transparency project setting.
 ## If [code]true[/code], it allows for the window to be transparent.
 ## This affects performance, so keep it [code]false[/code] if you don't need it.
+var low_processor_usage := true:
+	set(value):
+		if value == low_processor_usage:
+			return
+		low_processor_usage = value
+		OS.low_processor_usage_mode = value
 var window_transparency := false:
 	set(value):
 		if value == window_transparency:
@@ -680,6 +686,7 @@ func _init() -> void:
 	if ProjectSettings.get_setting("display/window/tablet_driver") == "winink":
 		tablet_driver = 1
 	single_window_mode = ProjectSettings.get_setting("display/window/subwindows/embed_subwindows")
+	low_processor_usage = ProjectSettings.get_setting("application/run/low_processor_mode")
 	window_transparency = ProjectSettings.get_setting(
 		"display/window/per_pixel_transparency/allowed"
 	)

--- a/src/Preferences/PreferencesDialog.gd
+++ b/src/Preferences/PreferencesDialog.gd
@@ -176,6 +176,12 @@ var preferences: Array[Preference] = [
 		true
 	),
 	Preference.new(
+		"low_processor_usage",
+		"Performance/PerformanceContainer/LowProcessorUsage",
+		"button_pressed",
+		true
+	),
+	Preference.new(
 		"window_transparency",
 		"Performance/PerformanceContainer/WindowTransparency",
 		"button_pressed",

--- a/src/Preferences/PreferencesDialog.gd
+++ b/src/Preferences/PreferencesDialog.gd
@@ -176,10 +176,10 @@ var preferences: Array[Preference] = [
 		true
 	),
 	Preference.new(
-		"low_processor_usage",
-		"Performance/PerformanceContainer/LowProcessorUsage",
+		"update_continuously",
+		"Performance/PerformanceContainer/UpdateContinuously",
 		"button_pressed",
-		true
+		false
 	),
 	Preference.new(
 		"window_transparency",

--- a/src/Preferences/PreferencesDialog.tscn
+++ b/src/Preferences/PreferencesDialog.tscn
@@ -1058,6 +1058,19 @@ mouse_default_cursor_shape = 2
 button_pressed = true
 text = "On"
 
+[node name="LowProcessorUsageLabel" type="Label" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Performance/PerformanceContainer"]
+layout_mode = 2
+tooltip_text = "If this is toggled on, the application will slow down when not used. This helps lower CPU usage when idle."
+mouse_filter = 0
+text = "Lower processing speed when not in use"
+
+[node name="LowProcessorUsage" type="CheckBox" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Performance/PerformanceContainer"]
+layout_mode = 2
+tooltip_text = "If this is toggled on, the application will slow down when not used. This helps lower CPU usage when idle."
+mouse_default_cursor_shape = 2
+button_pressed = true
+text = "On"
+
 [node name="WindowTransparencyLabel" type="Label" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Performance/PerformanceContainer"]
 layout_mode = 2
 tooltip_text = "If enabled, the application window can become transparent. This affects performance, so keep it off if you don't need it."

--- a/src/Preferences/PreferencesDialog.tscn
+++ b/src/Preferences/PreferencesDialog.tscn
@@ -1058,15 +1058,15 @@ mouse_default_cursor_shape = 2
 button_pressed = true
 text = "On"
 
-[node name="LowProcessorUsageLabel" type="Label" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Performance/PerformanceContainer"]
+[node name="UpdateContinuouslyLabel" type="Label" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Performance/PerformanceContainer"]
 layout_mode = 2
-tooltip_text = "If this is toggled on, the application will slow down when not used. This helps lower CPU usage when idle."
+tooltip_text = "If this is toggled on, the application will redraw the screen continuously, even while it's not used. Turning this off helps lower CPU and GPU usage when idle."
 mouse_filter = 0
-text = "Lower processing speed when not in use"
+text = "Update Continuously"
 
-[node name="LowProcessorUsage" type="CheckBox" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Performance/PerformanceContainer"]
+[node name="UpdateContinuously" type="CheckBox" parent="HSplitContainer/VBoxContainer/ScrollContainer/RightSide/Performance/PerformanceContainer"]
 layout_mode = 2
-tooltip_text = "If this is toggled on, the application will slow down when not used. This helps lower CPU usage when idle."
+tooltip_text = "If this is toggled on, the application will redraw the screen continuously, even while it's not used. Turning this off helps lower CPU and GPU usage when idle."
 mouse_default_cursor_shape = 2
 button_pressed = true
 text = "On"


### PR DESCRIPTION
Someone reported problems with lagging UI on discord. It looks like it is Godots low processor usage mode not working correctly, so i thought we could add a setting for disabling it.