### PR TITLE
Fix: Keep Screen On = False. Allows to turn off screen when app is open and system idle (energy efficient). (one-liner)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -54,6 +54,7 @@ gdscript/warnings/narrowing_conversion=false
 
 window/size/viewport_width=1280
 window/size/viewport_height=720
+window/energy_saving/keep_screen_on=false
 window/per_pixel_transparency/allowed.android=false
 window/per_pixel_transparency/allowed.web=false
 


### PR DESCRIPTION
Godot's project settings are configured by default to prevent the system from turning off the screen. While this is helpful for games—such as when playing a cutscene—it’s less useful for creative tools like Pixelorama. When Pixelorama remains open during pauses in the creative process, this behavior can lead to unnecessary power consumption.

Solves
https://github.com/Orama-Interactive/Pixelorama/discussions/1124


Solution description: 
Updated project.godot to set window/energy_saving/keep_screen_on to false (by default is true)

Making use of
https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-property-display-window-energy-saving-keep-screen-on

> If true, keeps the screen on (even in case of inactivity), so the screensaver does not take over. Works on desktop and mobile platforms.