### PR TITLE
Performance boost for spritesheet export

### DIFF
--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -25,39 +25,39 @@ func blend_layers(
 	only_selected_cels := false,
 	only_selected_layers := false,
 ) -> void:
-	var frame_index := project.frames.find(frame)
+	var frame_index: int = project.frames.find(frame)
 	var previous_ordered_layers: Array[int] = project.ordered_layers
 	project.order_layers(frame_index)
 	var textures: Array[Image] = []
 	# Nx4 texture, where N is the number of layers and the first row are the blend modes,
 	# the second are the opacities, the third are the origins and the fourth are the
 	# clipping mask booleans.
-	var metadata_image := Image.create(project.layers.size(), 4, false, Image.FORMAT_R8)
+	var metadata_image: Image = Image.create(project.layers.size(), 4, false, Image.FORMAT_R8)
 	for i in project.layers.size():
-		var ordered_index := project.ordered_layers[i]
-		var layer := project.layers[ordered_index]
-		var include := true if layer.is_visible_in_hierarchy() else false
+		var ordered_index: int = project.ordered_layers[i]
+		var layer: BaseLayer = project.layers[ordered_index]
+		var include: bool = true if layer.is_visible_in_hierarchy() else false
 		if only_selected_cels and include:
 			var test_array := [frame_index, i]
 			if not test_array in project.selected_cels:
 				include = false
 		if only_selected_layers and include:
-			var layer_is_selected := false
+			var layer_is_selected: bool = false
 			for selected_cel in project.selected_cels:
 				if i == selected_cel[1]:
 					layer_is_selected = true
 					break
 			if not layer_is_selected:
 				include = false
-		var cel := frame.cels[ordered_index]
+		var cel: BaseCel = frame.cels[ordered_index]
 		if DisplayServer.get_name() == "headless":
 			blend_layers_headless(image, project, layer, cel, origin)
 		else:
 			if layer is GroupLayer and layer.blend_mode != BaseLayer.BlendModes.PASS_THROUGH:
-				var cel_image := (layer as GroupLayer).blend_children(frame)
+				var cel_image: Image = (layer as GroupLayer).blend_children(frame)
 				textures.append(cel_image)
 			else:
-				var cel_image := layer.display_effects(cel)
+				var cel_image: Image = layer.display_effects(cel)
 				textures.append(cel_image)
 			if (
 				layer.is_blended_by_ancestor()
@@ -67,13 +67,13 @@ func blend_layers(
 				include = false
 			set_layer_metadata_image(layer, cel, metadata_image, ordered_index, include)
 	if DisplayServer.get_name() != "headless":
-		var texture_array := Texture2DArray.new()
+		var texture_array: Texture2DArray = Texture2DArray.new()
 		texture_array.create_from_images(textures)
 		var params := {
 			"layers": texture_array,
 			"metadata": ImageTexture.create_from_image(metadata_image),
 		}
-		var blended := Image.create(project.size.x, project.size.y, false, image.get_format())
+		var blended: Image = Image.create(project.size.x, project.size.y, false, image.get_format())
 		var gen := ShaderImageEffect.new()
 		gen.generate_image(blended, blend_layers_shader, params, project.size)
 		image.blend_rect(blended, Rect2i(Vector2i.ZERO, project.size), origin)

--- a/src/UI/Dialogs/ExportDialog.tscn
+++ b/src/UI/Dialogs/ExportDialog.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=3 uid="uid://clgu8wb5o6oup"]
+[gd_scene load_steps=6 format=3 uid="uid://clgu8wb5o6oup"]
 
 [ext_resource type="Script" path="res://src/UI/Dialogs/ExportDialog.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://3pmb60gpst7b" path="res://src/UI/Nodes/TransparentChecker.tscn" id="2"]
 [ext_resource type="Script" path="res://src/UI/Nodes/CollapsibleContainer.gd" id="3"]
+[ext_resource type="PackedScene" uid="uid://yjhp0ssng2mp" path="res://src/UI/Nodes/ValueSlider.tscn" id="3_u6gtq"]
 [ext_resource type="Script" path="res://src/UI/Nodes/ValueSlider.gd" id="4"]
 
 [node name="ExportDialog" type="ConfirmationDialog"]
@@ -84,6 +85,7 @@ item_count = 4
 popup/item_0/text = "Columns"
 popup/item_0/id = 1
 popup/item_1/text = "Rows"
+popup/item_1/id = 1
 popup/item_2/text = "Tags by column"
 popup/item_2/id = 2
 popup/item_3/text = "Tags by row"
@@ -94,11 +96,12 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Columns:"
 
-[node name="LinesCount" type="SpinBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer" groups=["ExportSpritesheetOptions"]]
+[node name="LinesCount" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer" groups=["ExportSpritesheetOptions"] instance=ExtResource("3_u6gtq")]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 0)
 layout_mode = 2
-size_flags_horizontal = 3
-mouse_default_cursor_shape = 2
+focus_mode = 0
+theme_type_variation = &""
 min_value = 1.0
 max_value = 1000.0
 value = 1.0
@@ -358,6 +361,11 @@ size_flags_horizontal = 3
 
 [node name="FrameTimer" type="Timer" parent="."]
 
+[node name="SpritesheetUpdateTimer" type="Timer" parent="."]
+unique_name_in_owner = true
+wait_time = 0.2
+one_shot = true
+
 [connection signal="about_to_popup" from="." to="." method="_on_ExportDialog_about_to_show"]
 [connection signal="confirmed" from="." to="." method="_on_ExportDialog_confirmed"]
 [connection signal="tab_clicked" from="VBoxContainer/TabBar" to="." method="_on_Tabs_tab_clicked"]
@@ -384,3 +392,4 @@ size_flags_horizontal = 3
 [connection signal="confirmed" from="FileExistsAlert" to="." method="_on_FileExistsAlert_confirmed"]
 [connection signal="custom_action" from="FileExistsAlert" to="." method="_on_FileExistsAlert_custom_action"]
 [connection signal="timeout" from="FrameTimer" to="." method="_on_FrameTimer_timeout"]
+[connection signal="timeout" from="SpritesheetUpdateTimer" to="." method="_on_spritesheet_update_timer_timeout"]


### PR DESCRIPTION
1. Added some static typing (i heard cases like `: bool`, `: Vector2i` etc works faster than `:=` so i changed them)
2. Added a recycling system for spritesheets, (old spritesheets get reused and only the different parts get changed). this makes changes to nearby values (e.g slider moved from `rows = 23` to `rows =  24`) almost instantaneous.
3. Added a slight delay between Valueslider (Yeah, i changed row/column `SpinBox` to a `Valueslider` :grin: ), this delay works the same as the Live Preview option in some ImageEffects, making it more smooth.