### PR TITLE
[bugfix + Gizmo] Improve the look of 3d movement gizmos

### DIFF
--- a/src/UI/Canvas/Gizmos3D.gd
+++ b/src/UI/Canvas/Gizmos3D.gd
@@ -114,9 +114,10 @@ func get_points(camera: Camera3D, object3d: Cel3DObject) -> void:
 		var back := object3d.position + object3d.transform.basis.z.normalized()
 		var front := object3d.position - object3d.transform.basis.z.normalized()
 
-		right_axis_width = lerpf(0.5, 0.1, (1 + (Vector3.RIGHT - right).z) / 2.0)
-		up_axis_width = lerpf(0.5, 0.1, (1 + (Vector3.RIGHT - up).z) / 2.0)
-		back_axis_width = lerpf(0.5, 0.1, (1 + (Vector3.RIGHT - back).z) / 2.0)
+		var camera_right = camera.transform.basis.x.normalized()
+		right_axis_width = lerpf(0.5, 0.1, (1 + (camera_right - right).z) / 2.0)
+		up_axis_width = lerpf(0.5, 0.1, (1 + (camera_right - up).z) / 2.0)
+		back_axis_width = lerpf(0.5, 0.1, (1 + (camera_right - back).z) / 2.0)
 
 		var proj_right := object3d.camera.unproject_position(right)
 		var proj_up := object3d.camera.unproject_position(up)


### PR DESCRIPTION
- Fix a bug where axis sometimes got inverted when scaling (fixed by using `normalized()`)

https://github.com/user-attachments/assets/df462902-f7d4-4efc-acb8-932fa183c4bd

- The axis lines have different width depending on their position, this adds a little bit of perspective/depth to the gizmos
- The axis lines stay visible when rotation is active (this is more pleasing to the eye, plus the user can easily get an intuitive understanding of what's going on for symmetrical shapes like cylinder, sphere, etc)
- The X, Y, Z text was too large so `CHAR_SCALE` was decreased from 16 to 10 (This is not shown in the picture)

![Screenshot from 2025-03-09 23-10-45](https://github.com/user-attachments/assets/57e6b263-a6a5-48bf-a762-f542ba59c8ef)
