### PR TITLE
Grid patch

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -752,7 +752,11 @@ func _ready() -> void:
 
 
 func update_grids(grids_data: Dictionary):
+	# Remove old grids
 	grids.clear()
+	if is_instance_valid(Global.canvas.grid):
+		Global.canvas.grid.queue_redraw()
+	# ADD new ones
 	for grid_idx in grids_data.size():
 		Grid.new(grids_data[grid_idx])  # gets auto added to grids array
 

--- a/src/Preferences/GridPreferences.gd
+++ b/src/Preferences/GridPreferences.gd
@@ -132,7 +132,7 @@ func _on_grids_count_value_changed(value: float) -> void:
 		for key in range(grids_select_container.get_child_count(), value):
 			if not new_grids.has(key):
 				var new_grid := create_default_properties()
-				if new_grids.has(key - 1): # failsafe
+				if new_grids.has(key - 1):  # Failsafe
 					var last_grid = new_grids[key - 1]
 					# This small bit of code is there to make ui look a little neater
 					# Reasons:


### PR DESCRIPTION
- Fixed second grid not appearing to be removed when first grid has default values. this was because queue_redraw was not called due to the app thinking nothing had changed.
- fixed reset button of color picker not set correctly when we switch to another grid
- Now, whenever you create a new grid, the new grid will be twice the size of previous grid (and with a different color). this is done because i felt that having all grids being being of same size and color may cause confusion for users when they try to change color of a grid not seeing it's changing (due to being covered by grids above it).