### PR TITLE
Change tilemap offset with the move tool

### DIFF
--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -710,15 +710,21 @@ func serialize() -> Dictionary:
 		var cell := cells[cell_coords] as Cell
 		cell_data[cell_coords] = cell.serialize()
 	dict["cell_data"] = cell_data
+	dict["offset"] = offset
 	return dict
 
 
 func deserialize(dict: Dictionary) -> void:
 	super.deserialize(dict)
-	var cell_data = dict.get("cell_data")
-	for cell_coords in cell_data:
-		var cell_data_serialized: Dictionary = cell_data[cell_coords]
-		cells[cell_coords].deserialize(cell_data_serialized)
+	var cell_data = dict.get("cell_data", [])
+	for cell_coords_str in cell_data:
+		var cell_data_serialized: Dictionary = cell_data[cell_coords_str]
+		var cell_coords := str_to_var("Vector2i" + cell_coords_str) as Vector2i
+		get_cell_at(cell_coords).deserialize(cell_data_serialized)
+	var new_offset_str = dict.get("offset", "Vector2i(0, 0)")
+	var new_offset := str_to_var("Vector2i" + new_offset_str) as Vector2i
+	if new_offset != offset:
+		change_offset(new_offset)
 
 
 func get_class_name() -> String:

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -100,12 +100,14 @@ func set_index(cell: Cell, index: int) -> void:
 	Global.canvas.queue_redraw()
 
 
+## Changes the [member offset] of the tilemap. Automatically resizes the cells and redraws the grid.
 func change_offset(new_offset: Vector2i) -> void:
 	offset = new_offset
 	_resize_cells(get_image().get_size(), false)
 	Global.canvas.grid.queue_redraw()
 
 
+## Returns the [CelTileMap.Cell] at position [param cell_coords] in tilemap space.
 func get_cell_at(cell_coords: Vector2i) -> Cell:
 	if not cells.has(cell_coords):
 		cells[cell_coords] = Cell.new()

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -117,7 +117,11 @@ func get_cell_at(cell_coords: Vector2i) -> Cell:
 ## Returns the position of a cell in the tilemap
 ## at pixel coordinates [param coords] in the cel's image.
 func get_cell_position(coords: Vector2i) -> Vector2i:
-	return (coords - offset) / tileset.tile_size
+	var offset_coords := coords - offset
+	var x_pos := float(offset_coords.x) / tileset.tile_size.x
+	var y_pos := float(offset_coords.y) / tileset.tile_size.y
+	var cell_position := Vector2i(floori(x_pos), floori(y_pos))
+	return cell_position
 
 
 ## Returns the index of a cell in the tilemap

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -578,9 +578,9 @@ func re_index_all_cells(set_invisible_to_zero := false) -> void:
 func _resize_cells(new_size: Vector2i, reset_indices := true) -> void:
 	var horizontal_cells := ceili(float(new_size.x) / tileset.tile_size.x)
 	var vertical_cells := ceili(float(new_size.y) / tileset.tile_size.y)
-	if offset.x % tileset.tile_size.x > 0:
+	if offset.x % tileset.tile_size.x != 0:
 		horizontal_cells += 1
-	if offset.y % tileset.tile_size.y > 0:
+	if offset.y % tileset.tile_size.y != 0:
 		vertical_cells += 1
 	var offset_in_tiles := Vector2i((Vector2(offset) / Vector2(tileset.tile_size)).ceil())
 	for x in horizontal_cells:

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -555,7 +555,7 @@ func update_cel_portions() -> void:
 func re_index_all_cells(set_invisible_to_zero := false) -> void:
 	for cell_coords: Vector2i in cells_dict:
 		var cell := cells_dict[cell_coords] as Cell
-		var coords := cell_coords * tileset.tile_size
+		var coords := cell_coords * tileset.tile_size + offset
 		var rect := Rect2i(coords, tileset.tile_size)
 		var image_portion := image.get_region(rect)
 		if image_portion.is_invisible():
@@ -654,7 +654,7 @@ func update_texture(undo := false) -> void:
 
 	for cell_coords: Vector2i in cells_dict:
 		var cell := cells_dict[cell_coords] as Cell
-		var coords := cell_coords * tileset.tile_size
+		var coords := cell_coords * tileset.tile_size + offset
 		var index := cell.index
 		if index >= tileset.tiles.size():
 			index = 0
@@ -676,7 +676,7 @@ func update_texture(undo := false) -> void:
 
 	for cell_coords: Vector2i in cells_dict:
 		var cell := cells_dict[cell_coords] as Cell
-		var coords := cell_coords * tileset.tile_size
+		var coords := cell_coords * tileset.tile_size + offset
 		var index := cell.index
 		if index >= tileset.tiles.size():
 			index = 0

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -128,12 +128,6 @@ func get_cell_index_at_coords(coords: Vector2i) -> int:
 	return get_cell_at(get_cell_position(coords)).index
 
 
-### Returns the index of a cell in the tilemap
-### at tilemap coordinates [param coords] in the cel's image.
-func get_cell_index_at_coords_in_tilemap_space(coords: Vector2i) -> int:
-	return get_cell_at(coords).index
-
-
 ## Returns [code]true[/code] if the tile at cell position [param cell_position]
 ## with image [param image_portion] is equal to [param tile_image].
 func _tiles_equal(cell: Cell, image_portion: Image, tile_image: Image) -> bool:

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -262,8 +262,7 @@ func apply_resizing_to_image(
 ) -> void:
 	for x in selected_cells.size():
 		for y in selected_cells[x].size():
-			var pos := Vector2i(x, y) * tileset.tile_size + selection_rect.position
-			var coords := pos - selection_rect.position
+			var coords := Vector2i(x, y) * tileset.tile_size
 			var rect := Rect2i(coords, tileset.tile_size)
 			var image_portion := target_image.get_region(rect)
 			var cell_data := Cell.new()

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -326,8 +326,9 @@ func deserialize_undo_data(dict: Dictionary, undo_redo: UndoRedo, undo: bool) ->
 			undo_redo.add_do_method(tileset.deserialize_undo_data.bind(dict.tileset, self))
 
 
-## Called when loading a new project. Loops through all [member cells]
-## and finds the amount of times each tile from the [member tileset] is being used.
+## Called when loading a new project, or when [method set_content] is called.
+## Loops through all [member cells] and finds the amount of times
+## each tile from the [member tileset] is being used.
 func find_times_used_of_tiles() -> void:
 	for cell_coords in cells:
 		var cell := cells[cell_coords] as Cell
@@ -639,9 +640,14 @@ func _deserialize_cell_data(cell_data: Dictionary, resize: bool) -> void:
 
 # Overridden Methods:
 func set_content(content, texture: ImageTexture = null) -> void:
+	for cell_coords in cells:
+		var cell := cells[cell_coords] as Cell
+		if cell.index > 0:
+			tileset.tiles[cell.index].times_used -= 1
 	super.set_content(content, texture)
 	_resize_cells(image.get_size())
 	re_index_all_cells()
+	find_times_used_of_tiles()
 
 
 func update_texture(undo := false) -> void:

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -15,11 +15,9 @@ extends PixelCel
 var tileset: TileSetCustom
 
 var cells_dict := {}  ## Dictionary of Vector2i and Cell.
-## The amount of horizontal cells.
-var horizontal_cells: int
-## The amount of vertical cells.
-var vertical_cells: int
-var offset := Vector2i.ZERO
+var vertical_cell_min := 0  ## The minimum vertical cell.
+var vertical_cell_max := 0  ## The maximum vertical cell.
+var offset := Vector2i.ZERO  ## The offset of the tilemap.
 var prev_offset := offset  ## Used for undo/redo purposes.
 ## Dictionary of [int] and [Array].
 ## The key is the index of the tile in the tileset,
@@ -589,19 +587,23 @@ func re_index_all_cells(set_invisible_to_zero := false) -> void:
 
 ## Resizes the [member cells] array based on [param new_size].
 func _resize_cells(new_size: Vector2i, reset_indices := true) -> void:
-	horizontal_cells = ceili(float(new_size.x) / tileset.tile_size.x)
-	vertical_cells = ceili(float(new_size.y) / tileset.tile_size.y)
+	var horizontal_cells := ceili(float(new_size.x) / tileset.tile_size.x)
+	var vertical_cells := ceili(float(new_size.y) / tileset.tile_size.y)
 	if offset.x % tileset.tile_size.x > 0:
 		horizontal_cells += 1
 	if offset.y % tileset.tile_size.y > 0:
 		vertical_cells += 1
 	var offset_in_tiles := Vector2i((Vector2(offset) / Vector2(tileset.tile_size)).ceil())
-	print(offset_in_tiles)
 	for x in horizontal_cells:
 		for y in vertical_cells:
 			var cell_coords := Vector2i(x, y) - offset_in_tiles
 			if not cells_dict.has(cell_coords):
 				cells_dict[cell_coords] = Cell.new()
+	for cell_coords: Vector2i in cells_dict:
+		if cell_coords.y < vertical_cell_min:
+			vertical_cell_min = cell_coords.y
+		if cell_coords.y > vertical_cell_max:
+			vertical_cell_max = cell_coords.y
 	if not is_zero_approx(fposmod(offset.x, tileset.tile_size.x)):
 		horizontal_cells += 1
 	if not is_zero_approx(fposmod(offset.y, tileset.tile_size.y)):

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -254,8 +254,8 @@ func _resize_rows(
 						resized_cells[y] = selected_cells[y_index]
 
 
-## Applies the [param selected_cells] data to [param target_image] data,
-## offset by [param selection_rect]. The target image needs to be resized first.
+## Applies the [param selected_cells] data to [param target_image] data.
+## The target image needs to be resized first.
 ## This method is used when resizing a selection and draw tiles mode is enabled.
 func apply_resizing_to_image(target_image: Image, selected_cells: Array[Array]) -> void:
 	for x in selected_cells.size():

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -131,9 +131,7 @@ func get_cell_index_at_coords(coords: Vector2i) -> int:
 ## Returns [code]true[/code] if the tile at cell position [param cell_position]
 ## with image [param image_portion] is equal to [param tile_image].
 func _tiles_equal(cell: Cell, image_portion: Image, tile_image: Image) -> bool:
-	var final_image_portion := transform_tile(
-		tile_image, cell.flip_h, cell.flip_v, cell.transpose
-	)
+	var final_image_portion := transform_tile(tile_image, cell.flip_h, cell.flip_v, cell.transpose)
 	return image_portion.get_data() == final_image_portion.get_data()
 
 
@@ -538,9 +536,7 @@ func _update_cell(cell: Cell) -> void:
 	if index >= tileset.tiles.size():
 		index = 0
 	var current_tile := tileset.tiles[index].image
-	var transformed_tile := transform_tile(
-		current_tile, cell.flip_h, cell.flip_v, cell.transpose
-	)
+	var transformed_tile := transform_tile(current_tile, cell.flip_h, cell.flip_v, cell.transpose)
 	if image_portion.get_data() != transformed_tile.get_data():
 		var tile_size := transformed_tile.get_size()
 		image.blit_rect(transformed_tile, Rect2i(Vector2i.ZERO, tile_size), coords)

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -257,9 +257,7 @@ func _resize_rows(
 ## Applies the [param selected_cells] data to [param target_image] data,
 ## offset by [param selection_rect]. The target image needs to be resized first.
 ## This method is used when resizing a selection and draw tiles mode is enabled.
-func apply_resizing_to_image(
-	target_image: Image, selected_cells: Array[Array], selection_rect: Rect2i
-) -> void:
+func apply_resizing_to_image(target_image: Image, selected_cells: Array[Array]) -> void:
 	for x in selected_cells.size():
 		for y in selected_cells[x].size():
 			var coords := Vector2i(x, y) * tileset.tile_size

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -646,7 +646,12 @@ func set_content(content, texture: ImageTexture = null) -> void:
 
 func update_texture(undo := false) -> void:
 	var tile_editing_mode := TileSetPanel.tile_editing_mode
-	if undo or _is_redo() or tile_editing_mode != TileSetPanel.TileEditingMode.MANUAL:
+	if (
+		undo
+		or _is_redo()
+		or tile_editing_mode != TileSetPanel.TileEditingMode.MANUAL
+		or Tools.is_placing_tiles()
+	):
 		super.update_texture(undo)
 		editing_images.clear()
 		return

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -102,17 +102,15 @@ func set_index(cell: Cell, index: int) -> void:
 
 
 func get_cell_at(cell_coords: Vector2i) -> Cell:
-	var cell: Cell
 	if not cells_dict.has(cell_coords):
 		cells_dict[cell_coords] = Cell.new()
-	cell = cells_dict[cell_coords]
-	return cell
+	return cells_dict[cell_coords]
 
 
 ## Returns the position of a cell in the tilemap
 ## at pixel coordinates [param coords] in the cel's image.
 func get_cell_position(coords: Vector2i) -> Vector2i:
-	return coords / tileset.tile_size
+	return (coords - offset) / tileset.tile_size
 
 
 ## Returns the index of a cell in the tilemap
@@ -350,7 +348,7 @@ func update_tilemap(
 	var tileset_size_before_update := tileset.tiles.size()
 	for cell_coords: Vector2i in cells_dict:
 		var cell := get_cell_at(cell_coords)
-		var coords := cell_coords * tileset.tile_size
+		var coords := cell_coords * tileset.tile_size + offset
 		var rect := Rect2i(coords, tileset.tile_size)
 		var image_portion := source_image.get_region(rect)
 		var index := cell.index
@@ -395,7 +393,7 @@ func update_tilemap(
 	# than the previous one.
 	for cell_coords: Vector2i in cells_dict:
 		var cell := cells_dict[cell_coords] as Cell
-		var coords := cell_coords * tileset.tile_size
+		var coords := cell_coords * tileset.tile_size + offset
 		var rect := Rect2i(coords, tileset.tile_size)
 		var image_portion := source_image.get_region(rect)
 		if not image_portion.is_invisible():
@@ -530,7 +528,7 @@ func _re_index_cells_after_index(index: int) -> void:
 ## to ensure that it is the same as its mapped tile in the [member tileset].
 func _update_cell(cell: Cell) -> void:
 	var cell_coords := cells_dict.find_key(cell) as Vector2i
-	var coords := cell_coords * tileset.tile_size
+	var coords := cell_coords * tileset.tile_size + offset
 	var rect := Rect2i(coords, tileset.tile_size)
 	var image_portion := image.get_region(rect)
 	var index := cell.index
@@ -582,9 +580,15 @@ func re_index_all_cells(set_invisible_to_zero := false) -> void:
 func _resize_cells(new_size: Vector2i, reset_indices := true) -> void:
 	horizontal_cells = ceili(float(new_size.x) / tileset.tile_size.x)
 	vertical_cells = ceili(float(new_size.y) / tileset.tile_size.y)
+	if offset.x % tileset.tile_size.x > 0:
+		horizontal_cells += 1
+	if offset.y % tileset.tile_size.y > 0:
+		vertical_cells += 1
+	var offset_in_tiles := Vector2i((Vector2(offset) / Vector2(tileset.tile_size)).ceil())
+	print(offset_in_tiles)
 	for x in horizontal_cells:
 		for y in vertical_cells:
-			var cell_coords := Vector2i(x, y)
+			var cell_coords := Vector2i(x, y) - offset_in_tiles
 			if not cells_dict.has(cell_coords):
 				cells_dict[cell_coords] = Cell.new()
 	if not is_zero_approx(fposmod(offset.x, tileset.tile_size.x)):

--- a/src/Classes/Cels/CelTileMap.gd
+++ b/src/Classes/Cels/CelTileMap.gd
@@ -20,6 +20,7 @@ var horizontal_cells: int
 ## The amount of vertical cells.
 var vertical_cells: int
 var offset := Vector2i.ZERO
+var prev_offset := offset  ## Used for undo/redo purposes.
 ## Dictionary of [int] and [Array].
 ## The key is the index of the tile in the tileset,
 ## and the value is the coords of the tilemap tile that changed first, along with
@@ -99,6 +100,12 @@ func set_index(cell: Cell, index: int) -> void:
 	cell.transpose = TileSetPanel.is_transposed
 	_update_cell(cell)
 	Global.canvas.queue_redraw()
+
+
+func change_offset(new_offset: Vector2i) -> void:
+	offset = new_offset
+	_resize_cells(get_image().get_size(), false)
+	Global.canvas.grid.queue_redraw()
 
 
 func get_cell_at(cell_coords: Vector2i) -> Cell:

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -529,9 +529,10 @@ func draw_indicator(left: bool) -> void:
 		var tilemap_cel := Global.current_project.get_current_cel() as CelTileMap
 		var tileset := tilemap_cel.tileset
 		var grid_size := tileset.tile_size
-		snapped_position = _snap_to_rectangular_grid_center(
-			snapped_position, grid_size, tilemap_cel.offset, -1
-		)
+		var offset := tilemap_cel.offset % grid_size
+		var offset_pos := snapped_position - Vector2(grid_size / 2) - Vector2(offset)
+		var grid_center := offset_pos.snapped(grid_size) + Vector2(grid_size / 2) + Vector2(offset)
+		snapped_position = grid_center.floor()
 	draw_indicator_at(snapped_position, Vector2i.ZERO, color)
 	if (
 		Global.current_project.has_selection

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -526,7 +526,7 @@ func draw_indicator(left: bool) -> void:
 	var color := Global.left_tool_color if left else Global.right_tool_color
 	var snapped_position := snap_position(_cursor)
 	if Tools.is_placing_tiles():
-		var tilemap_cel := (Global.current_project.get_current_cel() as CelTileMap)
+		var tilemap_cel := Global.current_project.get_current_cel() as CelTileMap
 		var tileset := tilemap_cel.tileset
 		var grid_size := tileset.tile_size
 		snapped_position = _snap_to_rectangular_grid_center(

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -326,7 +326,7 @@ func draw_end(pos: Vector2i) -> void:
 func draw_tile(pos: Vector2i) -> void:
 	var tile_index := 0 if _is_eraser else TileSetPanel.selected_tile_index
 	var mirrored_positions := Tools.get_mirrored_positions(pos, Global.current_project)
-	var tile_positions := PackedInt32Array()
+	var tile_positions: Array[Vector2i] = []
 	tile_positions.resize(mirrored_positions.size() + 1)
 	tile_positions[0] = get_cell_position(pos)
 	for i in mirrored_positions.size():
@@ -336,7 +336,8 @@ func draw_tile(pos: Vector2i) -> void:
 		if cel is not CelTileMap:
 			return
 		for tile_position in tile_positions:
-			(cel as CelTileMap).set_index(tile_position, tile_index)
+			var cell := (cel as CelTileMap).cells_dict[tile_position] as CelTileMap.Cell
+			(cel as CelTileMap).set_index(cell, tile_index)
 
 
 func _prepare_tool() -> void:

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -526,10 +526,11 @@ func draw_indicator(left: bool) -> void:
 	var color := Global.left_tool_color if left else Global.right_tool_color
 	var snapped_position := snap_position(_cursor)
 	if Tools.is_placing_tiles():
-		var tileset := (Global.current_project.get_current_cel() as CelTileMap).tileset
+		var tilemap_cel := (Global.current_project.get_current_cel() as CelTileMap)
+		var tileset := tilemap_cel.tileset
 		var grid_size := tileset.tile_size
 		snapped_position = _snap_to_rectangular_grid_center(
-			snapped_position, grid_size, Vector2i.ZERO, -1
+			snapped_position, grid_size, tilemap_cel.offset, -1
 		)
 	draw_indicator_at(snapped_position, Vector2i.ZERO, color)
 	if (

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -336,7 +336,7 @@ func draw_tile(pos: Vector2i) -> void:
 		if cel is not CelTileMap:
 			return
 		for tile_position in tile_positions:
-			var cell := (cel as CelTileMap).cells_dict[tile_position] as CelTileMap.Cell
+			var cell := (cel as CelTileMap).get_cell_at(tile_position)
 			(cel as CelTileMap).set_index(cell, tile_index)
 
 

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -218,7 +218,7 @@ func apply_selection(_position: Vector2i) -> void:
 func select_tilemap_cell(
 	cel: CelTileMap, cell_position: Vector2i, selection: SelectionMap, select: bool
 ) -> void:
-	var rect := Rect2i(cell_position, cel.tileset.tile_size)
+	var rect := Rect2i(cell_position + cel.offset, cel.tileset.tile_size)
 	selection.select_rect(rect, select)
 
 

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -216,9 +216,9 @@ func apply_selection(_position: Vector2i) -> void:
 
 
 func select_tilemap_cell(
-	cel: CelTileMap, cell_position: int, selection: SelectionMap, select: bool
+	cel: CelTileMap, cell_position: Vector2i, selection: SelectionMap, select: bool
 ) -> void:
-	var rect := Rect2i(cel.get_cell_coords_in_image(cell_position), cel.tileset.tile_size)
+	var rect := Rect2i(cell_position, cel.tileset.tile_size)
 	selection.select_rect(rect, select)
 
 

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -153,9 +153,11 @@ func draw_move(pos: Vector2i) -> void:
 		return
 
 	if Tools.is_placing_tiles():
-		var tileset := (Global.current_project.get_current_cel() as CelTileMap).tileset
+		var cel := Global.current_project.get_current_cel() as CelTileMap
+		var tileset := cel.tileset
 		var grid_size := tileset.tile_size
-		pos = Tools.snap_to_rectangular_grid_boundary(pos, grid_size)
+		var offset := cel.offset % grid_size
+		pos = Tools.snap_to_rectangular_grid_boundary(pos, grid_size, offset)
 	if Input.is_action_pressed("transform_snap_axis"):  # Snap to axis
 		var angle := Vector2(pos).angle_to_point(_start_pos)
 		if absf(angle) <= PI / 4 or absf(angle) >= 3 * PI / 4:

--- a/src/Tools/BaseTool.gd
+++ b/src/Tools/BaseTool.gd
@@ -79,8 +79,8 @@ func draw_end(_pos: Vector2i) -> void:
 	project.can_undo = true
 
 
-func get_cell_position(pos: Vector2i) -> int:
-	var tile_pos := 0
+func get_cell_position(pos: Vector2i) -> Vector2i:
+	var tile_pos := Vector2i.ZERO
 	if Global.current_project.get_current_cel() is not CelTileMap:
 		return tile_pos
 	var cel := Global.current_project.get_current_cel() as CelTileMap

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -188,7 +188,8 @@ func draw_end(pos: Vector2i) -> void:
 
 func draw_tile(pos: Vector2i, cel: CelTileMap) -> void:
 	var tile_position := get_cell_position(pos)
-	cel.set_index(tile_position, TileSetPanel.selected_tile_index)
+	var cell := cel.cells_dict[tile_position] as CelTileMap.Cell
+	cel.set_index(cell, TileSetPanel.selected_tile_index)
 
 
 func fill(pos: Vector2i) -> void:
@@ -210,10 +211,10 @@ func fill_in_color(pos: Vector2i) -> void:
 				continue
 			var tilemap_cel := cel as CelTileMap
 			var tile_index := tilemap_cel.get_cell_index_at_coords(pos)
-			for i in tilemap_cel.cells.size():
+			for i in tilemap_cel.cells_dict.size():
 				var cell := tilemap_cel.cells[i]
 				if cell.index == tile_index:
-					tilemap_cel.set_index(i, TileSetPanel.selected_tile_index)
+					tilemap_cel.set_index(cell, TileSetPanel.selected_tile_index)
 		return
 	var color := project.get_current_cel().get_image().get_pixelv(pos)
 	var images := _get_selected_draw_images()

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -210,7 +210,7 @@ func fill_in_color(pos: Vector2i) -> void:
 				continue
 			var tilemap_cel := cel as CelTileMap
 			var tile_index := tilemap_cel.get_cell_index_at_coords(pos)
-			for cell_coords: Vector2i in tilemap_cel.cells_dict:
+			for cell_coords: Vector2i in tilemap_cel.cells:
 				var cell := tilemap_cel.get_cell_at(cell_coords)
 				if cell.index == tile_index:
 					tilemap_cel.set_index(cell, TileSetPanel.selected_tile_index)
@@ -560,9 +560,9 @@ func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index:
 		return pos.x + 1
 	var west := pos
 	var east := pos
-	while cel.cells_dict.has(west) && cel.get_cell_at(west).index == src_index:
+	while cel.cells.has(west) && cel.get_cell_at(west).index == src_index:
 		west += Vector2i.LEFT
-	while cel.cells_dict.has(east) && cel.get_cell_at(east).index == src_index:
+	while cel.cells.has(east) && cel.get_cell_at(east).index == src_index:
 		east += Vector2i.RIGHT
 	# Make a note of the stuff we processed
 	var c := pos.y

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -187,8 +187,7 @@ func draw_end(pos: Vector2i) -> void:
 
 
 func draw_tile(pos: Vector2i, cel: CelTileMap) -> void:
-	var tile_position := get_cell_position(pos)
-	var cell := cel.get_cell_at(tile_position)
+	var cell := cel.get_cell_at(pos)
 	cel.set_index(cell, TileSetPanel.selected_tile_index)
 
 
@@ -336,11 +335,12 @@ func _flood_fill(pos: Vector2i) -> void:
 		for cel in _get_selected_draw_cels():
 			if cel is not CelTileMap:
 				continue
-			var tile_index := (cel as CelTileMap).get_cell_index_at_coords(pos)
+			var cell_pos := (cel as CelTileMap).get_cell_position(pos)
+			var tile_index := (cel as CelTileMap).get_cell_at(cell_pos).index
 			# init flood data structures
 			_allegro_flood_segments = []
 			_allegro_image_segments = []
-			_compute_segments_for_tilemap(pos, cel, tile_index)
+			_compute_segments_for_tilemap(cell_pos, cel, tile_index)
 			_color_segments_tilemap(cel)
 		return
 
@@ -560,10 +560,10 @@ func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index:
 		return pos.x + 1
 	var west := pos
 	var east := pos
-	while west.x >= 0 && cel.get_cell_index_at_coords_in_tilemap_space(west) == src_index:
+	while cel.cells_dict.has(west) && cel.get_cell_index_at_coords_in_tilemap_space(west) == src_index:
 		west += Vector2i.LEFT
 	while (
-		east.x < cel.horizontal_cells
+		cel.cells_dict.has(east)
 		&& cel.get_cell_index_at_coords_in_tilemap_space(east) == src_index
 	):
 		east += Vector2i.RIGHT
@@ -628,7 +628,7 @@ func _color_segments_tilemap(cel: CelTileMap) -> void:
 	for c in _allegro_image_segments.size():
 		var p := _allegro_image_segments[c]
 		for px in range(p.left_position, p.right_position + 1):
-			draw_tile(Vector2i(px, p.y) * cel.tileset.tile_size, cel)
+			draw_tile(Vector2i(px, p.y), cel)
 
 
 func commit_undo() -> void:

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -188,7 +188,7 @@ func draw_end(pos: Vector2i) -> void:
 
 func draw_tile(pos: Vector2i, cel: CelTileMap) -> void:
 	var tile_position := get_cell_position(pos)
-	var cell := cel.cells_dict[tile_position] as CelTileMap.Cell
+	var cell := cel.get_cell_at(tile_position)
 	cel.set_index(cell, TileSetPanel.selected_tile_index)
 
 
@@ -211,8 +211,8 @@ func fill_in_color(pos: Vector2i) -> void:
 				continue
 			var tilemap_cel := cel as CelTileMap
 			var tile_index := tilemap_cel.get_cell_index_at_coords(pos)
-			for i in tilemap_cel.cells_dict.size():
-				var cell := tilemap_cel.cells[i]
+			for cell_coords: Vector2i in tilemap_cel.cells_dict:
+				var cell := tilemap_cel.get_cell_at(cell_coords)
 				if cell.index == tile_index:
 					tilemap_cel.set_index(cell, TileSetPanel.selected_tile_index)
 		return

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -556,15 +556,15 @@ func _compute_segments_for_tilemap(pos: Vector2i, cel: CelTileMap, src_index: in
 ## Τhis method is called by [method _flood_fill] after the required data structures
 ## have been initialized.
 func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index: int) -> int:
-	if cel.get_cell_index_at_coords_in_tilemap_space(pos) != src_index:
+	if cel.get_cell_at(pos).index != src_index:
 		return pos.x + 1
 	var west := pos
 	var east := pos
-	while cel.cells_dict.has(west) && cel.get_cell_index_at_coords_in_tilemap_space(west) == src_index:
+	while cel.cells_dict.has(west) && cel.get_cell_at(west).index == src_index:
 		west += Vector2i.LEFT
 	while (
 		cel.cells_dict.has(east)
-		&& cel.get_cell_index_at_coords_in_tilemap_space(east) == src_index
+		&& cel.get_cell_at(east).index == src_index
 	):
 		east += Vector2i.RIGHT
 	# Make a note of the stuff we processed

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -524,7 +524,7 @@ func _set_pixel_pattern(image: ImageExtended, x: int, y: int, pattern_size: Vect
 
 func _compute_segments_for_tilemap(pos: Vector2i, cel: CelTileMap, src_index: int) -> void:
 	# initially allocate at least 1 segment per line of the tilemap
-	for j in cel.vertical_cells:
+	for j in range(cel.vertical_cell_min, cel.vertical_cell_max):
 		_add_new_segment(j)
 	pos /= cel.tileset.tile_size
 	# start flood algorithm
@@ -593,8 +593,8 @@ func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index:
 	# test will be performed later anyway.
 	# On the other hand, this test we described is the same `project.can_pixel_get_drawn` does if
 	# there is no selection, so we don't need branching here.
-	segment.todo_above = pos.y > 0
-	segment.todo_below = pos.y < cel.vertical_cells - 1
+	segment.todo_above = pos.y > cel.vertical_cell_min
+	segment.todo_below = pos.y < cel.vertical_cell_max
 	# this is an actual segment we should be coloring, so we add it to the results for the
 	# current image
 	if segment.right_position >= segment.left_position:

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -562,10 +562,7 @@ func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index:
 	var east := pos
 	while cel.cells_dict.has(west) && cel.get_cell_at(west).index == src_index:
 		west += Vector2i.LEFT
-	while (
-		cel.cells_dict.has(east)
-		&& cel.get_cell_at(east).index == src_index
-	):
+	while cel.cells_dict.has(east) && cel.get_cell_at(east).index == src_index:
 		east += Vector2i.RIGHT
 	# Make a note of the stuff we processed
 	var c := pos.y

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -50,7 +50,7 @@ func apply_selection(pos: Vector2i) -> void:
 				continue
 			var tilemap_cel := cel as CelTileMap
 			var tile_index := tilemap_cel.get_cell_index_at_coords(pos)
-			for cell_coords: Vector2i in tilemap_cel.cells_dict:
+			for cell_coords: Vector2i in tilemap_cel.cells:
 				var cell := tilemap_cel.get_cell_at(cell_coords)
 				var p := cell_coords * tilemap_cel.tileset.tile_size
 				if cell.index == tile_index:

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -50,16 +50,16 @@ func apply_selection(pos: Vector2i) -> void:
 				continue
 			var tilemap_cel := cel as CelTileMap
 			var tile_index := tilemap_cel.get_cell_index_at_coords(pos)
-			for i in tilemap_cel.cells.size():
-				var cell := tilemap_cel.cells[i]
+			for cell_coords: Vector2i in tilemap_cel.cells_dict:
+				var cell := tilemap_cel.get_cell_at(cell_coords)
+				var p := cell_coords * tilemap_cel.tileset.tile_size
 				if cell.index == tile_index:
 					if _intersect:
-						var p := (cel as CelTileMap).get_cell_coords_in_image(i)
 						select_tilemap_cell(
-							cel, i, project.selection_map, prev_selection_map.is_pixel_selected(p)
+							cel, p, project.selection_map, prev_selection_map.is_pixel_selected(p)
 						)
 					else:
-						select_tilemap_cell(cel, i, project.selection_map, !_subtract)
+						select_tilemap_cell(cel, p, project.selection_map, !_subtract)
 	else:
 		var cel_image := Image.new()
 		cel_image.copy_from(_get_draw_image())

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -134,10 +134,11 @@ func set_ellipse(selection_map: SelectionMap, pos: Vector2i) -> void:
 # where the shape will be drawn and what is its size
 func _get_result_rect(origin: Vector2i, dest: Vector2i) -> Rect2i:
 	if Tools.is_placing_tiles():
-		var tileset := (Global.current_project.get_current_cel() as CelTileMap).tileset
+		var cel := Global.current_project.get_current_cel() as CelTileMap
+		var tileset := cel.tileset
 		var grid_size := tileset.tile_size
-		origin = Tools.snap_to_rectangular_grid_boundary(origin, grid_size)
-		dest = Tools.snap_to_rectangular_grid_boundary(dest, grid_size)
+		origin = Tools.snap_to_rectangular_grid_boundary(origin, grid_size, cel.offset)
+		dest = Tools.snap_to_rectangular_grid_boundary(dest, grid_size, cel.offset)
 	var rect := Rect2i()
 	# Center the rect on the mouse
 	if _expand_from_center:

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -137,8 +137,9 @@ func _get_result_rect(origin: Vector2i, dest: Vector2i) -> Rect2i:
 		var cel := Global.current_project.get_current_cel() as CelTileMap
 		var tileset := cel.tileset
 		var grid_size := tileset.tile_size
-		origin = Tools.snap_to_rectangular_grid_boundary(origin, grid_size, cel.offset)
-		dest = Tools.snap_to_rectangular_grid_boundary(dest, grid_size, cel.offset)
+		var offset := cel.offset % grid_size
+		origin = Tools.snap_to_rectangular_grid_boundary(origin, grid_size, offset)
+		dest = Tools.snap_to_rectangular_grid_boundary(dest, grid_size, offset)
 	var rect := Rect2i()
 	# Center the rect on the mouse
 	if _expand_from_center:

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -115,7 +115,8 @@ func lasso_selection(
 func select_pixel(point: Vector2i, project: Project, select: bool) -> void:
 	if Tools.is_placing_tiles():
 		var tilemap := project.get_current_cel() as CelTileMap
-		select_tilemap_cell(tilemap, point, project.selection_map, select)
+		var cell_position := tilemap.get_cell_position(point) * tilemap.tileset.tile_size
+		select_tilemap_cell(tilemap, cell_position, project.selection_map, select)
 	project.selection_map.select_pixel(point, select)
 
 

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -115,8 +115,7 @@ func lasso_selection(
 func select_pixel(point: Vector2i, project: Project, select: bool) -> void:
 	if Tools.is_placing_tiles():
 		var tilemap := project.get_current_cel() as CelTileMap
-		var cell_position := tilemap.get_cell_position(point)
-		select_tilemap_cell(tilemap, cell_position, project.selection_map, select)
+		select_tilemap_cell(tilemap, point, project.selection_map, select)
 	project.selection_map.select_pixel(point, select)
 
 

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -252,15 +252,15 @@ func _compute_segments_for_tilemap(pos: Vector2i, cel: CelTileMap, src_index: in
 ## Τhis method is called by [method _flood_fill] after the required data structures
 ## have been initialized.
 func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index: int) -> int:
-	if cel.get_cell_index_at_coords_in_tilemap_space(pos) != src_index:
+	if cel.get_cell_at(pos).index != src_index:
 		return pos.x + 1
 	var west := pos
 	var east := pos
-	while cel.cells_dict.has(west) && cel.get_cell_index_at_coords_in_tilemap_space(west) == src_index:
+	while cel.cells_dict.has(west) && cel.get_cell_at(west).index == src_index:
 		west += Vector2i.LEFT
 	while (
 		cel.cells_dict.has(east)
-		&& cel.get_cell_index_at_coords_in_tilemap_space(east) == src_index
+		&& cel.get_cell_at(east).index == src_index
 	):
 		east += Vector2i.RIGHT
 	# Make a note of the stuff we processed

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -256,9 +256,9 @@ func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index:
 		return pos.x + 1
 	var west := pos
 	var east := pos
-	while cel.cells_dict.has(west) && cel.get_cell_at(west).index == src_index:
+	while cel.cells.has(west) && cel.get_cell_at(west).index == src_index:
 		west += Vector2i.LEFT
-	while cel.cells_dict.has(east) && cel.get_cell_at(east).index == src_index:
+	while cel.cells.has(east) && cel.get_cell_at(east).index == src_index:
 		east += Vector2i.RIGHT
 	# Make a note of the stuff we processed
 	var c := pos.y

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -221,7 +221,7 @@ func _set_bit(p: Vector2i, selection_map: SelectionMap, prev_selection_map: Sele
 
 func _compute_segments_for_tilemap(pos: Vector2i, cel: CelTileMap, src_index: int) -> void:
 	# initially allocate at least 1 segment per line of the tilemap
-	for j in cel.vertical_cells:
+	for j in range(cel.vertical_cell_min, cel.vertical_cell_max):
 		_add_new_segment(j)
 	# start flood algorithm
 	_flood_line_around_point_tilemap(pos, cel, src_index)
@@ -289,8 +289,8 @@ func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index:
 	# test will be performed later anyway.
 	# On the other hand, this test we described is the same `project.can_pixel_get_drawn` does if
 	# there is no selection, so we don't need branching here.
-	segment.todo_above = pos.y > 0
-	segment.todo_below = pos.y < cel.vertical_cells - 1
+	segment.todo_above = pos.y > cel.vertical_cell_min
+	segment.todo_below = pos.y < cel.vertical_cell_max
 	# this is an actual segment we should be coloring, so we add it to the results for the
 	# current image
 	if segment.right_position >= segment.left_position:

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -332,14 +332,9 @@ func _select_segments_tilemap(project: Project, previous_selection_map: Selectio
 func _set_bit_rect(p: Vector2i, project: Project, prev_selection_map: SelectionMap) -> void:
 	var selection_map := project.selection_map
 	var tilemap := project.get_current_cel() as CelTileMap
-	var cell_position := tilemap.get_cell_position_in_tilemap_space(p)
 	if _intersect:
-		var image_coords := tilemap.get_cell_coords_in_image(cell_position)
 		select_tilemap_cell(
-			tilemap,
-			cell_position,
-			project.selection_map,
-			prev_selection_map.is_pixel_selected(image_coords)
+			tilemap, p, project.selection_map, prev_selection_map.is_pixel_selected(p)
 		)
 	else:
-		select_tilemap_cell(tilemap, cell_position, project.selection_map, !_subtract)
+		select_tilemap_cell(tilemap, p, project.selection_map, !_subtract)

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -258,10 +258,7 @@ func _flood_line_around_point_tilemap(pos: Vector2i, cel: CelTileMap, src_index:
 	var east := pos
 	while cel.cells_dict.has(west) && cel.get_cell_at(west).index == src_index:
 		west += Vector2i.LEFT
-	while (
-		cel.cells_dict.has(east)
-		&& cel.get_cell_at(east).index == src_index
-	):
+	while cel.cells_dict.has(east) && cel.get_cell_at(east).index == src_index:
 		east += Vector2i.RIGHT
 	# Make a note of the stuff we processed
 	var c := pos.y

--- a/src/Tools/SelectionTools/PaintSelect.gd
+++ b/src/Tools/SelectionTools/PaintSelect.gd
@@ -130,7 +130,8 @@ func paint_selection(
 func select_pixel(point: Vector2i, project: Project, select: bool) -> void:
 	if Tools.is_placing_tiles():
 		var tilemap := project.get_current_cel() as CelTileMap
-		select_tilemap_cell(tilemap, point, project.selection_map, select)
+		var cell_position := tilemap.get_cell_position(point) * tilemap.tileset.tile_size
+		select_tilemap_cell(tilemap, cell_position, project.selection_map, select)
 	project.selection_map.select_pixel(point, select)
 
 

--- a/src/Tools/SelectionTools/PaintSelect.gd
+++ b/src/Tools/SelectionTools/PaintSelect.gd
@@ -130,8 +130,7 @@ func paint_selection(
 func select_pixel(point: Vector2i, project: Project, select: bool) -> void:
 	if Tools.is_placing_tiles():
 		var tilemap := project.get_current_cel() as CelTileMap
-		var cell_position := tilemap.get_cell_position(point)
-		select_tilemap_cell(tilemap, cell_position, project.selection_map, select)
+		select_tilemap_cell(tilemap, point, project.selection_map, select)
 	project.selection_map.select_pixel(point, select)
 
 

--- a/src/Tools/SelectionTools/PolygonSelect.gd
+++ b/src/Tools/SelectionTools/PolygonSelect.gd
@@ -158,7 +158,8 @@ func lasso_selection(
 func select_pixel(point: Vector2i, project: Project, select: bool) -> void:
 	if Tools.is_placing_tiles():
 		var tilemap := project.get_current_cel() as CelTileMap
-		select_tilemap_cell(tilemap, point, project.selection_map, select)
+		var cell_position := tilemap.get_cell_position(point) * tilemap.tileset.tile_size
+		select_tilemap_cell(tilemap, cell_position, project.selection_map, select)
 	project.selection_map.select_pixel(point, select)
 
 

--- a/src/Tools/SelectionTools/PolygonSelect.gd
+++ b/src/Tools/SelectionTools/PolygonSelect.gd
@@ -158,8 +158,7 @@ func lasso_selection(
 func select_pixel(point: Vector2i, project: Project, select: bool) -> void:
 	if Tools.is_placing_tiles():
 		var tilemap := project.get_current_cel() as CelTileMap
-		var cell_position := tilemap.get_cell_position(point)
-		select_tilemap_cell(tilemap, cell_position, project.selection_map, select)
+		select_tilemap_cell(tilemap, point, project.selection_map, select)
 	project.selection_map.select_pixel(point, select)
 
 

--- a/src/Tools/SelectionTools/RectSelect.gd
+++ b/src/Tools/SelectionTools/RectSelect.gd
@@ -102,10 +102,11 @@ func apply_selection(pos: Vector2i) -> void:
 ## where the shape will be drawn and what is its size
 func _get_result_rect(origin: Vector2i, dest: Vector2i) -> Rect2i:
 	if Tools.is_placing_tiles():
-		var tileset := (Global.current_project.get_current_cel() as CelTileMap).tileset
+		var cel := Global.current_project.get_current_cel() as CelTileMap
+		var tileset := cel.tileset
 		var grid_size := tileset.tile_size
-		origin = Tools.snap_to_rectangular_grid_boundary(origin, grid_size)
-		dest = Tools.snap_to_rectangular_grid_boundary(dest, grid_size)
+		origin = Tools.snap_to_rectangular_grid_boundary(origin, grid_size, cel.offset)
+		dest = Tools.snap_to_rectangular_grid_boundary(dest, grid_size, cel.offset)
 	var rect := Rect2i()
 
 	# Center the rect on the mouse

--- a/src/Tools/SelectionTools/RectSelect.gd
+++ b/src/Tools/SelectionTools/RectSelect.gd
@@ -105,8 +105,9 @@ func _get_result_rect(origin: Vector2i, dest: Vector2i) -> Rect2i:
 		var cel := Global.current_project.get_current_cel() as CelTileMap
 		var tileset := cel.tileset
 		var grid_size := tileset.tile_size
-		origin = Tools.snap_to_rectangular_grid_boundary(origin, grid_size, cel.offset)
-		dest = Tools.snap_to_rectangular_grid_boundary(dest, grid_size, cel.offset)
+		var offset := cel.offset % grid_size
+		origin = Tools.snap_to_rectangular_grid_boundary(origin, grid_size, offset)
+		dest = Tools.snap_to_rectangular_grid_boundary(dest, grid_size, offset)
 	var rect := Rect2i()
 
 	# Center the rect on the mouse

--- a/src/UI/Canvas/Grid.gd
+++ b/src/UI/Canvas/Grid.gd
@@ -39,7 +39,7 @@ func _draw_cartesian_grid(grid_index: int, target_rect: Rect2i) -> void:
 	var cel := Global.current_project.get_current_cel()
 	if cel is CelTileMap and grid_index == 0:
 		grid_size = (cel as CelTileMap).tileset.tile_size
-		grid_offset = Vector2i.ZERO
+		grid_offset = (cel as CelTileMap).offset
 	var grid_multiline_points := PackedVector2Array()
 
 	var x: float = (

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -553,7 +553,7 @@ func transform_content_start() -> void:
 	original_big_bounding_rectangle = big_bounding_rectangle
 	original_offset = project.selection_offset
 	var current_cel := project.get_current_cel()
-	if current_cel is CelTileMap:
+	if current_cel is CelTileMap and Tools.is_placing_tiles():
 		original_selected_tilemap_cells = (current_cel as CelTileMap).get_selected_cells(
 			project.selection_map, big_bounding_rectangle
 		)

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -338,7 +338,8 @@ func _gizmo_resize() -> void:
 	var mouse_pos := image_current_pixel
 	if Tools.is_placing_tiles():
 		var tilemap := Global.current_project.get_current_cel() as CelTileMap
-		mouse_pos = mouse_pos.snapped(tilemap.tileset.tile_size)
+		var offset := tilemap.offset % tilemap.tileset.tile_size
+		mouse_pos = mouse_pos.snapped(tilemap.tileset.tile_size) + Vector2(offset)
 	if Input.is_action_pressed("shape_center"):
 		# Code inspired from https://github.com/GDQuest/godot-open-rpg
 		if dir.x != 0 and dir.y != 0:  # Border gizmos

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -419,9 +419,7 @@ func resize_selection() -> void:
 					original_selected_tilemap_cells, horizontal_size, vertical_size
 				)
 				preview_image.crop(size.x, size.y)
-				tilemap.apply_resizing_to_image(
-					preview_image, selected_cells, big_bounding_rectangle
-				)
+				tilemap.apply_resizing_to_image(preview_image, selected_cells)
 		else:
 			var params := {"transformation_matrix": transformation_matrix, "pivot": content_pivot}
 			preview_image.resize(size.x, size.y, Image.INTERPOLATE_NEAREST)
@@ -586,7 +584,7 @@ func transform_content_confirm() -> void:
 					original_selected_tilemap_cells, horizontal_size, vertical_size
 				)
 				src.crop(preview_image.get_width(), preview_image.get_height())
-				tilemap.apply_resizing_to_image(src, selected_cells, big_bounding_rectangle)
+				tilemap.apply_resizing_to_image(src, selected_cells)
 			else:
 				var transformation_matrix := Transform2D(angle, Vector2.ZERO)
 				var params := {

--- a/src/UI/Canvas/TileModeIndices.gd
+++ b/src/UI/Canvas/TileModeIndices.gd
@@ -13,14 +13,15 @@ func _draw() -> void:
 	draw_set_transform(position, rotation, Vector2(0.5, 0.5))
 	if current_cel is CelTileMap and Input.is_action_pressed("ctrl"):
 		var tilemap_cel := current_cel as CelTileMap
-		for i in tilemap_cel.cells.size():
-			var tile_data := tilemap_cel.cells[i]
-			if tile_data.index == 0:
-				continue
-			var pos := tilemap_cel.get_cell_coords_in_image(i)
-			pos.y += tilemap_cel.tileset.tile_size.y
-			var text := tile_data.to_string()
-			draw_multiline_string(
-				Themes.get_font(), pos * 2, text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE
+		var tile_size := tilemap_cel.tileset.tile_size
+		var font := Themes.get_font()
+		for cell_coords: Vector2i in tilemap_cel.cells_dict:
+			var cell := tilemap_cel.cells_dict[cell_coords] as CelTileMap.Cell
+			var text := cell.to_string()
+			var pos := cell_coords * tilemap_cel.tileset.tile_size
+			#var pos := tilemap_cel.get_cell_coords_in_image(i) - Vector2i(Vector2(tilemap_cel.offset).posmodv(tilemap_cel.tileset.tile_size))
+			pos.y += tile_size.y - font.get_ascent(FONT_SIZE * 0.5) * 0.5
+			draw_string(
+				font, pos * 2, text, HORIZONTAL_ALIGNMENT_CENTER, tile_size.x * 2, FONT_SIZE
 			)
 	draw_set_transform(position, rotation, scale)

--- a/src/UI/Canvas/TileModeIndices.gd
+++ b/src/UI/Canvas/TileModeIndices.gd
@@ -15,7 +15,7 @@ func _draw() -> void:
 		var tilemap_cel := current_cel as CelTileMap
 		var tile_size := tilemap_cel.tileset.tile_size
 		var font := Themes.get_font()
-		for cell_coords: Vector2i in tilemap_cel.cells_dict:
+		for cell_coords: Vector2i in tilemap_cel.cells:
 			var cell := tilemap_cel.get_cell_at(cell_coords)
 			if cell.index == 0:
 				continue

--- a/src/UI/Canvas/TileModeIndices.gd
+++ b/src/UI/Canvas/TileModeIndices.gd
@@ -17,6 +17,8 @@ func _draw() -> void:
 		var font := Themes.get_font()
 		for cell_coords: Vector2i in tilemap_cel.cells_dict:
 			var cell := tilemap_cel.get_cell_at(cell_coords)
+			if cell.index == 0:
+				continue
 			var text := cell.to_string()
 			var pos := cell_coords * tilemap_cel.tileset.tile_size
 			pos.y += tile_size.y - font.get_ascent(FONT_SIZE * 0.5) * 0.5

--- a/src/UI/Canvas/TileModeIndices.gd
+++ b/src/UI/Canvas/TileModeIndices.gd
@@ -16,10 +16,9 @@ func _draw() -> void:
 		var tile_size := tilemap_cel.tileset.tile_size
 		var font := Themes.get_font()
 		for cell_coords: Vector2i in tilemap_cel.cells_dict:
-			var cell := tilemap_cel.cells_dict[cell_coords] as CelTileMap.Cell
+			var cell := tilemap_cel.get_cell_at(cell_coords)
 			var text := cell.to_string()
 			var pos := cell_coords * tilemap_cel.tileset.tile_size
-			#var pos := tilemap_cel.get_cell_coords_in_image(i) - Vector2i(Vector2(tilemap_cel.offset).posmodv(tilemap_cel.tileset.tile_size))
 			pos.y += tile_size.y - font.get_ascent(FONT_SIZE * 0.5) * 0.5
 			draw_string(
 				font, pos * 2, text, HORIZONTAL_ALIGNMENT_CENTER, tile_size.x * 2, FONT_SIZE

--- a/src/UI/Canvas/TileModeIndices.gd
+++ b/src/UI/Canvas/TileModeIndices.gd
@@ -20,7 +20,7 @@ func _draw() -> void:
 			if cell.index == 0:
 				continue
 			var text := cell.to_string()
-			var pos := cell_coords * tilemap_cel.tileset.tile_size
+			var pos := cell_coords * tilemap_cel.tileset.tile_size + tilemap_cel.offset
 			pos.y += tile_size.y - font.get_ascent(FONT_SIZE * 0.5) * 0.5
 			draw_string(
 				font, pos * 2, text, HORIZONTAL_ALIGNMENT_CENTER, tile_size.x * 2, FONT_SIZE

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -486,6 +486,7 @@ func copy_frames(
 					selected_id = src_cel.selected.id
 			elif src_cel is CelTileMap:
 				new_cel = CelTileMap.new(src_cel.tileset)
+				new_cel.offset = src_cel.offset
 			else:
 				new_cel = src_cel.get_script().new()
 
@@ -939,6 +940,7 @@ func _on_CloneLayer_pressed() -> void:
 				)
 			elif src_cel is CelTileMap:
 				new_cel = CelTileMap.new(src_cel.tileset)
+				new_cel.offset = src_cel.offset
 			else:
 				new_cel = src_cel.get_script().new()
 


### PR DESCRIPTION
Changing the offset of the tilemap with the move tool when draw tiles mode is active is now possible. I rewrote the tilemap cels to store their cell data in a dictionary instead of an array, allowing for coordinates that are outside the canvas boundaries, including negative coordinates. Right now indices for cells outside of the canvas are not being stored, but this rewrite should make it easier if we want to do this later.

https://github.com/user-attachments/assets/2f8de1af-de65-418d-9929-1135efd46db4

Bugs fixed:
-  Τhe tile preview was sometimes in the wrong place when placing tiles.
- Cloning frames/layers and then editing the cloned tilemap cels no longer breaks the tileset.
