### PR TITLE
Change german translation for "Unlink Cels"

### DIFF
--- a/Translations/de_DE.po
+++ b/Translations/de_DE.po
@@ -2132,7 +2132,7 @@ msgid "Link Cels to"
 msgstr "Cels verknüpfen mit"
 
 msgid "Unlink Cels"
-msgstr "Cels entfernen"
+msgstr "Cels Verknüpfung entfernen"
 
 msgid "Properties"
 msgstr "Eigenschaften"


### PR DESCRIPTION
Changed the german translation for "Unlink Cels" as the old translation means "Remove cel" which I interpreted as "cel/cel content will be deleted"