### PR TITLE
Add a way to get autoloads through the api

### DIFF
--- a/src/Autoload/ExtensionsApi.gd
+++ b/src/Autoload/ExtensionsApi.gd
@@ -381,6 +381,10 @@ class PanelAPI:
 
 ## Gives access to theme related functions.
 class ThemeAPI:
+	## Returns the Themes autoload. Allows interacting with themes on a more deeper level.
+	func get_autoload() -> Themes:
+		return Themes
+
 	## Adds the [param theme] to [code]Edit -> Preferences -> Interface -> Themes[/code].
 	func add_theme(theme: Theme) -> void:
 		Themes.add_theme(theme)
@@ -437,6 +441,10 @@ class ThemeAPI:
 class ToolAPI:
 	# gdlint: ignore=constant-name
 	const LayerTypes := Global.LayerTypes
+
+	## Returns the Tools autoload. Allows interacting with tools on a more deeper level.
+	func get_autoload() -> Tools:
+		return Tools
 
 	## Adds a tool to pixelorama with name [param tool_name] (without spaces),
 	## display name [param display_name], tool scene [param scene], layers that the tool works
@@ -678,6 +686,11 @@ class ExportAPI:
 	# gdlint: ignore=constant-name
 	const ExportTab := Export.ExportTab
 
+	## Returns the Export autoload.
+	## Allows interacting with the export workflow on a more deeper level.
+	func get_autoload() -> Export:
+		return Export
+
 	## [param format_info] has keys: [code]extension[/code] and [code]description[/code]
 	## whose values are of type [String] e.g:[codeblock]
 	## format_info = {"extension": ".gif", "description": "GIF Image"}
@@ -730,6 +743,11 @@ class ExportAPI:
 
 ## Gives access to adding custom import options.
 class ImportAPI:
+	## Returns the OpenSave autoload. Contains code to handle file loading.
+	## It also contains code to handle project saving (.pxo)
+	func get_autoload() -> OpenSave:
+		return OpenSave
+
 	## [param import_scene] is a scene preload that will be instanced and added to "import options"
 	## section of pixelorama's import dialogs and will appear whenever [param import_name] is
 	## chosen from import menu.
@@ -757,6 +775,10 @@ class ImportAPI:
 
 ## Gives access to palette related stuff.
 class PaletteAPI:
+	## Returns the Palettes autoload. Allows interacting with palettes on a more deeper level.
+	func get_autoload() -> Palettes:
+		return Palettes
+
 	## Creates and adds a new [Palette] with name [param palette_name] containing [param data].
 	## [param data] is a [Dictionary] containing the palette information.
 	## An example of [code]data[/code] will be:[codeblock]

--- a/src/Autoload/ExtensionsApi.gd
+++ b/src/Autoload/ExtensionsApi.gd
@@ -382,7 +382,7 @@ class PanelAPI:
 ## Gives access to theme related functions.
 class ThemeAPI:
 	## Returns the Themes autoload. Allows interacting with themes on a more deeper level.
-	func get_autoload() -> Themes:
+	func autoload() -> Themes:
 		return Themes
 
 	## Adds the [param theme] to [code]Edit -> Preferences -> Interface -> Themes[/code].
@@ -443,7 +443,7 @@ class ToolAPI:
 	const LayerTypes := Global.LayerTypes
 
 	## Returns the Tools autoload. Allows interacting with tools on a more deeper level.
-	func get_autoload() -> Tools:
+	func autoload() -> Tools:
 		return Tools
 
 	## Adds a tool to pixelorama with name [param tool_name] (without spaces),
@@ -688,7 +688,7 @@ class ExportAPI:
 
 	## Returns the Export autoload.
 	## Allows interacting with the export workflow on a more deeper level.
-	func get_autoload() -> Export:
+	func autoload() -> Export:
 		return Export
 
 	## [param format_info] has keys: [code]extension[/code] and [code]description[/code]
@@ -745,8 +745,11 @@ class ExportAPI:
 class ImportAPI:
 	## Returns the OpenSave autoload. Contains code to handle file loading.
 	## It also contains code to handle project saving (.pxo)
-	func get_autoload() -> OpenSave:
+	func open_save_autoload() -> OpenSave:
 		return OpenSave
+
+	func import_autoload() -> Import:
+		return Import
 
 	## [param import_scene] is a scene preload that will be instanced and added to "import options"
 	## section of pixelorama's import dialogs and will appear whenever [param import_name] is
@@ -776,7 +779,7 @@ class ImportAPI:
 ## Gives access to palette related stuff.
 class PaletteAPI:
 	## Returns the Palettes autoload. Allows interacting with palettes on a more deeper level.
-	func get_autoload() -> Palettes:
+	func autoload() -> Palettes:
 		return Palettes
 
 	## Creates and adds a new [Palette] with name [param palette_name] containing [param data].

--- a/src/Autoload/ExtensionsApi.gd
+++ b/src/Autoload/ExtensionsApi.gd
@@ -748,6 +748,7 @@ class ImportAPI:
 	func open_save_autoload() -> OpenSave:
 		return OpenSave
 
+	## Returns the Import autoload. Manages import of brushes and patterns.
 	func import_autoload() -> Import:
 		return Import
 


### PR DESCRIPTION
This allows accessing autoloads by placing an `autoload()` method in their related apis
(for the ImportApi, there are actually 2 available autoloads so it slightly deviates from the above naming convention)

this won't cover (as i don't think these are not important, and we don't have a category for it)
- Html5FileExchange
- Keychain