### PR TITLE
somewhat fix transparency for floating window

### DIFF
--- a/src/UI/Dialogs/WindowOpacityDialog.gd
+++ b/src/UI/Dialogs/WindowOpacityDialog.gd
@@ -1,9 +1,9 @@
 extends AcceptDialog
 
+var main_canvas := Global.control.find_child("Main Canvas", true, false)
+
 @onready var slider := $VBoxContainer/ValueSlider as ValueSlider
 @onready var fullscreen_warning := $VBoxContainer/FullscreenWarning as Label
-
-var main_canvas := Global.control.find_child("Main Canvas", true, false)
 
 
 func _ready() -> void:

--- a/src/UI/Dialogs/WindowOpacityDialog.gd
+++ b/src/UI/Dialogs/WindowOpacityDialog.gd
@@ -2,17 +2,21 @@ extends AcceptDialog
 
 @onready var slider := $VBoxContainer/ValueSlider as ValueSlider
 @onready var fullscreen_warning := $VBoxContainer/FullscreenWarning as Label
-@onready var main_canvas := Global.control.find_child("Main Canvas") as Control
+
+var main_canvas := Global.control.find_child("Main Canvas", true, false)
 
 
 func _ready() -> void:
+	if main_canvas is FloatingWindow:  ## If it's shifted to a window then get the content
+		main_canvas = main_canvas.window_content
 	await get_tree().process_frame
 	Global.control.main_ui.sort_children.connect(_recalculate_opacity)
 
 
 func _on_WindowOpacityDialog_about_to_show() -> void:
-	get_tree().root.transparent = true
-	get_tree().root.transparent_bg = true
+	var canvas_window = main_canvas.get_window()
+	canvas_window.transparent = true
+	canvas_window.transparent_bg = true
 	slider.editable = not is_fullscreen()
 	fullscreen_warning.visible = not slider.editable
 
@@ -31,7 +35,11 @@ func set_window_opacity(value: float) -> void:
 		if container is TabContainer:
 			var center := container.get_rect().get_center()
 			if main_canvas.get_rect().has_point(center):
-				container.self_modulate.a = value
+				if main_canvas.get_window() != get_tree().root:
+					## In case we converted to window while trransparency was active
+					container.self_modulate.a = 1.0
+				else:
+					container.self_modulate.a = value
 	Global.transparent_checker.update_transparency(value)
 
 

--- a/src/UI/UI.gd
+++ b/src/UI/UI.gd
@@ -2,9 +2,25 @@ extends Panel
 
 @onready var main_canvas_container := find_child("Main Canvas") as Container
 
+var shader_moved := false
+var transparency_material: ShaderMaterial
 
 func _ready() -> void:
+	transparency_material = material
+	main_canvas_container.property_list_changed.connect(_re_configure_shader)
 	update_transparent_shader()
+
+
+func _re_configure_shader():
+	await get_tree().process_frame
+	if get_window() != main_canvas_container.get_window():
+		main_canvas_container.material = transparency_material
+		material = null
+		shader_moved = true
+	else:
+		if shader_moved:
+			material = transparency_material
+			shader_moved = false
 
 
 func _on_main_canvas_item_rect_changed() -> void:
@@ -20,6 +36,6 @@ func update_transparent_shader() -> void:
 		return
 	# Works independently of the transparency feature
 	var canvas_size: Vector2 = (main_canvas_container.size - Vector2.DOWN * 2) * Global.shrink
-	material.set_shader_parameter("screen_resolution", get_viewport().size)
-	material.set_shader_parameter("position", main_canvas_container.global_position * Global.shrink)
-	material.set_shader_parameter("size", canvas_size)
+	transparency_material.set_shader_parameter("screen_resolution", get_viewport().size)
+	transparency_material.set_shader_parameter("position", main_canvas_container.global_position * Global.shrink)
+	transparency_material.set_shader_parameter("size", canvas_size)

--- a/src/UI/UI.gd
+++ b/src/UI/UI.gd
@@ -1,9 +1,10 @@
 extends Panel
 
+var shader_disabled := false
+var transparency_material: ShaderMaterial
+
 @onready var main_canvas_container := find_child("Main Canvas") as Container
 
-var shader_moved := false
-var transparency_material: ShaderMaterial
 
 func _ready() -> void:
 	transparency_material = material
@@ -14,13 +15,12 @@ func _ready() -> void:
 func _re_configure_shader():
 	await get_tree().process_frame
 	if get_window() != main_canvas_container.get_window():
-		main_canvas_container.material = transparency_material
 		material = null
-		shader_moved = true
+		shader_disabled = true
 	else:
-		if shader_moved:
+		if shader_disabled:
 			material = transparency_material
-			shader_moved = false
+			shader_disabled = false
 
 
 func _on_main_canvas_item_rect_changed() -> void:


### PR DESCRIPTION
Transparency works as expected when Main canvas is part of MAIN window.
but if it gets detached then it behaves un-expectedly in some ways.
- Transparency shader still remains in the Main window (so i temporarily remove it when main canvas is a floating window)
- The transparency didn't work for Floating window (It works now, but only the transparent checker gets modulated, the rest of window is fully transparent which was kinda un-avoidable).

I don't see a reason why a user would decide to detach the Main canvas (Plus enable transparency) but if they do then i hope this will minimize the annoyance