### PR TITLE
Implement indexed mode

### DIFF
--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -156,6 +156,14 @@ msgstr ""
 msgid "Percentage"
 msgstr ""
 
+#. Found in the image menu. A submenu that allows users to change the color mode of the project, such as RGBA or indexed mode.
+msgid "Color Mode"
+msgstr ""
+
+#. Found in the image menu, under the "Color Mode" submenu. Refers to the indexed color mode. See this wikipedia page for more information: https://en.wikipedia.org/wiki/Indexed_color
+msgid "Indexed"
+msgstr ""
+
 #. Found in the image menu. Sets the size of the project to be the same as the size of the active selection.
 msgid "Crop to Selection"
 msgstr ""

--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -156,6 +156,10 @@ msgstr ""
 msgid "Percentage"
 msgstr ""
 
+#. Found in the create new image dialog. Allows users to change the color mode of the new project, such as RGBA or indexed mode.
+msgid "Color mode:"
+msgstr ""
+
 #. Found in the image menu. A submenu that allows users to change the color mode of the project, such as RGBA or indexed mode.
 msgid "Color Mode"
 msgstr ""

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -217,7 +217,7 @@ func get_ellipse_points_filled(pos: Vector2i, size: Vector2i, thickness := 1) ->
 
 func scale_3x(sprite: Image, tol := 0.196078) -> Image:
 	var scaled := Image.create(
-		sprite.get_width() * 3, sprite.get_height() * 3, false, Image.FORMAT_RGBA8
+		sprite.get_width() * 3, sprite.get_height() * 3, false, sprite.get_format()
 	)
 	var width_minus_one := sprite.get_width() - 1
 	var height_minus_one := sprite.get_height() - 1
@@ -528,7 +528,9 @@ func center(indices: Array) -> void:
 		for cel in project.frames[frame].cels:
 			if not cel is PixelCel:
 				continue
-			var sprite := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+			var sprite := Image.create(
+				project.size.x, project.size.y, false, project.get_image_format()
+			)
 			sprite.blend_rect(cel.image, used_rect, offset)
 			Global.undo_redo_compress_images({cel.image: sprite.data}, {cel.image: cel.image.data})
 	project.undo_redo.add_undo_method(Global.undo_or_redo.bind(true))
@@ -633,7 +635,9 @@ func resize_canvas(width: int, height: int, offset_x: int, offset_y: int) -> voi
 		for cel in f.cels:
 			if not cel is PixelCel:
 				continue
-			var sprite := Image.create(width, height, false, Image.FORMAT_RGBA8)
+			var sprite := Image.create(
+				width, height, false, Global.current_project.get_image_format()
+			)
 			sprite.blend_rect(
 				cel.get_image(),
 				Rect2i(Vector2i.ZERO, Global.current_project.size),

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -217,7 +217,7 @@ func get_ellipse_points_filled(pos: Vector2i, size: Vector2i, thickness := 1) ->
 
 func scale_3x(sprite: Image, tol := 0.196078) -> Image:
 	var scaled := Image.create(
-		sprite.get_width() * 3, sprite.get_height() * 3, false, sprite.get_format()
+		sprite.get_width() * 3, sprite.get_height() * 3, sprite.has_mipmaps(), sprite.get_format()
 	)
 	var width_minus_one := sprite.get_width() - 1
 	var height_minus_one := sprite.get_height() - 1

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -528,9 +528,7 @@ func center(indices: Array) -> void:
 		for cel in project.frames[frame].cels:
 			if not cel is PixelCel:
 				continue
-			var sprite := Image.create(
-				project.size.x, project.size.y, false, project.get_image_format()
-			)
+			var sprite := project.new_empty_image()
 			sprite.blend_rect(cel.image, used_rect, offset)
 			Global.undo_redo_compress_images({cel.image: sprite.data}, {cel.image: cel.image.data})
 	project.undo_redo.add_undo_method(Global.undo_or_redo.bind(true))

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -533,7 +533,7 @@ func center(indices: Array) -> void:
 			var cel_image := (cel as PixelCel).get_image()
 			var tmp_centered := project.new_empty_image()
 			tmp_centered.blend_rect(cel.image, used_rect, offset)
-			var centered := PixeloramaImage.new()
+			var centered := ImageExtended.new()
 			centered.copy_from_custom(tmp_centered, cel_image.is_indexed)
 			centered.add_data_to_dictionary(redo_data, cel_image)
 			cel_image.add_data_to_dictionary(undo_data)
@@ -552,7 +552,7 @@ func scale_project(width: int, height: int, interpolation: int) -> void:
 			if not cel is PixelCel:
 				continue
 			var cel_image := (cel as PixelCel).get_image()
-			var sprite := _resize_image(cel_image, width, height, interpolation) as PixeloramaImage
+			var sprite := _resize_image(cel_image, width, height, interpolation) as ImageExtended
 			sprite.add_data_to_dictionary(redo_data, cel_image)
 			cel_image.add_data_to_dictionary(undo_data)
 
@@ -563,8 +563,8 @@ func _resize_image(
 	image: Image, width: int, height: int, interpolation: Image.Interpolation
 ) -> Image:
 	var new_image: Image
-	if image is PixeloramaImage:
-		new_image = PixeloramaImage.new()
+	if image is ImageExtended:
+		new_image = ImageExtended.new()
 		new_image.is_indexed = image.is_indexed
 		new_image.copy_from(image)
 		new_image.select_palette("", false)
@@ -587,7 +587,7 @@ func _resize_image(
 		gen.generate_image(new_image, omniscale_shader, {}, Vector2i(width, height), false)
 	else:
 		new_image.resize(width, height, interpolation)
-	if new_image is PixeloramaImage:
+	if new_image is ImageExtended:
 		new_image.on_size_changed()
 	return new_image
 
@@ -604,7 +604,7 @@ func crop_to_selection() -> void:
 	for cel in Global.current_project.get_all_pixel_cels():
 		var cel_image := cel.get_image()
 		var tmp_cropped := cel_image.get_region(rect)
-		var cropped := PixeloramaImage.new()
+		var cropped := ImageExtended.new()
 		cropped.copy_from_custom(tmp_cropped, cel_image.is_indexed)
 		cropped.add_data_to_dictionary(redo_data, cel_image)
 		cel_image.add_data_to_dictionary(undo_data)
@@ -642,7 +642,7 @@ func crop_to_content() -> void:
 	for cel in Global.current_project.get_all_pixel_cels():
 		var cel_image := cel.get_image()
 		var tmp_cropped := cel_image.get_region(used_rect)
-		var cropped := PixeloramaImage.new()
+		var cropped := ImageExtended.new()
 		cropped.copy_from_custom(tmp_cropped, cel_image.is_indexed)
 		cropped.add_data_to_dictionary(redo_data, cel_image)
 		cel_image.add_data_to_dictionary(undo_data)
@@ -655,7 +655,7 @@ func resize_canvas(width: int, height: int, offset_x: int, offset_y: int) -> voi
 	var undo_data := {}
 	for cel in Global.current_project.get_all_pixel_cels():
 		var cel_image := cel.get_image()
-		var resized := PixeloramaImage.create_custom(
+		var resized := ImageExtended.create_custom(
 			width, height, cel_image.has_mipmaps(), cel_image.get_format(), cel_image.is_indexed
 		)
 		resized.blend_rect(

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -161,7 +161,7 @@ func cache_blended_frames(project := Global.current_project) -> void:
 	blended_frames.clear()
 	var frames := _calculate_frames(project)
 	for frame in frames:
-		var image := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+		var image := Image.create(project.size.x, project.size.y, false, project.get_image_format())
 		_blend_layers(image, frame)
 		blended_frames[frame] = image
 
@@ -208,7 +208,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 			spritesheet_columns = temp
 	var width := project.size.x * spritesheet_columns
 	var height := project.size.y * spritesheet_rows
-	var whole_image := Image.create(width, height, false, Image.FORMAT_RGBA8)
+	var whole_image := Image.create(width, height, false, project.get_image_format())
 	var origin := Vector2i.ZERO
 	var hh := 0
 	var vv := 0
@@ -287,10 +287,14 @@ func process_animation(project := Global.current_project) -> void:
 					ProcessedImage.new(image, project.frames.find(frame), duration)
 				)
 		else:
-			var image := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+			var image := Image.create(
+				project.size.x, project.size.y, false, project.get_image_format()
+			)
 			image.copy_from(blended_frames[frame])
 			if erase_unselected_area and project.has_selection:
-				var crop := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+				var crop := Image.create(
+					project.size.x, project.size.y, false, project.get_image_format()
+				)
 				var selection_image = project.selection_map.return_cropped_copy(project.size)
 				crop.blit_rect_mask(
 					image, selection_image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -161,7 +161,7 @@ func cache_blended_frames(project := Global.current_project) -> void:
 	blended_frames.clear()
 	var frames := _calculate_frames(project)
 	for frame in frames:
-		var image := Image.create(project.size.x, project.size.y, false, project.get_image_format())
+		var image := project.new_empty_image()
 		_blend_layers(image, frame)
 		blended_frames[frame] = image
 
@@ -287,14 +287,10 @@ func process_animation(project := Global.current_project) -> void:
 					ProcessedImage.new(image, project.frames.find(frame), duration)
 				)
 		else:
-			var image := Image.create(
-				project.size.x, project.size.y, false, project.get_image_format()
-			)
+			var image := project.new_empty_image()
 			image.copy_from(blended_frames[frame])
 			if erase_unselected_area and project.has_selection:
-				var crop := Image.create(
-					project.size.x, project.size.y, false, project.get_image_format()
-				)
+				var crop := project.new_empty_image()
 				var selection_image = project.selection_map.return_cropped_copy(project.size)
 				crop.blit_rect_mask(
 					image, selection_image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -1114,7 +1114,7 @@ func undo_redo_compress_images(
 func undo_redo_draw_op(
 	image: Image, new_size: Vector2i, compressed_image_data: PackedByteArray, buffer_size: int
 ) -> void:
-	if image is PixeloramaImage and image.is_indexed:
+	if image is ImageExtended and image.is_indexed:
 		# If using indexed mode,
 		# just convert the indices to RGB instead of setting the image data directly.
 		if image.get_size() != new_size:

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -46,6 +46,7 @@ enum WindowMenu { WINDOW_OPACITY, PANELS, LAYOUTS, MOVABLE_PANELS, ZEN_MODE, FUL
 ## Enumeration of items present in the Image Menu.
 enum ImageMenu {
 	PROJECT_PROPERTIES,
+	COLOR_MODE,
 	RESIZE_CANVAS,
 	SCALE_IMAGE,
 	CROP_TO_SELECTION,

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -1113,8 +1113,15 @@ func undo_redo_compress_images(
 func undo_redo_draw_op(
 	image: Image, new_size: Vector2i, compressed_image_data: PackedByteArray, buffer_size: int
 ) -> void:
-	var decompressed := compressed_image_data.decompress(buffer_size)
-	image.set_data(new_size.x, new_size.y, image.has_mipmaps(), image.get_format(), decompressed)
+	if image is PixeloramaImage and image.is_indexed:
+		# If using indexed mode,
+		# just convert the indices to RGB instead of setting the image data directly.
+		image.convert_indexed_to_rgb()
+	else:
+		var decompressed := compressed_image_data.decompress(buffer_size)
+		image.set_data(
+			new_size.x, new_size.y, image.has_mipmaps(), image.get_format(), decompressed
+		)
 
 
 ## This method is used to write project setting overrides to the override.cfg file, located

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -1117,6 +1117,8 @@ func undo_redo_draw_op(
 	if image is PixeloramaImage and image.is_indexed:
 		# If using indexed mode,
 		# just convert the indices to RGB instead of setting the image data directly.
+		if image.get_size() != new_size:
+			image.crop(new_size.x, new_size.y)
 		image.convert_indexed_to_rgb()
 	else:
 		var decompressed := compressed_image_data.decompress(buffer_size)

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -704,9 +704,8 @@ func open_image_at_cel(image: Image, layer_index := 0, frame_index := 0) -> void
 	)
 	new_cel_image.blit_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
 	new_cel_image.convert_rgb_to_indexed()
-	var redo_data := {
-		cel_image.indices_image: new_cel_image.indices_image.data, cel_image: new_cel_image.data
-	}
+	var redo_data := {}
+	new_cel_image.add_data_to_dictionary(redo_data, cel_image)
 	var undo_data := {}
 	cel_image.add_data_to_dictionary(undo_data)
 	Global.undo_redo_compress_images(redo_data, undo_data, project)

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -150,7 +150,7 @@ func handle_loading_aimg(path: String, frames: Array) -> void:
 		if not frames_agree:
 			frame.duration = aimg_frame.duration * project.fps
 		var content := aimg_frame.content
-		content.convert(Image.FORMAT_RGBA8)
+		content.convert(project.get_image_format())
 		frame.cels.append(PixelCel.new(content, 1))
 		project.frames.append(frame)
 
@@ -389,7 +389,9 @@ func save_pxo_file(
 	var frame_index := 1
 	for frame in project.frames:
 		if not autosave and include_blended:
-			var blended := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+			var blended := Image.create(
+				project.size.x, project.size.y, false, project.get_image_format()
+			)
 			DrawingAlgos.blend_layers(blended, frame, Vector2i.ZERO, project)
 			zip_packer.start_file("image_data/final_images/%s" % frame_index)
 			zip_packer.write_file(blended.get_data())
@@ -462,7 +464,7 @@ func open_image_as_new_tab(path: String, image: Image) -> void:
 	Global.projects.append(project)
 
 	var frame := Frame.new()
-	image.convert(Image.FORMAT_RGBA8)
+	image.convert(project.get_image_format())
 	frame.cels.append(layer.new_cel_from_image(image))
 
 	project.frames.append(frame)
@@ -482,8 +484,10 @@ func open_image_as_spritesheet_tab_smart(
 	for rect in sliced_rects:
 		var offset: Vector2 = (0.5 * (frame_size - rect.size)).floor()
 		var frame := Frame.new()
-		var cropped_image := Image.create(frame_size.x, frame_size.y, false, Image.FORMAT_RGBA8)
-		image.convert(Image.FORMAT_RGBA8)
+		var cropped_image := Image.create(
+			frame_size.x, frame_size.y, false, project.get_image_format()
+		)
+		image.convert(project.get_image_format())
 		cropped_image.blit_rect(image, rect, offset)
 		frame.cels.append(layer.new_cel_from_image(cropped_image))
 		project.frames.append(frame)
@@ -506,7 +510,7 @@ func open_image_as_spritesheet_tab(path: String, image: Image, horiz: int, vert:
 				Rect2i(frame_width * xx, frame_height * yy, frame_width, frame_height)
 			)
 			project.size = cropped_image.get_size()
-			cropped_image.convert(Image.FORMAT_RGBA8)
+			cropped_image.convert(project.get_image_format())
 			frame.cels.append(layer.new_cel_from_image(cropped_image))
 			project.frames.append(frame)
 	set_new_imported_tab(project, path)
@@ -565,9 +569,9 @@ func open_image_as_spritesheet_layer_smart(
 		if f >= start_frame and f < (start_frame + sliced_rects.size()):
 			# Slice spritesheet
 			var offset: Vector2 = (0.5 * (frame_size - sliced_rects[f - start_frame].size)).floor()
-			image.convert(Image.FORMAT_RGBA8)
+			image.convert(project.get_image_format())
 			var cropped_image := Image.create(
-				project_width, project_height, false, Image.FORMAT_RGBA8
+				project_width, project_height, false, project.get_image_format()
 			)
 			cropped_image.blit_rect(image, sliced_rects[f - start_frame], offset)
 			cels.append(layer.new_cel_from_image(cropped_image))
@@ -647,9 +651,9 @@ func open_image_as_spritesheet_layer(
 			# Slice spritesheet
 			var xx := (f - start_frame) % horizontal
 			var yy := (f - start_frame) / horizontal
-			image.convert(Image.FORMAT_RGBA8)
+			image.convert(project.get_image_format())
 			var cropped_image := Image.create(
-				project_width, project_height, false, Image.FORMAT_RGBA8
+				project_width, project_height, false, project.get_image_format()
 			)
 			cropped_image.blit_rect(
 				image,
@@ -690,9 +694,9 @@ func open_image_at_cel(image: Image, layer_index := 0, frame_index := 0) -> void
 	var cel := project.frames[frame_index].cels[layer_index]
 	if not cel is PixelCel:
 		return
-	image.convert(Image.FORMAT_RGBA8)
+	image.convert(project.get_image_format())
 	var cel_image := PixeloramaImage.create_custom(
-		project_width, project_height, false, Image.FORMAT_RGBA8
+		project_width, project_height, false, project.get_image_format()
 	)
 	cel_image.blit_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
 	cel_image.convert_rgb_to_indexed()
@@ -724,8 +728,10 @@ func open_image_as_new_frame(
 	for i in project.layers.size():
 		var layer := project.layers[i]
 		if i == layer_index and layer is PixelLayer:
-			image.convert(Image.FORMAT_RGBA8)
-			var cel_image := Image.create(project_width, project_height, false, Image.FORMAT_RGBA8)
+			image.convert(project.get_image_format())
+			var cel_image := Image.create(
+				project_width, project_height, false, project.get_image_format()
+			)
 			cel_image.blit_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
 			frame.cels.append(layer.new_cel_from_image(cel_image))
 		else:
@@ -760,8 +766,10 @@ func open_image_as_new_layer(image: Image, file_name: String, frame_index := 0) 
 	Global.current_project.undo_redo.create_action("Add Layer")
 	for i in project.frames.size():
 		if i == frame_index:
-			image.convert(Image.FORMAT_RGBA8)
-			var cel_image := Image.create(project_width, project_height, false, Image.FORMAT_RGBA8)
+			image.convert(project.get_image_format())
+			var cel_image := Image.create(
+				project_width, project_height, false, project.get_image_format()
+			)
 			cel_image.blit_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
 			cels.append(layer.new_cel_from_image(cel_image))
 		else:

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -396,10 +396,15 @@ func save_pxo_file(
 			zip_packer.close_file()
 		var cel_index := 1
 		for cel in frame.cels:
-			var cel_image := cel.get_image()
+			var cel_image := cel.get_image() as PixeloramaImage
 			if is_instance_valid(cel_image) and cel is PixelCel:
 				zip_packer.start_file("image_data/frames/%s/layer_%s" % [frame_index, cel_index])
 				zip_packer.write_file(cel_image.get_data())
+				zip_packer.close_file()
+				zip_packer.start_file(
+					"image_data/frames/%s/indices_layer_%s" % [frame_index, cel_index]
+				)
+				zip_packer.write_file(cel_image.indices_image.get_data())
 				zip_packer.close_file()
 			cel_index += 1
 		frame_index += 1

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -694,7 +694,8 @@ func open_image_at_cel(image: Image, layer_index := 0, frame_index := 0) -> void
 	var cel_image := PixeloramaImage.create_custom(
 		project_width, project_height, false, Image.FORMAT_RGBA8
 	)
-	cel_image.blit_rect_custom(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
+	cel_image.blit_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
+	cel_image.convert_rgb_to_indexed()
 	Global.undo_redo_compress_images(
 		{cel.image: cel_image.data}, {cel.image: cel.image.data}, project
 	)

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -389,9 +389,7 @@ func save_pxo_file(
 	var frame_index := 1
 	for frame in project.frames:
 		if not autosave and include_blended:
-			var blended := Image.create(
-				project.size.x, project.size.y, false, project.get_image_format()
-			)
+			var blended := project.new_empty_image()
 			DrawingAlgos.blend_layers(blended, frame, Vector2i.ZERO, project)
 			zip_packer.start_file("image_data/final_images/%s" % frame_index)
 			zip_packer.write_file(blended.get_data())

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -396,7 +396,7 @@ func save_pxo_file(
 			zip_packer.close_file()
 		var cel_index := 1
 		for cel in frame.cels:
-			var cel_image := cel.get_image() as PixeloramaImage
+			var cel_image := cel.get_image() as ImageExtended
 			if is_instance_valid(cel_image) and cel is PixelCel:
 				zip_packer.start_file("image_data/frames/%s/layer_%s" % [frame_index, cel_index])
 				zip_packer.write_file(cel_image.get_data())
@@ -699,7 +699,7 @@ func open_image_at_cel(image: Image, layer_index := 0, frame_index := 0) -> void
 		return
 	image.convert(project.get_image_format())
 	var cel_image := (cel as PixelCel).get_image()
-	var new_cel_image := PixeloramaImage.create_custom(
+	var new_cel_image := ImageExtended.create_custom(
 		project_width, project_height, false, project.get_image_format(), cel_image.is_indexed
 	)
 	new_cel_image.blit_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)

--- a/src/Classes/Cels/GroupCel.gd
+++ b/src/Classes/Cels/GroupCel.gd
@@ -11,7 +11,10 @@ func _init(_opacity := 1.0) -> void:
 
 func get_image() -> Image:
 	var image := Image.create(
-		Global.current_project.size.x, Global.current_project.size.y, false, Image.FORMAT_RGBA8
+		Global.current_project.size.x,
+		Global.current_project.size.y,
+		false,
+		Global.current_project.get_image_format()
 	)
 	return image
 

--- a/src/Classes/Cels/GroupCel.gd
+++ b/src/Classes/Cels/GroupCel.gd
@@ -10,12 +10,7 @@ func _init(_opacity := 1.0) -> void:
 
 
 func get_image() -> Image:
-	var image := Image.create(
-		Global.current_project.size.x,
-		Global.current_project.size.y,
-		false,
-		Global.current_project.get_image_format()
-	)
+	var image := Global.current_project.new_empty_image()
 	return image
 
 

--- a/src/Classes/Cels/PixelCel.gd
+++ b/src/Classes/Cels/PixelCel.gd
@@ -4,17 +4,17 @@ extends BaseCel
 ## The term "cel" comes from "celluloid" (https://en.wikipedia.org/wiki/Cel).
 
 ## This variable is where the image data of the cel are.
-var image: Image:
+var image: PixeloramaImage:
 	set = image_changed
 
 
-func _init(_image := Image.new(), _opacity := 1.0) -> void:
+func _init(_image: PixeloramaImage, _opacity := 1.0) -> void:
 	image_texture = ImageTexture.new()
 	image = _image  # Set image and call setter
 	opacity = _opacity
 
 
-func image_changed(value: Image) -> void:
+func image_changed(value: PixeloramaImage) -> void:
 	image = value
 	if not image.is_empty() and is_instance_valid(image_texture):
 		image_texture.set_image(image)

--- a/src/Classes/Cels/PixelCel.gd
+++ b/src/Classes/Cels/PixelCel.gd
@@ -48,7 +48,7 @@ func copy_content():
 	return copy_image
 
 
-func get_image() -> Image:
+func get_image() -> PixeloramaImage:
 	return image
 
 

--- a/src/Classes/Cels/PixelCel.gd
+++ b/src/Classes/Cels/PixelCel.gd
@@ -4,17 +4,17 @@ extends BaseCel
 ## The term "cel" comes from "celluloid" (https://en.wikipedia.org/wiki/Cel).
 
 ## This variable is where the image data of the cel are.
-var image: PixeloramaImage:
+var image: ImageExtended:
 	set = image_changed
 
 
-func _init(_image: PixeloramaImage, _opacity := 1.0) -> void:
+func _init(_image: ImageExtended, _opacity := 1.0) -> void:
 	image_texture = ImageTexture.new()
 	image = _image  # Set image and call setter
 	opacity = _opacity
 
 
-func image_changed(value: PixeloramaImage) -> void:
+func image_changed(value: ImageExtended) -> void:
 	image = value
 	if not image.is_empty() and is_instance_valid(image_texture):
 		image_texture.set_image(image)
@@ -48,7 +48,7 @@ func copy_content():
 	return copy_image
 
 
-func get_image() -> PixeloramaImage:
+func get_image() -> ImageExtended:
 	return image
 
 

--- a/src/Classes/Drawers.gd
+++ b/src/Classes/Drawers.gd
@@ -27,7 +27,7 @@ class ColorOp:
 
 
 class SimpleDrawer:
-	func set_pixel(image: PixeloramaImage, position: Vector2i, color: Color, op: ColorOp) -> void:
+	func set_pixel(image: ImageExtended, position: Vector2i, color: Color, op: ColorOp) -> void:
 		var color_old := image.get_pixelv(position)
 		var color_str := color.to_html()
 		var color_new := op.process(Color(color_str), color_old)
@@ -43,7 +43,7 @@ class PixelPerfectDrawer:
 	func reset() -> void:
 		last_pixels = [null, null]
 
-	func set_pixel(image: PixeloramaImage, position: Vector2i, color: Color, op: ColorOp) -> void:
+	func set_pixel(image: ImageExtended, position: Vector2i, color: Color, op: ColorOp) -> void:
 		var color_old := image.get_pixelv(position)
 		var color_str := color.to_html()
 		last_pixels.push_back([position, color_old])

--- a/src/Classes/Drawers.gd
+++ b/src/Classes/Drawers.gd
@@ -27,12 +27,12 @@ class ColorOp:
 
 
 class SimpleDrawer:
-	func set_pixel(image: Image, position: Vector2i, color: Color, op: ColorOp) -> void:
+	func set_pixel(image: PixeloramaImage, position: Vector2i, color: Color, op: ColorOp) -> void:
 		var color_old := image.get_pixelv(position)
 		var color_str := color.to_html()
 		var color_new := op.process(Color(color_str), color_old)
 		if not color_new.is_equal_approx(color_old):
-			image.set_pixelv(position, color_new)
+			image.set_pixelv_custom(position, color_new)
 
 
 class PixelPerfectDrawer:
@@ -43,11 +43,11 @@ class PixelPerfectDrawer:
 	func reset() -> void:
 		last_pixels = [null, null]
 
-	func set_pixel(image: Image, position: Vector2i, color: Color, op: ColorOp) -> void:
+	func set_pixel(image: PixeloramaImage, position: Vector2i, color: Color, op: ColorOp) -> void:
 		var color_old := image.get_pixelv(position)
 		var color_str := color.to_html()
 		last_pixels.push_back([position, color_old])
-		image.set_pixelv(position, op.process(Color(color_str), color_old))
+		image.set_pixelv_custom(position, op.process(Color(color_str), color_old))
 
 		var corner = last_pixels.pop_front()
 		var neighbour = last_pixels[0]
@@ -56,7 +56,7 @@ class PixelPerfectDrawer:
 			return
 
 		if position - corner[0] in CORNERS and position - neighbour[0] in NEIGHBOURS:
-			image.set_pixel(neighbour[0].x, neighbour[0].y, neighbour[1])
+			image.set_pixel_custom(neighbour[0].x, neighbour[0].y, neighbour[1])
 			last_pixels[0] = corner
 
 

--- a/src/Classes/ImageEffect.gd
+++ b/src/Classes/ImageEffect.gd
@@ -80,10 +80,7 @@ func _confirmed() -> void:
 			if not cel is PixelCel:
 				continue
 			commit_idx = cel_index[0]  # frame is cel_index[0] in this mode
-			var image := (cel as PixelCel).get_image()
-			commit_action(image)
-			if image.is_indexed:
-				image.convert_rgb_to_indexed()
+			commit_action(cel.image)
 		_commit_undo("Draw", undo_data, project)
 
 	elif affect == FRAME:
@@ -96,10 +93,7 @@ func _confirmed() -> void:
 				i += 1
 				continue
 			if project.layers[i].can_layer_get_drawn():
-				var image := (cel as PixelCel).get_image()
-				commit_action(image)
-				if image.is_indexed:
-					image.convert_rgb_to_indexed()
+				commit_action(cel.image)
 			i += 1
 		_commit_undo("Draw", undo_data, project)
 
@@ -114,10 +108,7 @@ func _confirmed() -> void:
 					i += 1
 					continue
 				if project.layers[i].can_layer_get_drawn():
-					var image := (cel as PixelCel).get_image()
-					commit_action(image)
-					if image.is_indexed:
-						image.convert_rgb_to_indexed()
+					commit_action(cel.image)
 				i += 1
 		_commit_undo("Draw", undo_data, project)
 
@@ -135,10 +126,7 @@ func _confirmed() -> void:
 						i += 1
 						continue
 					if _project.layers[i].can_layer_get_drawn():
-						var image := (cel as PixelCel).get_image()
-						commit_action(image, _project)
-						if image.is_indexed:
-							image.convert_rgb_to_indexed()
+						commit_action(cel.image, _project)
 					i += 1
 			_commit_undo("Draw", undo_data, _project)
 

--- a/src/Classes/ImageEffect.gd
+++ b/src/Classes/ImageEffect.gd
@@ -80,7 +80,10 @@ func _confirmed() -> void:
 			if not cel is PixelCel:
 				continue
 			commit_idx = cel_index[0]  # frame is cel_index[0] in this mode
-			commit_action(cel.image)
+			var image := (cel as PixelCel).get_image()
+			commit_action(image)
+			if image.is_indexed:
+				image.convert_rgb_to_indexed()
 		_commit_undo("Draw", undo_data, project)
 
 	elif affect == FRAME:
@@ -93,7 +96,10 @@ func _confirmed() -> void:
 				i += 1
 				continue
 			if project.layers[i].can_layer_get_drawn():
-				commit_action(cel.image)
+				var image := (cel as PixelCel).get_image()
+				commit_action(image)
+				if image.is_indexed:
+					image.convert_rgb_to_indexed()
 			i += 1
 		_commit_undo("Draw", undo_data, project)
 
@@ -108,7 +114,10 @@ func _confirmed() -> void:
 					i += 1
 					continue
 				if project.layers[i].can_layer_get_drawn():
-					commit_action(cel.image)
+					var image := (cel as PixelCel).get_image()
+					commit_action(image)
+					if image.is_indexed:
+						image.convert_rgb_to_indexed()
 				i += 1
 		_commit_undo("Draw", undo_data, project)
 
@@ -126,7 +135,10 @@ func _confirmed() -> void:
 						i += 1
 						continue
 					if _project.layers[i].can_layer_get_drawn():
-						commit_action(cel.image, _project)
+						var image := (cel as PixelCel).get_image()
+						commit_action(image, _project)
+						if image.is_indexed:
+							image.convert_rgb_to_indexed()
 					i += 1
 			_commit_undo("Draw", undo_data, _project)
 
@@ -170,12 +182,12 @@ func _get_undo_data(project: Project) -> Dictionary:
 	var data := {}
 	var images := _get_selected_draw_images(project)
 	for image in images:
-		data[image] = image.data
+		image.add_data_to_dictionary(data)
 	return data
 
 
-func _get_selected_draw_images(project: Project) -> Array[Image]:
-	var images: Array[Image] = []
+func _get_selected_draw_images(project: Project) -> Array[PixeloramaImage]:
+	var images: Array[PixeloramaImage] = []
 	if affect == SELECTED_CELS:
 		for cel_index in project.selected_cels:
 			var cel: BaseCel = project.frames[cel_index[0]].cels[cel_index[1]]

--- a/src/Classes/ImageEffect.gd
+++ b/src/Classes/ImageEffect.gd
@@ -174,8 +174,8 @@ func _get_undo_data(project: Project) -> Dictionary:
 	return data
 
 
-func _get_selected_draw_images(project: Project) -> Array[PixeloramaImage]:
-	var images: Array[PixeloramaImage] = []
+func _get_selected_draw_images(project: Project) -> Array[ImageExtended]:
+	var images: Array[ImageExtended] = []
 	if affect == SELECTED_CELS:
 		for cel_index in project.selected_cels:
 			var cel: BaseCel = project.frames[cel_index[0]].cels[cel_index[1]]

--- a/src/Classes/ImageExtended.gd
+++ b/src/Classes/ImageExtended.gd
@@ -1,4 +1,4 @@
-class_name PixeloramaImage
+class_name ImageExtended
 extends Image
 
 const TRANSPARENT := Color(0)
@@ -18,8 +18,8 @@ func _init() -> void:
 
 static func create_custom(
 	width: int, height: int, mipmaps: bool, format: Image.Format, _is_indexed := false
-) -> PixeloramaImage:
-	var new_image := PixeloramaImage.new()
+) -> ImageExtended:
+	var new_image := ImageExtended.new()
 	new_image.crop(width, height)
 	if mipmaps:
 		new_image.generate_mipmaps()
@@ -136,7 +136,7 @@ func color_distance(c1: Color, c2: Color) -> float:
 
 
 ## Adds image data to a [param dict] [Dictionary]. Used for undo/redo.
-func add_data_to_dictionary(dict: Dictionary, other_image: PixeloramaImage = null) -> void:
+func add_data_to_dictionary(dict: Dictionary, other_image: ImageExtended = null) -> void:
 	# The order matters! Setting self's data first would make undo/redo appear to work incorrectly.
 	if is_instance_valid(other_image):
 		dict[other_image.indices_image] = indices_image.data

--- a/src/Classes/Layers/BaseLayer.gd
+++ b/src/Classes/Layers/BaseLayer.gd
@@ -218,11 +218,16 @@ func link_cel(cel: BaseCel, link_set = null) -> void:
 ## This method is not destructive as it does NOT change the data of the image,
 ## it just returns a copy.
 func display_effects(cel: BaseCel, image_override: Image = null) -> Image:
-	var image := Image.new()
+	var image := PixeloramaImage.new()
 	if is_instance_valid(image_override):
-		image.copy_from(image_override)
+		if image_override is PixeloramaImage:
+			image.is_indexed = image_override.is_indexed
+		image.copy_from_custom(image_override)
 	else:
-		image.copy_from(cel.get_image())
+		var cel_image := cel.get_image()
+		if cel_image is PixeloramaImage:
+			image.is_indexed = cel_image.is_indexed
+		image.copy_from_custom(cel_image)
 	if not effects_enabled:
 		return image
 	var image_size := image.get_size()

--- a/src/Classes/Layers/BaseLayer.gd
+++ b/src/Classes/Layers/BaseLayer.gd
@@ -218,14 +218,14 @@ func link_cel(cel: BaseCel, link_set = null) -> void:
 ## This method is not destructive as it does NOT change the data of the image,
 ## it just returns a copy.
 func display_effects(cel: BaseCel, image_override: Image = null) -> Image:
-	var image := PixeloramaImage.new()
+	var image := ImageExtended.new()
 	if is_instance_valid(image_override):
-		if image_override is PixeloramaImage:
+		if image_override is ImageExtended:
 			image.is_indexed = image_override.is_indexed
 		image.copy_from_custom(image_override)
 	else:
 		var cel_image := cel.get_image()
-		if cel_image is PixeloramaImage:
+		if cel_image is ImageExtended:
 			image.is_indexed = cel_image.is_indexed
 		image.copy_from_custom(cel_image)
 	if not effects_enabled:

--- a/src/Classes/Layers/GroupLayer.gd
+++ b/src/Classes/Layers/GroupLayer.gd
@@ -13,7 +13,9 @@ func _init(_project: Project, _name := "") -> void:
 
 ## Blends all of the images of children layer of the group layer into a single image.
 func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true) -> Image:
-	var image := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+	var image := PixeloramaImage.create_custom(
+		project.size.x, project.size.y, false, project.get_image_format(), project.is_indexed()
+	)
 	var children := get_children(false)
 	if children.size() <= 0:
 		return image
@@ -66,7 +68,7 @@ func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true
 
 
 func _include_child_in_blending(
-	image: Image,
+	image: PixeloramaImage,
 	layer: BaseLayer,
 	frame: Frame,
 	textures: Array[Image],
@@ -100,7 +102,7 @@ func _include_child_in_blending(
 ## Gets called recursively if the child group has children groups of its own,
 ## and they are also set to pass through mode.
 func _blend_child_group(
-	image: Image,
+	image: PixeloramaImage,
 	layer: BaseLayer,
 	frame: Frame,
 	textures: Array[Image],

--- a/src/Classes/Layers/GroupLayer.gd
+++ b/src/Classes/Layers/GroupLayer.gd
@@ -13,7 +13,7 @@ func _init(_project: Project, _name := "") -> void:
 
 ## Blends all of the images of children layer of the group layer into a single image.
 func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true) -> Image:
-	var image := PixeloramaImage.create_custom(
+	var image := ImageExtended.create_custom(
 		project.size.x, project.size.y, false, project.get_image_format(), project.is_indexed()
 	)
 	var children := get_children(false)
@@ -68,7 +68,7 @@ func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true
 
 
 func _include_child_in_blending(
-	image: PixeloramaImage,
+	image: ImageExtended,
 	layer: BaseLayer,
 	frame: Frame,
 	textures: Array[Image],
@@ -102,7 +102,7 @@ func _include_child_in_blending(
 ## Gets called recursively if the child group has children groups of its own,
 ## and they are also set to pass through mode.
 func _blend_child_group(
-	image: PixeloramaImage,
+	image: ImageExtended,
 	layer: BaseLayer,
 	frame: Frame,
 	textures: Array[Image],

--- a/src/Classes/Layers/PixelLayer.gd
+++ b/src/Classes/Layers/PixelLayer.gd
@@ -28,7 +28,10 @@ func get_layer_type() -> int:
 
 
 func new_empty_cel() -> BaseCel:
-	var image := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+	#var image := Image.create_empty(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+	var image := PixeloramaImage.create_custom(
+		project.size.x, project.size.y, false, Image.FORMAT_RGBA8
+	)
 	return PixelCel.new(image)
 
 

--- a/src/Classes/Layers/PixelLayer.gd
+++ b/src/Classes/Layers/PixelLayer.gd
@@ -28,9 +28,10 @@ func get_layer_type() -> int:
 
 
 func new_empty_cel() -> BaseCel:
-	#var image := Image.create_empty(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+	var format := project.get_image_format()
+	var is_indexed := project.is_indexed()
 	var image := PixeloramaImage.create_custom(
-		project.size.x, project.size.y, false, Image.FORMAT_RGBA8
+		project.size.x, project.size.y, false, format, is_indexed
 	)
 	return PixelCel.new(image)
 

--- a/src/Classes/Layers/PixelLayer.gd
+++ b/src/Classes/Layers/PixelLayer.gd
@@ -38,6 +38,7 @@ func new_empty_cel() -> BaseCel:
 
 func new_cel_from_image(image: Image) -> PixelCel:
 	var pixelorama_image := PixeloramaImage.new()
+	pixelorama_image.is_indexed = project.is_indexed()
 	pixelorama_image.copy_from_custom(image)
 	return PixelCel.new(pixelorama_image)
 

--- a/src/Classes/Layers/PixelLayer.gd
+++ b/src/Classes/Layers/PixelLayer.gd
@@ -35,5 +35,11 @@ func new_empty_cel() -> BaseCel:
 	return PixelCel.new(image)
 
 
+func new_cel_from_image(image: Image) -> PixelCel:
+	var pixelorama_image := PixeloramaImage.new()
+	pixelorama_image.copy_from_custom(image)
+	return PixelCel.new(pixelorama_image)
+
+
 func can_layer_get_drawn() -> bool:
 	return is_visible_in_hierarchy() && !is_locked_in_hierarchy()

--- a/src/Classes/Layers/PixelLayer.gd
+++ b/src/Classes/Layers/PixelLayer.gd
@@ -30,14 +30,14 @@ func get_layer_type() -> int:
 func new_empty_cel() -> BaseCel:
 	var format := project.get_image_format()
 	var is_indexed := project.is_indexed()
-	var image := PixeloramaImage.create_custom(
+	var image := ImageExtended.create_custom(
 		project.size.x, project.size.y, false, format, is_indexed
 	)
 	return PixelCel.new(image)
 
 
 func new_cel_from_image(image: Image) -> PixelCel:
-	var pixelorama_image := PixeloramaImage.new()
+	var pixelorama_image := ImageExtended.new()
 	pixelorama_image.copy_from_custom(image, project.is_indexed())
 	return PixelCel.new(pixelorama_image)
 

--- a/src/Classes/Layers/PixelLayer.gd
+++ b/src/Classes/Layers/PixelLayer.gd
@@ -38,8 +38,7 @@ func new_empty_cel() -> BaseCel:
 
 func new_cel_from_image(image: Image) -> PixelCel:
 	var pixelorama_image := PixeloramaImage.new()
-	pixelorama_image.is_indexed = project.is_indexed()
-	pixelorama_image.copy_from_custom(image)
+	pixelorama_image.copy_from_custom(image, project.is_indexed())
 	return PixelCel.new(pixelorama_image)
 
 

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -28,15 +28,15 @@ static func create_custom(
 	new_image.is_indexed = _is_indexed
 	if new_image.is_indexed:
 		new_image.resize_indices()
-		new_image.select_palette("")
+		new_image.select_palette("", false)
 	return new_image
 
 
 func copy_from_custom(image: Image) -> void:
 	copy_from(image)
 	if is_indexed:
-		update_palette()
 		resize_indices()
+		select_palette("", false)
 		convert_rgb_to_indexed()
 
 

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -1,0 +1,96 @@
+class_name PixeloramaImage
+extends Image
+
+const TRANSPARENT := Color(0)
+
+var current_palette := Palettes.current_palette
+var indices := PackedInt32Array()
+var palette := PackedColorArray()
+
+
+func _init() -> void:
+	select_palette("")
+	Palettes.palette_selected.connect(select_palette)
+	resize_indices()
+
+
+static func create_custom(
+	width: int, height: int, mipmaps: bool, format: Image.Format
+) -> PixeloramaImage:
+	var new_image := PixeloramaImage.new()
+	new_image.crop(width, height)
+	new_image.fill(TRANSPARENT)
+	if mipmaps:
+		new_image.generate_mipmaps()
+	new_image.convert(format)
+	new_image.resize_indices()
+	new_image.select_palette("")
+	return new_image
+
+
+func select_palette(_name: String) -> void:
+	current_palette = Palettes.current_palette
+	if not is_instance_valid(current_palette):
+		return
+	update_indices()
+	if not current_palette.data_changed.is_connected(update_indices):
+		current_palette.data_changed.connect(update_indices)
+
+
+func update_indices() -> void:
+	if palette.size() != current_palette.colors.size():
+		palette.resize(current_palette.colors.size())
+	for i in current_palette.colors:
+		palette[i] = current_palette.colors[i].color
+	for x in get_width():
+		for y in get_height():
+			var index := indices[(x * get_width()) + y]
+			if index > -1:
+				if index >= palette.size():
+					set_pixel(x, y, TRANSPARENT)
+				else:
+					set_pixel(x, y, palette[index])
+			else:
+				set_pixel(x, y, TRANSPARENT)
+	Global.canvas.queue_redraw()
+
+
+func resize_indices() -> void:
+	print(get_width() * get_height())
+	indices.resize(get_width() * get_height())
+	for i in indices.size():
+		indices[i] = -1
+
+
+func set_pixel_custon(x: int, y: int, color: Color) -> void:
+	set_pixelv_custom(Vector2i(x, y), color)
+
+
+func set_pixelv_custom(point: Vector2i, color: Color) -> void:
+	var color_to_fill := TRANSPARENT
+	var color_index := -1
+	if not color.is_equal_approx(TRANSPARENT):
+		if palette.has(color):
+			color_index = palette.find(color)
+		else:  # Find the most similar color
+			if not is_zero_approx(palette[0].a):
+				color_index = 0
+			var smaller_distance := color_distance(color, palette[0])
+			for i in palette.size():
+				var swatch := palette[i]
+				if is_zero_approx(swatch.a):  # Skip transparent colors
+					continue
+				var dist := color_distance(color, swatch)
+				if dist < smaller_distance:
+					smaller_distance = dist
+					color_index = i
+	indices[(point.x * get_width()) + point.y] = color_index
+	if color_index > -1:
+		color_to_fill = palette[color_index]
+	set_pixelv(point, color_to_fill)
+
+
+func color_distance(c1: Color, c2: Color) -> float:
+	var v1 := Vector4(c1.r, c1.g, c1.b, c1.a)
+	var v2 := Vector4(c2.r, c2.g, c2.b, c2.a)
+	return v2.distance_to(v1)

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -87,6 +87,12 @@ func convert_rgb_to_indexed() -> void:
 	convert_indexed_to_rgb()
 
 
+func on_size_changed() -> void:
+	if is_indexed:
+		resize_indices()
+		convert_rgb_to_indexed()
+
+
 func resize_indices() -> void:
 	print(get_width(), " ", get_height(), " ", get_width() * get_height())
 	indices_image.crop(get_width(), get_height())
@@ -132,7 +138,11 @@ func color_distance(c1: Color, c2: Color) -> float:
 
 
 ## Adds image data to a [param dict] [Dictionary]. Used for undo/redo.
-func add_data_to_dictionary(dict: Dictionary) -> void:
+func add_data_to_dictionary(dict: Dictionary, other_image: PixeloramaImage = null) -> void:
 	# The order matters! Setting self's data first would make undo/redo appear to work incorrectly.
-	dict[indices_image] = indices_image.data
-	dict[self] = data
+	if is_instance_valid(other_image):
+		dict[other_image.indices_image] = indices_image.data
+		dict[other_image] = data
+	else:
+		dict[indices_image] = indices_image.data
+		dict[self] = data

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -40,16 +40,17 @@ func copy_from_custom(image: Image) -> void:
 		convert_rgb_to_indexed()
 
 
-func select_palette(_name: String) -> void:
+func select_palette(_name: String, convert_to_rgb := true) -> void:
 	current_palette = Palettes.current_palette
 	if not is_instance_valid(current_palette) or not is_indexed:
 		return
 	update_palette()
-	convert_indexed_to_rgb()
 	if not current_palette.data_changed.is_connected(update_palette):
 		current_palette.data_changed.connect(update_palette)
 	if not current_palette.data_changed.is_connected(convert_indexed_to_rgb):
 		current_palette.data_changed.connect(convert_indexed_to_rgb)
+	if convert_to_rgb:
+		convert_indexed_to_rgb()
 
 
 func update_palette() -> void:
@@ -60,6 +61,8 @@ func update_palette() -> void:
 
 
 func convert_indexed_to_rgb() -> void:
+	if not is_indexed:
+		return
 	var palette_image := Palettes.current_palette.convert_to_image()
 	var palette_texture := ImageTexture.create_from_image(palette_image)
 	var shader_image_effect := ShaderImageEffect.new()

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -32,7 +32,8 @@ static func create_custom(
 	return new_image
 
 
-func copy_from_custom(image: Image) -> void:
+func copy_from_custom(image: Image, indexed := is_indexed) -> void:
+	is_indexed = indexed
 	copy_from(image)
 	if is_indexed:
 		resize_indices()

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -128,3 +128,10 @@ func blit_rect_custom(src: Image, src_rect: Rect2i, origin: Vector2i) -> void:
 	blit_rect(src, src_rect, origin)
 	if is_indexed:
 		convert_rgb_to_indexed()
+
+
+## Adds image data to a [param dict] [Dictionary]. Used for undo/redo.
+func add_data_to_dictionary(dict: Dictionary) -> void:
+	# The order matters! Setting self's data first would make undo/redo appear to work incorrectly.
+	dict[indices_image] = indices_image.data
+	dict[self] = data

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -104,32 +104,30 @@ func set_pixel_custom(x: int, y: int, color: Color) -> void:
 
 
 func set_pixelv_custom(point: Vector2i, color: Color) -> void:
-	if not is_indexed:
-		set_pixelv(point, color)
-		return
-	var color_to_fill := TRANSPARENT
-	var color_index := 0
-	if not color.is_equal_approx(TRANSPARENT):
-		if palette.has(color):
-			color_index = palette.find(color)
-		else:  # Find the most similar color
-			#if not is_zero_approx(palette[0].a):
-			#color_index = 0
-			var smaller_distance := color_distance(color, palette[0])
-			for i in palette.size():
-				var swatch := palette[i]
-				if is_zero_approx(swatch.a):  # Skip transparent colors
-					continue
-				var dist := color_distance(color, swatch)
-				if dist < smaller_distance:
-					smaller_distance = dist
-					color_index = i
-		indices_image.set_pixelv(point, Color((color_index + 1) / 255.0, 0, 0, 0))
-		color_to_fill = palette[color_index]
-		set_pixelv(point, color_to_fill)
-	else:
-		indices_image.set_pixelv(point, TRANSPARENT)
-		set_pixelv(point, TRANSPARENT)
+	var new_color := color
+	if is_indexed:
+		var color_to_fill := TRANSPARENT
+		var color_index := 0
+		if not color.is_equal_approx(TRANSPARENT):
+			if palette.has(color):
+				color_index = palette.find(color)
+			else:  # Find the most similar color
+				var smaller_distance := color_distance(color, palette[0])
+				for i in palette.size():
+					var swatch := palette[i]
+					if is_zero_approx(swatch.a):  # Skip transparent colors
+						continue
+					var dist := color_distance(color, swatch)
+					if dist < smaller_distance:
+						smaller_distance = dist
+						color_index = i
+			indices_image.set_pixelv(point, Color((color_index + 1) / 255.0, 0, 0, 0))
+			color_to_fill = palette[color_index]
+			new_color = color_to_fill
+		else:
+			indices_image.set_pixelv(point, TRANSPARENT)
+			new_color = TRANSPARENT
+	set_pixelv(point, new_color)
 
 
 func color_distance(c1: Color, c2: Color) -> float:

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -70,6 +70,8 @@ func convert_indexed_to_rgb() -> void:
 
 
 func convert_rgb_to_indexed() -> void:
+	if not is_indexed:
+		return
 	var palette_image := Palettes.current_palette.convert_to_image()
 	var palette_texture := ImageTexture.create_from_image(palette_image)
 	var params := {
@@ -124,12 +126,6 @@ func color_distance(c1: Color, c2: Color) -> float:
 	var v1 := Vector4(c1.r, c1.g, c1.b, c1.a)
 	var v2 := Vector4(c2.r, c2.g, c2.b, c2.a)
 	return v2.distance_to(v1)
-
-
-func blit_rect_custom(src: Image, src_rect: Rect2i, origin: Vector2i) -> void:
-	blit_rect(src, src_rect, origin)
-	if is_indexed:
-		convert_rgb_to_indexed()
 
 
 ## Adds image data to a [param dict] [Dictionary]. Used for undo/redo.

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -65,7 +65,7 @@ func convert_indexed_to_rgb() -> void:
 	var shader_image_effect := ShaderImageEffect.new()
 	var indices_texture := ImageTexture.create_from_image(indices_image)
 	var params := {"palette_texture": palette_texture, "indices_texture": indices_texture}
-	shader_image_effect.generate_image(self, INDEXED_TO_RGB, params, get_size())
+	shader_image_effect.generate_image(self, INDEXED_TO_RGB, params, get_size(), false)
 	Global.canvas.queue_redraw()
 
 
@@ -76,7 +76,9 @@ func convert_rgb_to_indexed() -> void:
 		"palette_texture": palette_texture, "rgb_texture": ImageTexture.create_from_image(self)
 	}
 	var shader_image_effect := ShaderImageEffect.new()
-	shader_image_effect.generate_image(indices_image, SET_INDICES, params, indices_image.get_size())
+	shader_image_effect.generate_image(
+		indices_image, SET_INDICES, params, indices_image.get_size(), false
+	)
 	convert_indexed_to_rgb()
 
 

--- a/src/Classes/PixeloramaImage.gd
+++ b/src/Classes/PixeloramaImage.gd
@@ -95,7 +95,6 @@ func on_size_changed() -> void:
 
 
 func resize_indices() -> void:
-	print(get_width(), " ", get_height(), " ", get_width() * get_height())
 	indices_image.crop(get_width(), get_height())
 
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -9,6 +9,8 @@ signal about_to_deserialize(dict: Dictionary)
 signal resized
 signal timeline_updated
 
+const INDEXED_MODE := Image.FORMAT_MAX + 1
+
 var name := "":
 	set(value):
 		name = value
@@ -21,6 +23,7 @@ var undo_redo := UndoRedo.new()
 var tiles: Tiles
 var undos := 0  ## The number of times we added undo properties
 var can_undo := true
+var color_mode := Image.FORMAT_RGBA8
 var fill_color := Color(0)
 var has_changed := false:
 	set(value):
@@ -181,6 +184,16 @@ func get_current_cel() -> BaseCel:
 	return frames[current_frame].cels[current_layer]
 
 
+func get_image_format() -> Image.Format:
+	if color_mode == INDEXED_MODE:
+		return Image.FORMAT_RGBA8
+	return color_mode
+
+
+func is_indexed() -> bool:
+	return color_mode == INDEXED_MODE
+
+
 func selection_map_changed() -> void:
 	var image_texture: ImageTexture
 	has_selection = !selection_map.is_invisible()
@@ -317,12 +330,12 @@ func deserialize(dict: Dictionary, zip_reader: ZIPReader = null, file: FileAcces
 								"image_data/frames/%s/layer_%s" % [frame_i + 1, cel_i + 1]
 							)
 							image = Image.create_from_data(
-								size.x, size.y, false, Image.FORMAT_RGBA8, image_data
+								size.x, size.y, false, get_image_format(), image_data
 							)
 						elif is_instance_valid(file):  # For pxo files saved in 0.x
 							var buffer := file.get_buffer(size.x * size.y * 4)
 							image = Image.create_from_data(
-								size.x, size.y, false, Image.FORMAT_RGBA8, buffer
+								size.x, size.y, false, get_image_format(), buffer
 							)
 						var pixelorama_image := PixeloramaImage.new()
 						pixelorama_image.copy_from_custom(image)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -359,7 +359,7 @@ func deserialize(dict: Dictionary, zip_reader: ZIPReader = null, file: FileAcces
 							image = Image.create_from_data(
 								size.x, size.y, false, get_image_format(), buffer
 							)
-						var pixelorama_image := PixeloramaImage.new()
+						var pixelorama_image := ImageExtended.new()
 						pixelorama_image.is_indexed = is_indexed()
 						if not indices_data.is_empty() and is_indexed():
 							pixelorama_image.indices_image = Image.create_from_data(

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -23,7 +23,17 @@ var undo_redo := UndoRedo.new()
 var tiles: Tiles
 var undos := 0  ## The number of times we added undo properties
 var can_undo := true
-var color_mode := Image.FORMAT_RGBA8
+var color_mode: int = Image.FORMAT_RGBA8:
+	set(value):
+		if color_mode != value:
+			color_mode = value
+			for cel in get_all_pixel_cels():
+				var image := cel.get_image()
+				image.is_indexed = is_indexed()
+				if image.is_indexed:
+					image.resize_indices()
+					image.select_palette("", false)
+					image.convert_rgb_to_indexed()
 var fill_color := Color(0)
 var has_changed := false:
 	set(value):
@@ -179,6 +189,7 @@ func new_empty_frame() -> Frame:
 	return frame
 
 
+## Returns a new [Image] of size [member size] and format [method get_image_format].
 func new_empty_image() -> Image:
 	return Image.create(size.x, size.y, false, get_image_format())
 
@@ -576,6 +587,16 @@ func find_first_drawable_cel(frame := frames[current_frame]) -> BaseCel:
 	if not cel is GroupCel:
 		result = cel
 	return result
+
+
+## Returns an [Array] of type [PixelCel] containing all of the pixel cels of the project.
+func get_all_pixel_cels() -> Array[PixelCel]:
+	var cels: Array[PixelCel]
+	for frame in frames:
+		for cel in frame.cels:
+			if cel is PixelCel:
+				cels.append(cel)
+	return cels
 
 
 ## Re-order layers to take each cel's z-index into account. If all z-indexes are 0,

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -179,6 +179,10 @@ func new_empty_frame() -> Frame:
 	return frame
 
 
+func new_empty_image() -> Image:
+	return Image.create(size.x, size.y, false, get_image_format())
+
+
 ## Returns the currently selected [BaseCel].
 func get_current_cel() -> BaseCel:
 	return frames[current_frame].cels[current_layer]

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -324,7 +324,9 @@ func deserialize(dict: Dictionary, zip_reader: ZIPReader = null, file: FileAcces
 							image = Image.create_from_data(
 								size.x, size.y, false, Image.FORMAT_RGBA8, buffer
 							)
-						cels.append(PixelCel.new(image))
+						var pixelorama_image := PixeloramaImage.new()
+						pixelorama_image.copy_from_custom(image)
+						cels.append(PixelCel.new(pixelorama_image))
 					Global.LayerTypes.GROUP:
 						cels.append(GroupCel.new())
 					Global.LayerTypes.THREE_D:

--- a/src/Classes/ShaderImageEffect.gd
+++ b/src/Classes/ShaderImageEffect.gd
@@ -5,7 +5,9 @@ extends RefCounted
 signal done
 
 
-func generate_image(img: Image, shader: Shader, params: Dictionary, size: Vector2i) -> void:
+func generate_image(
+	img: Image, shader: Shader, params: Dictionary, size: Vector2i, respect_indexed := true
+) -> void:
 	# duplicate shader before modifying code to avoid affecting original resource
 	var resized_width := false
 	var resized_height := false
@@ -60,4 +62,6 @@ func generate_image(img: Image, shader: Shader, params: Dictionary, size: Vector
 		img.crop(img.get_width() - 1, img.get_height())
 	if resized_height:
 		img.crop(img.get_width(), img.get_height() - 1)
+	if img is PixeloramaImage and img.is_indexed and respect_indexed:
+		img.convert_rgb_to_indexed()
 	done.emit()

--- a/src/Classes/ShaderImageEffect.gd
+++ b/src/Classes/ShaderImageEffect.gd
@@ -62,6 +62,6 @@ func generate_image(
 		img.crop(img.get_width() - 1, img.get_height())
 	if resized_height:
 		img.crop(img.get_width(), img.get_height() - 1)
-	if img is PixeloramaImage and respect_indexed:
+	if img is ImageExtended and respect_indexed:
 		img.convert_rgb_to_indexed()
 	done.emit()

--- a/src/Classes/ShaderImageEffect.gd
+++ b/src/Classes/ShaderImageEffect.gd
@@ -62,6 +62,6 @@ func generate_image(
 		img.crop(img.get_width() - 1, img.get_height())
 	if resized_height:
 		img.crop(img.get_width(), img.get_height() - 1)
-	if img is PixeloramaImage and img.is_indexed and respect_indexed:
+	if img is PixeloramaImage and respect_indexed:
 		img.convert_rgb_to_indexed()
 	done.emit()

--- a/src/Shaders/Effects/Palettize.gdshader
+++ b/src/Shaders/Effects/Palettize.gdshader
@@ -3,6 +3,7 @@
 shader_type canvas_item;
 render_mode unshaded;
 
+#include "res://src/Shaders/FindPaletteColorIndex.gdshaderinc"
 uniform sampler2D palette_texture : filter_nearest;
 uniform sampler2D selection : filter_nearest;
 
@@ -10,18 +11,9 @@ vec4 swap_color(vec4 color) {
 	if (color.a <= 0.01) {
 		return color;
 	}
-	int color_index = 0;
+
 	int n_of_colors = textureSize(palette_texture, 0).x;
-	float smaller_distance = distance(color, texture(palette_texture, vec2(0.0)));
-	for (int i = 0; i <= n_of_colors; i++) {
-		vec2 uv = vec2(float(i) / float(n_of_colors), 0.0);
-		vec4 palette_color = texture(palette_texture, uv);
-		float dist = distance(color, palette_color);
-		if (dist < smaller_distance) {
-			smaller_distance = dist;
-			color_index = i;
-		}
-	}
+	int color_index = find_index(color, n_of_colors, palette_texture);
 	return texture(palette_texture, vec2(float(color_index) / float(n_of_colors), 0.0));
 }
 

--- a/src/Shaders/FindPaletteColorIndex.gdshaderinc
+++ b/src/Shaders/FindPaletteColorIndex.gdshaderinc
@@ -1,0 +1,14 @@
+int find_index(vec4 color, int n_of_colors, sampler2D palette_texture) {
+	int color_index = 0;
+	float smaller_distance = distance(color, texture(palette_texture, vec2(0.0)));
+	for (int i = 0; i <= n_of_colors; i++) {
+		vec2 uv = vec2(float(i) / float(n_of_colors), 0.0);
+		vec4 palette_color = texture(palette_texture, uv);
+		float dist = distance(color, palette_color);
+		if (dist < smaller_distance) {
+			smaller_distance = dist;
+			color_index = i;
+		}
+	}
+	return color_index;
+}

--- a/src/Shaders/IndexedToRGB.gdshader
+++ b/src/Shaders/IndexedToRGB.gdshader
@@ -1,0 +1,28 @@
+shader_type canvas_item;
+render_mode unshaded;
+
+const float EPSILON = 0.0001;
+
+uniform sampler2D palette_texture : filter_nearest;
+uniform sampler2D indices_texture : filter_nearest;
+
+void fragment() {
+	float index = texture(indices_texture, UV).r;
+	if (index <= EPSILON) { // If index is zero, make it transparent
+		COLOR = vec4(0.0);
+	}
+	else {
+		float n_of_colors = float(textureSize(palette_texture, 0).x);
+		index -= 1.0 / 255.0;
+		float index_normalized = ((index * 255.0)) / n_of_colors;
+		if (index_normalized + EPSILON < 1.0) {
+			COLOR = texture(palette_texture, vec2(index_normalized + EPSILON, 0.0));
+		}
+		else {
+			// If index is bigger than the size of the palette, make it transparent.
+			// This happens when switching to a palette, where the previous palette was bigger
+			// than the newer one, and the current index is out of bounds of the new one.
+			COLOR = vec4(0.0);
+		}
+	}
+}

--- a/src/Shaders/SetIndices.gdshader
+++ b/src/Shaders/SetIndices.gdshader
@@ -8,6 +8,11 @@ uniform sampler2D palette_texture : filter_nearest;
 
 void fragment() {
 	vec4 color = texture(rgb_texture, UV);
-	int color_index = find_index(color, textureSize(palette_texture, 0).x, palette_texture);
-	COLOR.r = float(color_index + 1) / 255.0;
+	if (color.a <= 0.01) {
+		COLOR.r = 0.0;
+	}
+	else {
+		int color_index = find_index(color, textureSize(palette_texture, 0).x, palette_texture);
+		COLOR.r = float(color_index + 1) / 255.0;
+	}
 }

--- a/src/Shaders/SetIndices.gdshader
+++ b/src/Shaders/SetIndices.gdshader
@@ -1,0 +1,13 @@
+shader_type canvas_item;
+render_mode unshaded;
+
+#include "res://src/Shaders/FindPaletteColorIndex.gdshaderinc"
+uniform sampler2D rgb_texture : filter_nearest;
+uniform sampler2D palette_texture : filter_nearest;
+
+
+void fragment() {
+	vec4 color = texture(rgb_texture, UV);
+	int color_index = find_index(color, textureSize(palette_texture, 0).x, palette_texture);
+	COLOR.r = float(color_index + 1) / 255.0;
+}

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -730,8 +730,8 @@ func _get_undo_data() -> Dictionary:
 	for cel in cels:
 		if not cel is PixelCel:
 			continue
-		var image := cel.get_image()
-		data[image] = image.data
+		var image := (cel as PixelCel).get_image()
+		image.add_data_to_dictionary(data)
 	return data
 
 

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -35,7 +35,7 @@ var _line_polylines := []
 
 # Memorize some stuff when doing brush strokes
 var _stroke_project: Project
-var _stroke_images: Array[Image] = []
+var _stroke_images: Array[PixeloramaImage] = []
 var _is_mask_size_zero := true
 var _circle_tool_shortcut: Array[Vector2i]
 

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -35,7 +35,7 @@ var _line_polylines := []
 
 # Memorize some stuff when doing brush strokes
 var _stroke_project: Project
-var _stroke_images: Array[PixeloramaImage] = []
+var _stroke_images: Array[ImageExtended] = []
 var _is_mask_size_zero := true
 var _circle_tool_shortcut: Array[Vector2i]
 

--- a/src/Tools/BaseTool.gd
+++ b/src/Tools/BaseTool.gd
@@ -299,12 +299,12 @@ func _get_draw_rect() -> Rect2i:
 		return Rect2i(Vector2i.ZERO, Global.current_project.size)
 
 
-func _get_draw_image() -> PixeloramaImage:
+func _get_draw_image() -> ImageExtended:
 	return Global.current_project.get_current_cel().get_image()
 
 
-func _get_selected_draw_images() -> Array[PixeloramaImage]:
-	var images: Array[PixeloramaImage] = []
+func _get_selected_draw_images() -> Array[ImageExtended]:
+	var images: Array[ImageExtended] = []
 	var project := Global.current_project
 	for cel_index in project.selected_cels:
 		var cel: BaseCel = project.frames[cel_index[0]].cels[cel_index[1]]

--- a/src/Tools/BaseTool.gd
+++ b/src/Tools/BaseTool.gd
@@ -299,12 +299,12 @@ func _get_draw_rect() -> Rect2i:
 		return Rect2i(Vector2i.ZERO, Global.current_project.size)
 
 
-func _get_draw_image() -> Image:
+func _get_draw_image() -> PixeloramaImage:
 	return Global.current_project.get_current_cel().get_image()
 
 
-func _get_selected_draw_images() -> Array[Image]:
-	var images: Array[Image] = []
+func _get_selected_draw_images() -> Array[PixeloramaImage]:
+	var images: Array[PixeloramaImage] = []
 	var project := Global.current_project
 	for cel_index in project.selected_cels:
 		var cel: BaseCel = project.frames[cel_index[0]].cels[cel_index[1]]

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -220,9 +220,7 @@ func fill_in_color(pos: Vector2i) -> void:
 		if project.has_selection:
 			selection = project.selection_map.return_cropped_copy(project.size)
 		else:
-			selection = Image.create(
-				project.size.x, project.size.y, false, project.get_image_format()
-			)
+			selection = project.new_empty_image()
 			selection.fill(Color(1, 1, 1, 1))
 
 		selection_tex = ImageTexture.create_from_image(selection)
@@ -265,9 +263,7 @@ func fill_in_selection() -> void:
 	var images := _get_selected_draw_images()
 	if _fill_with == FillWith.COLOR or _pattern == null:
 		if project.has_selection:
-			var filler := Image.create(
-				project.size.x, project.size.y, false, project.get_image_format()
-			)
+			var filler := project.new_empty_image()
 			filler.fill(tool_slot.color)
 			var rect: Rect2i = Global.canvas.selection.big_bounding_rectangle
 			var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
@@ -288,9 +284,7 @@ func fill_in_selection() -> void:
 		if project.has_selection:
 			selection = project.selection_map.return_cropped_copy(project.size)
 		else:
-			selection = Image.create(
-				project.size.x, project.size.y, false, project.get_image_format()
-			)
+			selection = project.new_empty_image()
 			selection.fill(Color(1, 1, 1, 1))
 
 		selection_tex = ImageTexture.create_from_image(selection)

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -220,7 +220,9 @@ func fill_in_color(pos: Vector2i) -> void:
 		if project.has_selection:
 			selection = project.selection_map.return_cropped_copy(project.size)
 		else:
-			selection = Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+			selection = Image.create(
+				project.size.x, project.size.y, false, project.get_image_format()
+			)
 			selection.fill(Color(1, 1, 1, 1))
 
 		selection_tex = ImageTexture.create_from_image(selection)
@@ -263,7 +265,9 @@ func fill_in_selection() -> void:
 	var images := _get_selected_draw_images()
 	if _fill_with == FillWith.COLOR or _pattern == null:
 		if project.has_selection:
-			var filler := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+			var filler := Image.create(
+				project.size.x, project.size.y, false, project.get_image_format()
+			)
 			filler.fill(tool_slot.color)
 			var rect: Rect2i = Global.canvas.selection.big_bounding_rectangle
 			var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
@@ -284,7 +288,9 @@ func fill_in_selection() -> void:
 		if project.has_selection:
 			selection = project.selection_map.return_cropped_copy(project.size)
 		else:
-			selection = Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+			selection = Image.create(
+				project.size.x, project.size.y, false, project.get_image_format()
+			)
 			selection.fill(Color(1, 1, 1, 1))
 
 		selection_tex = ImageTexture.create_from_image(selection)

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -461,7 +461,7 @@ func _compute_segments_for_image(
 					done = false
 
 
-func _color_segments(image: PixeloramaImage) -> void:
+func _color_segments(image: ImageExtended) -> void:
 	if _fill_with == FillWith.COLOR or _pattern == null:
 		# This is needed to ensure that the color used to fill is not wrong, due to float
 		# rounding issues.
@@ -484,7 +484,7 @@ func _color_segments(image: PixeloramaImage) -> void:
 				_set_pixel_pattern(image, px, p.y, pattern_size)
 
 
-func _set_pixel_pattern(image: PixeloramaImage, x: int, y: int, pattern_size: Vector2i) -> void:
+func _set_pixel_pattern(image: ImageExtended, x: int, y: int, pattern_size: Vector2i) -> void:
 	var px := (x + _offset_x) % pattern_size.x
 	var py := (y + _offset_y) % pattern_size.y
 	var pc := _pattern.image.get_pixel(px, py)

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -461,7 +461,7 @@ func _compute_segments_for_image(
 					done = false
 
 
-func _color_segments(image: Image) -> void:
+func _color_segments(image: PixeloramaImage) -> void:
 	if _fill_with == FillWith.COLOR or _pattern == null:
 		# This is needed to ensure that the color used to fill is not wrong, due to float
 		# rounding issues.
@@ -472,7 +472,7 @@ func _color_segments(image: Image) -> void:
 			var p := _allegro_image_segments[c]
 			for px in range(p.left_position, p.right_position + 1):
 				# We don't have to check again whether the point being processed is within the bounds
-				image.set_pixel(px, p.y, color)
+				image.set_pixel_custom(px, p.y, color)
 	else:
 		# shortcircuit tests for patternfills
 		var pattern_size := _pattern.image.get_size()
@@ -484,11 +484,11 @@ func _color_segments(image: Image) -> void:
 				_set_pixel_pattern(image, px, p.y, pattern_size)
 
 
-func _set_pixel_pattern(image: Image, x: int, y: int, pattern_size: Vector2i) -> void:
+func _set_pixel_pattern(image: PixeloramaImage, x: int, y: int, pattern_size: Vector2i) -> void:
 	var px := (x + _offset_x) % pattern_size.x
 	var py := (y + _offset_y) % pattern_size.y
 	var pc := _pattern.image.get_pixel(px, py)
-	image.set_pixel(x, y, pc)
+	image.set_pixel_custom(x, y, pc)
 
 
 func commit_undo() -> void:
@@ -514,12 +514,12 @@ func _get_undo_data() -> Dictionary:
 	if Global.animation_timeline.animation_timer.is_stopped():
 		var images := _get_selected_draw_images()
 		for image in images:
-			data[image] = image.data
+			image.add_data_to_dictionary(data)
 	else:
 		for frame in Global.current_project.frames:
 			var cel := frame.cels[Global.current_project.current_layer]
 			if not cel is PixelCel:
 				continue
-			var image := cel.get_image()
-			data[image] = image.data
+			var image := (cel as PixelCel).get_image()
+			image.add_data_to_dictionary(data)
 	return data

--- a/src/Tools/DesignTools/CurveTool.gd
+++ b/src/Tools/DesignTools/CurveTool.gd
@@ -203,7 +203,7 @@ func _draw_shape() -> void:
 	commit_undo()
 
 
-func _draw_pixel(point: Vector2i, images: Array[Image]) -> void:
+func _draw_pixel(point: Vector2i, images: Array[PixeloramaImage]) -> void:
 	if Global.current_project.can_pixel_get_drawn(point):
 		for image in images:
 			_drawer.set_pixel(image, point, tool_slot.color)

--- a/src/Tools/DesignTools/CurveTool.gd
+++ b/src/Tools/DesignTools/CurveTool.gd
@@ -203,7 +203,7 @@ func _draw_shape() -> void:
 	commit_undo()
 
 
-func _draw_pixel(point: Vector2i, images: Array[PixeloramaImage]) -> void:
+func _draw_pixel(point: Vector2i, images: Array[ImageExtended]) -> void:
 	if Global.current_project.can_pixel_get_drawn(point):
 		for image in images:
 			_drawer.set_pixel(image, point, tool_slot.color)

--- a/src/Tools/DesignTools/Eraser.gd
+++ b/src/Tools/DesignTools/Eraser.gd
@@ -122,6 +122,7 @@ func _draw_brush_image(image: Image, src_rect: Rect2i, dst: Vector2i) -> void:
 		var images := _get_selected_draw_images()
 		for draw_image in images:
 			draw_image.blit_rect_mask(_clear_image, image, src_rect, dst)
+			draw_image.convert_rgb_to_indexed()
 	else:
 		for xx in image.get_size().x:
 			for yy in image.get_size().y:

--- a/src/Tools/DesignTools/Pencil.gd
+++ b/src/Tools/DesignTools/Pencil.gd
@@ -211,6 +211,7 @@ func _draw_brush_image(brush_image: Image, src_rect: Rect2i, dst: Vector2i) -> v
 				draw_image.blit_rect_mask(brush_image, mask, src_rect, dst)
 			else:
 				draw_image.blit_rect(brush_image, src_rect, dst)
+			draw_image.convert_rgb_to_indexed()
 	else:
 		for draw_image in images:
 			if Tools.alpha_locked:
@@ -218,3 +219,4 @@ func _draw_brush_image(brush_image: Image, src_rect: Rect2i, dst: Vector2i) -> v
 				draw_image.blend_rect_mask(brush_image, mask, src_rect, dst)
 			else:
 				draw_image.blend_rect(brush_image, src_rect, dst)
+			draw_image.convert_rgb_to_indexed()

--- a/src/Tools/UtilityTools/Text.gd
+++ b/src/Tools/UtilityTools/Text.gd
@@ -149,12 +149,14 @@ func text_to_pixels() -> void:
 	RenderingServer.free_rid(canvas)
 	RenderingServer.free_rid(ci_rid)
 	RenderingServer.free_rid(texture)
-	viewport_texture.convert(Image.FORMAT_RGBA8)
+	viewport_texture.convert(image.get_format())
 
 	text_edit.queue_free()
 	text_edit = null
 	if not viewport_texture.is_empty():
 		image.copy_from(viewport_texture)
+		if image is PixeloramaImage:
+			image.convert_rgb_to_indexed()
 		commit_undo("Draw", undo_data)
 
 
@@ -179,7 +181,7 @@ func _get_undo_data() -> Dictionary:
 	var data := {}
 	var images := _get_selected_draw_images()
 	for image in images:
-		data[image] = image.data
+		image.add_data_to_dictionary(data)
 	return data
 
 

--- a/src/Tools/UtilityTools/Text.gd
+++ b/src/Tools/UtilityTools/Text.gd
@@ -155,7 +155,7 @@ func text_to_pixels() -> void:
 	text_edit = null
 	if not viewport_texture.is_empty():
 		image.copy_from(viewport_texture)
-		if image is PixeloramaImage:
+		if image is ImageExtended:
 			image.convert_rgb_to_indexed()
 		commit_undo("Draw", undo_data)
 

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -516,8 +516,7 @@ func transform_content_confirm() -> void:
 			Rect2i(Vector2i.ZERO, project.selection_map.get_size()),
 			big_bounding_rectangle.position
 		)
-		if cel_image.is_indexed:
-			cel_image.convert_rgb_to_indexed()
+		cel_image.convert_rgb_to_indexed()
 	project.selection_map.move_bitmap_values(project)
 	commit_undo("Move Selection", undo_data)
 

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -802,7 +802,7 @@ func delete(selected_cels := true) -> void:
 		images = [project.get_current_cel().get_image()]
 
 	if project.has_selection:
-		var blank := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+		var blank := Image.create(project.size.x, project.size.y, false, project.get_image_format())
 		var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
 		for image in images:
 			image.blit_rect_mask(
@@ -871,13 +871,18 @@ func _project_switched() -> void:
 
 func _get_preview_image() -> void:
 	var project := Global.current_project
-	var blended_image := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+	var blended_image := Image.create(
+		project.size.x, project.size.y, false, project.get_image_format()
+	)
 	DrawingAlgos.blend_layers(
 		blended_image, project.frames[project.current_frame], Vector2i.ZERO, project, true
 	)
 	if original_preview_image.is_empty():
 		original_preview_image = Image.create(
-			big_bounding_rectangle.size.x, big_bounding_rectangle.size.y, false, Image.FORMAT_RGBA8
+			big_bounding_rectangle.size.x,
+			big_bounding_rectangle.size.y,
+			false,
+			project.get_image_format()
 		)
 		var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
 		original_preview_image.blit_rect_mask(
@@ -893,8 +898,8 @@ func _get_preview_image() -> void:
 	var clear_image := Image.create(
 		original_preview_image.get_width(),
 		original_preview_image.get_height(),
-		false,
-		Image.FORMAT_RGBA8
+		original_preview_image.has_mipmaps(),
+		original_preview_image.get_format()
 	)
 	for cel in _get_selected_draw_cels():
 		var cel_image := cel.get_image()
@@ -912,7 +917,10 @@ func _get_preview_image() -> void:
 func _get_selected_image(cel_image: Image) -> Image:
 	var project := Global.current_project
 	var image := Image.create(
-		big_bounding_rectangle.size.x, big_bounding_rectangle.size.y, false, Image.FORMAT_RGBA8
+		big_bounding_rectangle.size.x,
+		big_bounding_rectangle.size.y,
+		false,
+		project.get_image_format()
 	)
 	var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
 	image.blit_rect_mask(cel_image, selection_map_copy, big_bounding_rectangle, Vector2i.ZERO)

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -623,8 +623,8 @@ func _get_selected_draw_cels() -> Array[PixelCel]:
 	return cels
 
 
-func _get_selected_draw_images() -> Array[PixeloramaImage]:
-	var images: Array[PixeloramaImage] = []
+func _get_selected_draw_images() -> Array[ImageExtended]:
+	var images: Array[ImageExtended] = []
 	var project := Global.current_project
 	for cel_index in project.selected_cels:
 		var cel: BaseCel = project.frames[cel_index[0]].cels[cel_index[1]]
@@ -795,7 +795,7 @@ func delete(selected_cels := true) -> void:
 		return
 
 	var undo_data_tmp := get_undo_data(true)
-	var images: Array[PixeloramaImage]
+	var images: Array[ImageExtended]
 	if selected_cels:
 		images = _get_selected_draw_images()
 	else:

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -802,7 +802,7 @@ func delete(selected_cels := true) -> void:
 		images = [project.get_current_cel().get_image()]
 
 	if project.has_selection:
-		var blank := Image.create(project.size.x, project.size.y, false, project.get_image_format())
+		var blank := project.new_empty_image()
 		var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
 		for image in images:
 			image.blit_rect_mask(
@@ -871,9 +871,7 @@ func _project_switched() -> void:
 
 func _get_preview_image() -> void:
 	var project := Global.current_project
-	var blended_image := Image.create(
-		project.size.x, project.size.y, false, project.get_image_format()
-	)
+	var blended_image := project.new_empty_image()
 	DrawingAlgos.blend_layers(
 		blended_image, project.frames[project.current_frame], Vector2i.ZERO, project, true
 	)

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -516,6 +516,8 @@ func transform_content_confirm() -> void:
 			Rect2i(Vector2i.ZERO, project.selection_map.get_size()),
 			big_bounding_rectangle.position
 		)
+		if cel_image.is_indexed:
+			cel_image.convert_rgb_to_indexed()
 	project.selection_map.move_bitmap_values(project)
 	commit_undo("Move Selection", undo_data)
 
@@ -605,13 +607,13 @@ func get_undo_data(undo_image: bool) -> Dictionary:
 	if undo_image:
 		var images := _get_selected_draw_images()
 		for image in images:
-			data[image] = image.data
+			image.add_data_to_dictionary(data)
 
 	return data
 
 
-func _get_selected_draw_cels() -> Array[BaseCel]:
-	var cels: Array[BaseCel] = []
+func _get_selected_draw_cels() -> Array[PixelCel]:
+	var cels: Array[PixelCel] = []
 	var project := Global.current_project
 	for cel_index in project.selected_cels:
 		var cel: BaseCel = project.frames[cel_index[0]].cels[cel_index[1]]
@@ -622,8 +624,8 @@ func _get_selected_draw_cels() -> Array[BaseCel]:
 	return cels
 
 
-func _get_selected_draw_images() -> Array[Image]:
-	var images: Array[Image] = []
+func _get_selected_draw_images() -> Array[PixeloramaImage]:
+	var images: Array[PixeloramaImage] = []
 	var project := Global.current_project
 	for cel_index in project.selected_cels:
 		var cel: BaseCel = project.frames[cel_index[0]].cels[cel_index[1]]
@@ -794,7 +796,7 @@ func delete(selected_cels := true) -> void:
 		return
 
 	var undo_data_tmp := get_undo_data(true)
-	var images: Array[Image]
+	var images: Array[PixeloramaImage]
 	if selected_cels:
 		images = _get_selected_draw_images()
 	else:
@@ -896,7 +898,7 @@ func _get_preview_image() -> void:
 		Image.FORMAT_RGBA8
 	)
 	for cel in _get_selected_draw_cels():
-		var cel_image: Image = cel.get_image()
+		var cel_image := cel.get_image()
 		cel.transformed_content = _get_selected_image(cel_image)
 		cel_image.blit_rect_mask(
 			clear_image,

--- a/src/UI/Dialogs/CreateNewImage.gd
+++ b/src/UI/Dialogs/CreateNewImage.gd
@@ -52,7 +52,9 @@ var templates: Array[Template] = [
 @onready var height_value := %HeightValue as SpinBox
 @onready var portrait_button := %PortraitButton as Button
 @onready var landscape_button := %LandscapeButton as Button
+@onready var name_input := $VBoxContainer/FillColorContainer/NameInput as LineEdit
 @onready var fill_color_node := %FillColor as ColorPickerButton
+@onready var color_mode := $VBoxContainer/FillColorContainer/ColorMode as OptionButton
 @onready var recent_templates_list := %RecentTemplates as ItemList
 
 
@@ -123,13 +125,14 @@ func _on_CreateNewImage_confirmed() -> void:
 	if recent_sizes.size() > 10:
 		recent_sizes.resize(10)
 	Global.config_cache.set_value("templates", "recent_sizes", recent_sizes)
-	var fill_color: Color = fill_color_node.color
-
-	var proj_name: String = $VBoxContainer/ProjectName/NameInput.text
+	var fill_color := fill_color_node.color
+	var proj_name := name_input.text
 	if !proj_name.is_valid_filename():
 		proj_name = tr("untitled")
 
 	var new_project := Project.new([], proj_name, image_size)
+	if color_mode.selected == 1:
+		new_project.color_mode = Project.INDEXED_MODE
 	new_project.layers.append(PixelLayer.new(new_project))
 	new_project.fill_color = fill_color
 	new_project.frames.append(new_project.new_empty_frame())

--- a/src/UI/Dialogs/CreateNewImage.tscn
+++ b/src/UI/Dialogs/CreateNewImage.tscn
@@ -9,7 +9,8 @@
 
 [node name="CreateNewImage" type="ConfirmationDialog"]
 title = "New..."
-size = Vector2i(384, 330)
+position = Vector2i(0, 36)
+size = Vector2i(434, 330)
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
@@ -22,19 +23,6 @@ offset_right = -8.0
 offset_bottom = -49.0
 size_flags_horizontal = 0
 
-[node name="ProjectName" type="HBoxContainer" parent="VBoxContainer"]
-layout_mode = 2
-
-[node name="NameLabel" type="Label" parent="VBoxContainer/ProjectName"]
-custom_minimum_size = Vector2(100, 0)
-layout_mode = 2
-text = "Project Name:"
-
-[node name="NameInput" type="LineEdit" parent="VBoxContainer/ProjectName"]
-layout_mode = 2
-size_flags_horizontal = 3
-placeholder_text = "Enter name... (Default \"untitled\")"
-
 [node name="ImageSize" type="Label" parent="VBoxContainer"]
 layout_mode = 2
 text = "Image Size"
@@ -42,49 +30,48 @@ text = "Image Size"
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="SizeContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="Templates" type="VBoxContainer" parent="VBoxContainer/VBoxContainer"]
+[node name="SizeOptions" type="VBoxContainer" parent="VBoxContainer/SizeContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TemplatesContainer" type="HBoxContainer" parent="VBoxContainer/VBoxContainer/Templates"]
+[node name="TemplatesContainer" type="HBoxContainer" parent="VBoxContainer/SizeContainer/SizeOptions"]
 layout_mode = 2
 
-[node name="TemplatesLabel" type="Label" parent="VBoxContainer/VBoxContainer/Templates/TemplatesContainer"]
+[node name="TemplatesLabel" type="Label" parent="VBoxContainer/SizeContainer/SizeOptions/TemplatesContainer"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Templates:"
 
-[node name="TemplatesOptions" type="OptionButton" parent="VBoxContainer/VBoxContainer/Templates/TemplatesContainer"]
+[node name="TemplatesOptions" type="OptionButton" parent="VBoxContainer/SizeContainer/SizeOptions/TemplatesContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_default_cursor_shape = 2
 toggle_mode = false
-item_count = 1
 selected = 0
+item_count = 1
 popup/item_0/text = "Default"
-popup/item_0/id = 0
 
-[node name="SizeContainer" type="HBoxContainer" parent="VBoxContainer/VBoxContainer/Templates"]
+[node name="WidthHeightContainer" type="HBoxContainer" parent="VBoxContainer/SizeContainer/SizeOptions"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="WidthContainer" type="HBoxContainer" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer/VBoxContainer"]
+[node name="WidthContainer" type="HBoxContainer" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="WidthLabel" type="Label" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer/VBoxContainer/WidthContainer"]
+[node name="WidthLabel" type="Label" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/VBoxContainer/WidthContainer"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Width:"
 
-[node name="WidthValue" type="SpinBox" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer/VBoxContainer/WidthContainer"]
+[node name="WidthValue" type="SpinBox" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/VBoxContainer/WidthContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -94,15 +81,15 @@ max_value = 16384.0
 value = 64.0
 suffix = "px"
 
-[node name="HeightContainer" type="HBoxContainer" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer/VBoxContainer"]
+[node name="HeightContainer" type="HBoxContainer" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HeightLabel" type="Label" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer/VBoxContainer/HeightContainer"]
+[node name="HeightLabel" type="Label" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/VBoxContainer/HeightContainer"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "Height:"
 
-[node name="HeightValue" type="SpinBox" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer/VBoxContainer/HeightContainer"]
+[node name="HeightValue" type="SpinBox" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/VBoxContainer/HeightContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -112,11 +99,11 @@ max_value = 16384.0
 value = 64.0
 suffix = "px"
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer" groups=["UIButtons"]]
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer" groups=["UIButtons"]]
 layout_mode = 2
 texture = ExtResource("6")
 
-[node name="AspectRatioButton" type="TextureButton" parent="VBoxContainer/VBoxContainer/Templates/SizeContainer/TextureRect" groups=["UIButtons"]]
+[node name="AspectRatioButton" type="TextureButton" parent="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/TextureRect" groups=["UIButtons"]]
 unique_name_in_owner = true
 layout_mode = 0
 anchor_left = 0.5
@@ -133,31 +120,10 @@ toggle_mode = true
 texture_normal = ExtResource("4")
 texture_pressed = ExtResource("5")
 
-[node name="VSeparator" type="VSeparator" parent="VBoxContainer/VBoxContainer"]
+[node name="SizeButtonsContainer" type="HBoxContainer" parent="VBoxContainer/SizeContainer/SizeOptions"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/VBoxContainer"]
-clip_contents = true
-custom_minimum_size = Vector2(150, 0)
-layout_mode = 2
-focus_mode = 2
-mouse_filter = 0
-
-[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer/VBoxContainer"]
-layout_mode = 2
-text = "Recent:"
-
-[node name="RecentTemplates" type="ItemList" parent="VBoxContainer/VBoxContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-allow_reselect = true
-
-[node name="SizeButtonsContainer" type="HBoxContainer" parent="VBoxContainer"]
-layout_mode = 2
-
-[node name="PortraitButton" type="Button" parent="VBoxContainer/SizeButtonsContainer" groups=["UIButtons"]]
+[node name="PortraitButton" type="Button" parent="VBoxContainer/SizeContainer/SizeOptions/SizeButtonsContainer" groups=["UIButtons"]]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(24, 24)
 layout_mode = 2
@@ -166,7 +132,7 @@ focus_mode = 0
 mouse_default_cursor_shape = 2
 toggle_mode = true
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/SizeButtonsContainer/PortraitButton"]
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/SizeContainer/SizeOptions/SizeButtonsContainer/PortraitButton"]
 layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
@@ -178,7 +144,7 @@ offset_right = 8.0
 offset_bottom = 8.0
 texture = ExtResource("2")
 
-[node name="LandscapeButton" type="Button" parent="VBoxContainer/SizeButtonsContainer" groups=["UIButtons"]]
+[node name="LandscapeButton" type="Button" parent="VBoxContainer/SizeContainer/SizeOptions/SizeButtonsContainer" groups=["UIButtons"]]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(24, 24)
 layout_mode = 2
@@ -187,7 +153,7 @@ focus_mode = 0
 mouse_default_cursor_shape = 2
 toggle_mode = true
 
-[node name="TextureRect" type="TextureRect" parent="VBoxContainer/SizeButtonsContainer/LandscapeButton"]
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/SizeContainer/SizeOptions/SizeButtonsContainer/LandscapeButton"]
 layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
@@ -199,12 +165,49 @@ offset_right = 8.0
 offset_bottom = 8.0
 texture = ExtResource("3")
 
-[node name="FillColorContainer" type="HBoxContainer" parent="VBoxContainer"]
+[node name="VSeparator" type="VSeparator" parent="VBoxContainer/SizeContainer"]
 layout_mode = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/SizeContainer"]
+clip_contents = true
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+focus_mode = 2
+mouse_filter = 0
+
+[node name="Label" type="Label" parent="VBoxContainer/SizeContainer/VBoxContainer"]
+layout_mode = 2
+text = "Recent:"
+
+[node name="RecentTemplates" type="ItemList" parent="VBoxContainer/SizeContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+allow_reselect = true
+
+[node name="HSeparator2" type="HSeparator" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="FillColorContainer" type="GridContainer" parent="VBoxContainer"]
+layout_mode = 2
+columns = 2
+
+[node name="NameLabel" type="Label" parent="VBoxContainer/FillColorContainer"]
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Project Name:"
+
+[node name="NameInput" type="LineEdit" parent="VBoxContainer/FillColorContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "Enter name... (Default \"untitled\")"
 
 [node name="FillColorLabel" type="Label" parent="VBoxContainer/FillColorContainer"]
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
+size_flags_horizontal = 3
 text = "Fill with color:"
 
 [node name="FillColor" type="ColorPickerButton" parent="VBoxContainer/FillColorContainer"]
@@ -215,13 +218,28 @@ size_flags_horizontal = 3
 mouse_default_cursor_shape = 2
 color = Color(0, 0, 0, 0)
 
+[node name="ColorModeLabel" type="Label" parent="VBoxContainer/FillColorContainer"]
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Color mode:"
+
+[node name="ColorMode" type="OptionButton" parent="VBoxContainer/FillColorContainer"]
+layout_mode = 2
+mouse_default_cursor_shape = 2
+selected = 0
+item_count = 2
+popup/item_0/text = "RGBA"
+popup/item_1/text = "Indexed"
+popup/item_1/id = 1
+
 [connection signal="about_to_popup" from="." to="." method="_on_CreateNewImage_about_to_show"]
 [connection signal="confirmed" from="." to="." method="_on_CreateNewImage_confirmed"]
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
-[connection signal="item_selected" from="VBoxContainer/VBoxContainer/Templates/TemplatesContainer/TemplatesOptions" to="." method="_on_TemplatesOptions_item_selected"]
-[connection signal="value_changed" from="VBoxContainer/VBoxContainer/Templates/SizeContainer/VBoxContainer/WidthContainer/WidthValue" to="." method="_on_SizeValue_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/VBoxContainer/Templates/SizeContainer/VBoxContainer/HeightContainer/HeightValue" to="." method="_on_SizeValue_value_changed"]
-[connection signal="toggled" from="VBoxContainer/VBoxContainer/Templates/SizeContainer/TextureRect/AspectRatioButton" to="." method="_on_AspectRatioButton_toggled"]
-[connection signal="item_selected" from="VBoxContainer/VBoxContainer/VBoxContainer/RecentTemplates" to="." method="_on_RecentTemplates_item_selected"]
-[connection signal="toggled" from="VBoxContainer/SizeButtonsContainer/PortraitButton" to="." method="_on_PortraitButton_toggled"]
-[connection signal="toggled" from="VBoxContainer/SizeButtonsContainer/LandscapeButton" to="." method="_on_LandscapeButton_toggled"]
+[connection signal="item_selected" from="VBoxContainer/SizeContainer/SizeOptions/TemplatesContainer/TemplatesOptions" to="." method="_on_TemplatesOptions_item_selected"]
+[connection signal="value_changed" from="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/VBoxContainer/WidthContainer/WidthValue" to="." method="_on_SizeValue_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/VBoxContainer/HeightContainer/HeightValue" to="." method="_on_SizeValue_value_changed"]
+[connection signal="toggled" from="VBoxContainer/SizeContainer/SizeOptions/WidthHeightContainer/TextureRect/AspectRatioButton" to="." method="_on_AspectRatioButton_toggled"]
+[connection signal="toggled" from="VBoxContainer/SizeContainer/SizeOptions/SizeButtonsContainer/PortraitButton" to="." method="_on_PortraitButton_toggled"]
+[connection signal="toggled" from="VBoxContainer/SizeContainer/SizeOptions/SizeButtonsContainer/LandscapeButton" to="." method="_on_LandscapeButton_toggled"]
+[connection signal="item_selected" from="VBoxContainer/SizeContainer/VBoxContainer/RecentTemplates" to="." method="_on_RecentTemplates_item_selected"]

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -136,6 +136,8 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 			cel.blend_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
 		else:
 			cel.blit_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
+		if cel is PixeloramaImage:
+			cel.convert_rgb_to_indexed()
 
 
 func _type_is_shader() -> bool:

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -136,7 +136,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 			cel.blend_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
 		else:
 			cel.blit_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
-		if cel is PixeloramaImage:
+		if cel is ImageExtended:
 			cel.convert_rgb_to_indexed()
 
 

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -89,7 +89,9 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 		selection_tex = ImageTexture.create_from_image(selection)
 
 		if !_type_is_shader():
-			var blank := Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+			var blank := Image.create(
+				project.size.x, project.size.y, false, project.get_image_format()
+			)
 			cel.blit_rect_mask(
 				blank, selection, Rect2i(Vector2i.ZERO, cel.get_size()), Vector2i.ZERO
 			)

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -89,9 +89,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 		selection_tex = ImageTexture.create_from_image(selection)
 
 		if !_type_is_shader():
-			var blank := Image.create(
-				project.size.x, project.size.y, false, project.get_image_format()
-			)
+			var blank := project.new_empty_image()
 			cel.blit_rect_mask(
 				blank, selection, Rect2i(Vector2i.ZERO, cel.get_size()), Vector2i.ZERO
 			)

--- a/src/UI/Dialogs/ImageEffects/ScaleImage.gd
+++ b/src/UI/Dialogs/ImageEffects/ScaleImage.gd
@@ -34,7 +34,7 @@ func _on_ScaleImage_confirmed() -> void:
 	var width: int = width_value.value
 	var height: int = height_value.value
 	var interpolation: int = interpolation_type.selected
-	DrawingAlgos.scale_image(width, height, interpolation)
+	DrawingAlgos.scale_project(width, height, interpolation)
 
 
 func _on_visibility_changed() -> void:

--- a/src/UI/Dialogs/ImportTagDialog.gd
+++ b/src/UI/Dialogs/ImportTagDialog.gd
@@ -22,7 +22,9 @@ func refresh_list() -> void:
 	animation_tags_list.clear()
 	get_ok_button().disabled = true
 	for tag: AnimationTag in from_project.animation_tags:
-		var img = Image.create(from_project.size.x, from_project.size.y, true, Image.FORMAT_RGBA8)
+		var img = Image.create(
+			from_project.size.x, from_project.size.y, true, from_project.get_image_format()
+		)
 		DrawingAlgos.blend_layers(
 			img, from_project.frames[tag.from - 1], Vector2i.ZERO, from_project
 		)
@@ -187,7 +189,7 @@ func add_animation(indices: Array, destination: int, from_tag: AnimationTag = nu
 					if src_cel is PixelCel:
 						var src_img = src_cel.copy_content()
 						var copy := Image.create(
-							project.size.x, project.size.y, false, Image.FORMAT_RGBA8
+							project.size.x, project.size.y, false, project.get_image_format()
 						)
 						copy.blit_rect(
 							src_img, Rect2(Vector2.ZERO, src_img.get_size()), Vector2.ZERO

--- a/src/UI/Dialogs/ImportTagDialog.gd
+++ b/src/UI/Dialogs/ImportTagDialog.gd
@@ -22,9 +22,7 @@ func refresh_list() -> void:
 	animation_tags_list.clear()
 	get_ok_button().disabled = true
 	for tag: AnimationTag in from_project.animation_tags:
-		var img = Image.create(
-			from_project.size.x, from_project.size.y, true, from_project.get_image_format()
-		)
+		var img := from_project.new_empty_image()
 		DrawingAlgos.blend_layers(
 			img, from_project.frames[tag.from - 1], Vector2i.ZERO, from_project
 		)
@@ -188,9 +186,7 @@ func add_animation(indices: Array, destination: int, from_tag: AnimationTag = nu
 					# add more types here if they have a copy_content() method
 					if src_cel is PixelCel:
 						var src_img = src_cel.copy_content()
-						var copy := Image.create(
-							project.size.x, project.size.y, false, project.get_image_format()
-						)
+						var copy := project.new_empty_image()
 						copy.blit_rect(
 							src_img, Rect2(Vector2.ZERO, src_img.get_size()), Vector2.ZERO
 						)

--- a/src/UI/Dialogs/ProjectProperties.gd
+++ b/src/UI/Dialogs/ProjectProperties.gd
@@ -1,6 +1,7 @@
 extends AcceptDialog
 
 @onready var size_value_label := $GridContainer/SizeValueLabel as Label
+@onready var color_mode_value_label := $GridContainer/ColorModeValueLabel as Label
 @onready var frames_value_label := $GridContainer/FramesValueLabel as Label
 @onready var layers_value_label := $GridContainer/LayersValueLabel as Label
 @onready var name_line_edit := $GridContainer/NameLineEdit as LineEdit
@@ -10,6 +11,12 @@ extends AcceptDialog
 func _on_visibility_changed() -> void:
 	Global.dialog_open(visible)
 	size_value_label.text = str(Global.current_project.size)
+	if Global.current_project.get_image_format() == Image.FORMAT_RGBA8:
+		color_mode_value_label.text = "RGBA8"
+	else:
+		color_mode_value_label.text = str(Global.current_project.get_image_format())
+	if Global.current_project.is_indexed():
+		color_mode_value_label.text += " (%s)" % tr("Indexed")
 	frames_value_label.text = str(Global.current_project.frames.size())
 	layers_value_label.text = str(Global.current_project.layers.size())
 	name_line_edit.text = Global.current_project.name

--- a/src/UI/Dialogs/ProjectProperties.tscn
+++ b/src/UI/Dialogs/ProjectProperties.tscn
@@ -24,6 +24,16 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "64x64"
 
+[node name="ColorModeLabel" type="Label" parent="GridContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Color mode:"
+
+[node name="ColorModeValueLabel" type="Label" parent="GridContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "RGBA8"
+
 [node name="FramesLabel" type="Label" parent="GridContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
@@ -32,7 +42,7 @@ text = "Frames:"
 [node name="FramesValueLabel" type="Label" parent="GridContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "64x64"
+text = "1"
 
 [node name="LayersLabel" type="Label" parent="GridContainer"]
 layout_mode = 2
@@ -42,7 +52,7 @@ text = "Layers:"
 [node name="LayersValueLabel" type="Label" parent="GridContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "64x64"
+text = "1"
 
 [node name="NameLabel" type="Label" parent="GridContainer"]
 layout_mode = 2

--- a/src/UI/Recorder/Recorder.gd
+++ b/src/UI/Recorder/Recorder.gd
@@ -70,7 +70,7 @@ class Recorder:
 			image = recorder_panel.get_window().get_texture().get_image()
 		else:
 			var frame := project.frames[project.current_frame]
-			image = Image.create(project.size.x, project.size.y, false, project.get_image_format())
+			image = project.new_empty_image()
 			DrawingAlgos.blend_layers(image, frame, Vector2i.ZERO, project)
 
 			if recorder_panel.resize_percent != 100:

--- a/src/UI/Recorder/Recorder.gd
+++ b/src/UI/Recorder/Recorder.gd
@@ -70,7 +70,7 @@ class Recorder:
 			image = recorder_panel.get_window().get_texture().get_image()
 		else:
 			var frame := project.frames[project.current_frame]
-			image = Image.create(project.size.x, project.size.y, false, Image.FORMAT_RGBA8)
+			image = Image.create(project.size.x, project.size.y, false, project.get_image_format())
 			DrawingAlgos.blend_layers(image, frame, Vector2i.ZERO, project)
 
 			if recorder_panel.resize_percent != 100:

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -1059,7 +1059,7 @@ func _on_MergeDownLayer_pressed() -> void:
 		var params := {
 			"layers": texture_array, "metadata": ImageTexture.create_from_image(metadata_image)
 		}
-		var new_bottom_image := PixeloramaImage.create_custom(
+		var new_bottom_image := ImageExtended.create_custom(
 			top_image.get_width(),
 			top_image.get_height(),
 			top_image.has_mipmaps(),

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -1045,9 +1045,10 @@ func _on_MergeDownLayer_pressed() -> void:
 		top_cels.append(top_cel)  # Store for undo purposes
 
 		var top_image := top_layer.display_effects(top_cel)
-		var bottom_cel := frame.cels[bottom_layer.index]
+		var bottom_cel := frame.cels[bottom_layer.index] as PixelCel
+		var bottom_image := bottom_cel.get_image()
 		var textures: Array[Image] = []
-		textures.append(bottom_cel.get_image())
+		textures.append(bottom_image)
 		textures.append(top_image)
 		var metadata_image := Image.create(2, 4, false, Image.FORMAT_R8)
 		DrawingAlgos.set_layer_metadata_image(bottom_layer, bottom_cel, metadata_image, 0)
@@ -1058,12 +1059,17 @@ func _on_MergeDownLayer_pressed() -> void:
 		var params := {
 			"layers": texture_array, "metadata": ImageTexture.create_from_image(metadata_image)
 		}
-		var bottom_image := Image.create(
-			top_image.get_width(), top_image.get_height(), false, top_image.get_format()
+		var new_bottom_image := PixeloramaImage.create_custom(
+			top_image.get_width(),
+			top_image.get_height(),
+			top_image.has_mipmaps(),
+			top_image.get_format(),
+			project.is_indexed()
 		)
+		# Merge the image itself.
 		var gen := ShaderImageEffect.new()
-		gen.generate_image(bottom_image, DrawingAlgos.blend_layers_shader, params, project.size)
-
+		gen.generate_image(new_bottom_image, DrawingAlgos.blend_layers_shader, params, project.size)
+		new_bottom_image.convert_rgb_to_indexed()
 		if (
 			bottom_cel.link_set != null
 			and bottom_cel.link_set.size() > 1
@@ -1074,14 +1080,16 @@ func _on_MergeDownLayer_pressed() -> void:
 			project.undo_redo.add_undo_method(
 				bottom_layer.link_cel.bind(bottom_cel, bottom_cel.link_set)
 			)
-			project.undo_redo.add_do_property(bottom_cel, "image", bottom_image)
+			project.undo_redo.add_do_property(bottom_cel, "image", new_bottom_image)
 			project.undo_redo.add_undo_property(bottom_cel, "image", bottom_cel.image)
 		else:
-			Global.undo_redo_compress_images(
-				{bottom_cel.image: bottom_image.data},
-				{bottom_cel.image: bottom_cel.image.data},
-				project
-			)
+			var redo_data := {
+				bottom_image.indices_image: new_bottom_image.indices_image.data,
+				bottom_image: new_bottom_image.data
+			}
+			var undo_data := {}
+			bottom_image.add_data_to_dictionary(undo_data)
+			Global.undo_redo_compress_images(redo_data, undo_data, project)
 
 	project.undo_redo.add_do_method(project.remove_layers.bind([top_layer.index]))
 	project.undo_redo.add_undo_method(

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -1083,11 +1083,9 @@ func _on_MergeDownLayer_pressed() -> void:
 			project.undo_redo.add_do_property(bottom_cel, "image", new_bottom_image)
 			project.undo_redo.add_undo_property(bottom_cel, "image", bottom_cel.image)
 		else:
-			var redo_data := {
-				bottom_image.indices_image: new_bottom_image.indices_image.data,
-				bottom_image: new_bottom_image.data
-			}
+			var redo_data := {}
 			var undo_data := {}
+			new_bottom_image.add_data_to_dictionary(redo_data, bottom_image)
 			bottom_image.add_data_to_dictionary(undo_data)
 			Global.undo_redo_compress_images(redo_data, undo_data, project)
 

--- a/src/UI/Timeline/LayerEffects/LayerEffectsSettings.gd
+++ b/src/UI/Timeline/LayerEffects/LayerEffectsSettings.gd
@@ -154,15 +154,15 @@ func _apply_effect(layer: BaseLayer, effect: LayerEffect) -> void:
 	var undo_data := {}
 	for frame in Global.current_project.frames:
 		var cel := frame.cels[layer.index]
-		var new_image := PixeloramaImage.new()
+		var new_image := ImageExtended.new()
 		var cel_image := cel.get_image()
-		if cel_image is PixeloramaImage:
+		if cel_image is ImageExtended:
 			new_image.is_indexed = cel_image.is_indexed
 		new_image.copy_from_custom(cel_image)
 		var image_size := new_image.get_size()
 		var shader_image_effect := ShaderImageEffect.new()
 		shader_image_effect.generate_image(new_image, effect.shader, effect.params, image_size)
-		if cel_image is PixeloramaImage:
+		if cel_image is ImageExtended:
 			redo_data[cel_image.indices_image] = new_image.indices_image.data
 			undo_data[cel_image.indices_image] = cel_image.indices_image.data
 		redo_data[cel_image] = new_image.data

--- a/src/UI/Timeline/LayerEffects/LayerEffectsSettings.gd
+++ b/src/UI/Timeline/LayerEffects/LayerEffectsSettings.gd
@@ -154,13 +154,19 @@ func _apply_effect(layer: BaseLayer, effect: LayerEffect) -> void:
 	var undo_data := {}
 	for frame in Global.current_project.frames:
 		var cel := frame.cels[layer.index]
-		var new_image := Image.new()
-		new_image.copy_from(cel.get_image())
+		var new_image := PixeloramaImage.new()
+		var cel_image := cel.get_image()
+		if cel_image is PixeloramaImage:
+			new_image.is_indexed = cel_image.is_indexed
+		new_image.copy_from_custom(cel_image)
 		var image_size := new_image.get_size()
 		var shader_image_effect := ShaderImageEffect.new()
 		shader_image_effect.generate_image(new_image, effect.shader, effect.params, image_size)
-		redo_data[cel.image] = new_image.data
-		undo_data[cel.image] = cel.image.data
+		if cel_image is PixeloramaImage:
+			redo_data[cel_image.indices_image] = new_image.indices_image.data
+			undo_data[cel_image.indices_image] = cel_image.indices_image.data
+		redo_data[cel_image] = new_image.data
+		undo_data[cel_image] = cel_image.data
 	Global.current_project.undos += 1
 	Global.current_project.undo_redo.create_action("Apply layer effect")
 	Global.undo_redo_compress_images(redo_data, undo_data)


### PR DESCRIPTION
Implements #572. In indexed mode, each pixel is assigned to a number that references a palette color. This essentially means that the colors of the image are restricted to a specific palette, and they will automatically get updated when you make changes to that palette, or when you switch to a different one.

Users can select whether new projects are using RGBA or indexed mode from the create new project dialog, and they can change the color mode whenever they want from the Image menu. Converting a project from RGBA to indexed mode will automatically change the colors of the image by finding the closest color in the selected palette, similar to what the Palettize effect does. Changing from indexed mode to RGBA does not change the colors of the image, but they will stop changing automatically get making changes to the palette.

https://github.com/user-attachments/assets/abbd294e-7148-4384-89f2-cdbc7dbd91f9

Since Godot's `Image` class has no indexed format, I made a custom `ImageExtended` class that extends `Image` and mimics indexed mode by having an internal `Image` for the indices of each pixel. Using an `Image` for the indices gives us the advantage of using shaders for quick operations, such as setting the indices when converting from RGB to indexed, and when converting from indexed to RGB. Now all `PixelCels` have an `ImageExtended` instance instead of `Image`. The indices are also stored in pxo files.

If a pixel's index is set to 0, it means that that pixel is transparent. Indices that are outside the bounds of the current palette (which can occur by shrinking the palette or switching to a smaller one) will also appear as transparent.

All tools, image effects, layer effects, resizing, merging layers and undo/redo all work with indexed mode.