### PR TITLE
Fix layouts overwriting the position info of pannels, added by extensions.

### DIFF
--- a/src/UI/TopMenuContainer/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer/TopMenuContainer.gd
@@ -412,7 +412,8 @@ func _setup_layouts_submenu(item: String) -> void:
 	window_menu.add_submenu_node_item(item, layouts_submenu)
 
 	var saved_layout: int = Global.config_cache.get_value("window", "layout", 0)
-	set_layout(saved_layout)
+	# Wait for pixelorama to fully load up, then change the layout.
+	Global.pixelorama_opened.connect(set_layout.bind(saved_layout))
 
 
 func populate_layouts_submenu() -> void:


### PR DESCRIPTION
The problem was that the layout change was done too early, before the extension adding the panel.
As the panel always initially gets added to the left most side (which is different form it's last closed position, where we moved the panel), it gets counted as a change and the layout overwrote/reset the panel's position