### PR TITLE
Fix Orama-Interactive#958 (reset custom brush when switch another tool)

### DIFF
--- a/src/UI/Buttons/BrushesPopup.gd
+++ b/src/UI/Buttons/BrushesPopup.gd
@@ -96,6 +96,7 @@ static func clear_project_brush() -> void:
 		"Background/Brushes/Categories/ProjectBrushContainer"
 	)
 	for child in container.get_children():
+		container.remove_child(child)
 		child.queue_free()
 		Global.brushes_popup.brush_removed.emit(child.brush)
 


### PR DESCRIPTION
This should fix issue #958 (reset custom brush when switch another tool) by removing the childs safely from BrushPopup when project data is cleared.