### PR TITLE
Add WinGet as the installation variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Stable versions:
 - [GitHub Pages (Web)](https://orama-interactive.github.io/Pixelorama/)
 - [Flathub (Linux)](https://flathub.org/apps/details/com.orama_interactive.Pixelorama)
 - [Snap Store (Linux)](https://snapcraft.io/pixelorama)
+- WinGet (Windows) - `winget install pixelorama`
 
 You can also find early access builds in the [GitHub Actions page](https://github.com/Orama-Interactive/Pixelorama/actions). There's also a [Web version available](https://orama-interactive.github.io/Pixelorama/early_access/).
 Keep in mind that these versions will have bugs and are unstable. Unless you're interested in testing the main branch of Pixelorama, it's recommended that you stick to a stable version.


### PR DESCRIPTION
Pixelorama has been added to WinGet repository: https://github.com/microsoft/winget-pkgs/pull/170556, it pulls the GitHub release ZIP and installs the package in the system.
This PR adds the info about the required command to install the package via WinGet.