### PR TITLE
.gitmodules: remove

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "addons/godot-gifexporter"]
-	path = addons/godot-gifexporter
-	url = https://github.com/novhack/godot-gifexporter.git


### PR DESCRIPTION
> https://github.com/novhack/godot-gifexporter.git

Is for Godot 3 and seems outdated. I haven't found any reference to it.