### PR TITLE
Add missing translations strings and fix broken ones

### DIFF
--- a/Translations/Translations.pot
+++ b/Translations/Translations.pot
@@ -343,6 +343,10 @@ msgstr ""
 msgid "Moveable Panels"
 msgstr ""
 
+#. Button found in the three vertical dots menu of any panel, when Moveable Panels is enabled in the Window menu. It "detaches" the panel, making it a floating window.
+msgid "Make Floating"
+msgstr ""
+
 msgid "Manage Layouts"
 msgstr ""
 
@@ -1507,6 +1511,8 @@ msgid "Color Picker\n\n"
 msgstr ""
 
 msgid "Crop\n\n"
+"%s for left mouse button\n"
+"%s for right mouse button\n\n"
 "Resize the canvas"
 msgstr ""
 
@@ -1595,7 +1601,7 @@ msgid "Reset the colors to their default state (black for left, white for right)
 msgstr ""
 
 #. Tooltip of the screen color picker button found in the color picker panel.
-msgid "Pick a color from the screen."
+msgid "Pick a color from the application window."
 msgstr ""
 
 #. Tooltip of the color text field found in the color picker panel that lets users change the color by hex code or english name ("red" cannot be translated).
@@ -1875,6 +1881,30 @@ msgstr ""
 msgid "Explore Online"
 msgstr ""
 
+#. Found in the Preferences, under Extensions, in the "Explore Online" popup. Title of the tab that shows the Extensions Store, where you can download extensions.
+msgid "Store"
+msgstr ""
+
+#. Found in the Preferences, under Extensions, in the "Explore Online" popup. Text field to search for extensions.
+msgid "Search..."
+msgstr ""
+
+#. Found in the Preferences, under Extensions, in the "Explore Online" popup. Refers to the tags used to filter extensions in the explorer.
+msgid "Tags:"
+msgstr ""
+
+#. Found in the Preferences, under Extensions, in the "Explore Online" popup. Button to download an extension.
+msgid "Download"
+msgstr ""
+
+#. Found in the Preferences, under Extensions, in the "Explore Online" popup, under Options. It's the section where you can add links to more extension stores.
+msgid "Store Links:"
+msgstr ""
+
+#. Found in the Preferences, under Extensions, in the "Explore Online" popup, under Options. Placeholder text for adding a link to an extensions store. "Will be automatically removed" refers to the text field itself, if no link is entered.
+msgid "Paste Store link, given by the store owner (will automatically be removed if left empty)"
+msgstr ""
+
 #. Found in the Preferences, under Extensions. This is the text of a confirmation dialog that appears when the user attempts to enable an extension.
 msgid "Are you sure you want to enable this extension? Make sure to only enable extensions from sources that you trust."
 msgstr ""
@@ -1929,19 +1959,62 @@ msgstr ""
 msgid "Select a brush"
 msgstr ""
 
+#. Found when selecting a brush. It's a section that shows the default Pixelorama brushes.
+msgid "Default Brushes"
+msgstr ""
+
+#. Found when selecting a brush. One of the default brushes that come with Pixelorama.
 msgid "Pixel brush"
 msgstr ""
 
+#. Found when selecting a brush. One of the default brushes that come with Pixelorama.
 msgid "Circle brush"
 msgstr ""
 
+#. Found when selecting a brush. One of the default brushes that come with Pixelorama.
 msgid "Filled circle brush"
+msgstr ""
+
+#. Found when selecting a brush. It's a section that shows brushes the user has imported for the current project specifically.
+msgid "Project Brushes"
+msgstr ""
+
+#. Found when selecting a brush. It's a section that shows a few brushes that come with Pixelorama and brushes the user has imported from files (not project-specific).
+msgid "File Brushes"
+msgstr ""
+
+#. Found when selecting a brush. One of the file brushes that come with Pixelorama.
+msgid "Snow"
+msgstr ""
+
+#. Found when selecting a brush. It's a section that shows file brushes that are randomized.
+msgid "Random File Brushes"
+msgstr ""
+
+#. Found when selecting a brush. One of the random brushes that come with Pixelorama.
+msgid "Grass"
+msgstr ""
+
+#. Found when selecting a brush. One of the random brushes that come with Pixelorama.
+msgid "Star"
 msgstr ""
 
 msgid "Custom brush"
 msgstr ""
 
 msgid "Brush size:"
+msgstr ""
+
+#. Found in the pencil tool options, when you select a brush that isn't a default brush. It's a dropdown that shows rotation options for the brush.
+msgid "Rotation options"
+msgstr ""
+
+#. Found under "Rotation options" in the pencil tool options, when you select a brush that isn't a default brush. Property to flip the brush in the X or Y axis.
+msgid "Flip:"
+msgstr ""
+
+#. Found under "Rotation options" in the pencil tool options, when you select a brush that isn't a default brush. Property to rotate the brush.
+msgid "Rotate:"
 msgstr ""
 
 msgid "Overwrite color"
@@ -1986,7 +2059,8 @@ msgstr ""
 msgid "Density:"
 msgstr ""
 
-msgid "Brush color from"
+#. Found in the pencil tool options, when you select a brush that isn't a default brush. Property to change the strength of the selected color in the selected brush (0: Color from the brush itself, 100: the currently selected color).
+msgid "Brush color from:"
 msgstr ""
 
 msgid "0: Color from the brush itself, 100: the currently selected color"
@@ -2040,6 +2114,17 @@ msgstr ""
 msgid "Lighten/Darken amount"
 msgstr ""
 
+#. Found in the shading tool options. Mode to apply shading by replacing drawing's colors with the colors that are next to them in the selected palette.
+msgid "Color Replace"
+msgstr ""
+
+msgid "Please select a color from the palette."
+msgstr ""
+
+#. Found in the shading tool options, in "Color Replace" mode. Parameter that specifies how many colors to the right of the selected color in the palette should be included for the shading.
+msgid "Colors right:"
+msgstr ""
+
 msgid "Pick for:"
 msgstr ""
 
@@ -2047,6 +2132,18 @@ msgid "Left Color"
 msgstr ""
 
 msgid "Right Color"
+msgstr ""
+
+#. Found in the color picker tool options. Specifies what mode should be used for picking a color.
+msgid "Pick mode:"
+msgstr ""
+
+#. Found in the color picker tool options, as a pick mode. Picks the top color from the canvas in the selected pixel.
+msgid "Top Color"
+msgstr ""
+
+#. Found in the color picker tool options, as a pick mode. Picks the color from the currently selected layer in the selected pixel.
+msgid "Current Layer"
 msgstr ""
 
 msgid "Mode:"
@@ -2383,6 +2480,10 @@ msgstr ""
 
 #. Adjective, refers to something usual/regular, such as the normal blend mode.
 msgid "Normal"
+msgstr ""
+
+#. Found in the layer's section of the timeline, as a blend mode option. Uses the opacity of pixels in this layer to erase pixels from the layers under it.
+msgid "Erase"
 msgstr ""
 
 #. Found in the layer's section of the timeline, as a blend mode option. For more info refer to: https://en.wikipedia.org/wiki/Blend_modes
@@ -2756,6 +2857,9 @@ msgid "Magic Wand"
 msgstr ""
 
 msgid "Lasso / Free Select Tool"
+msgstr ""
+
+msgid "Select by Drawing"
 msgstr ""
 
 msgid "Move"

--- a/src/Tools/DesignTools/Shading.tscn
+++ b/src/Tools/DesignTools/Shading.tscn
@@ -83,7 +83,7 @@ layout_mode = 2
 layout_mode = 2
 max_value = 10.0
 allow_greater = true
-prefix = "Colors right"
+prefix = "Colors right:"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="ColorReplaceOptions/Settings" index="1"]
 layout_mode = 2


### PR DESCRIPTION
Adds some missing translation strings I found and fixes a few broken or updated ones.
Also added a colon to the string of a parameter in the editor, for the sake of consistency.