### PR TITLE
fix `theme_font_index` setter not being triggered

### DIFF
--- a/src/Autoload/Themes.gd
+++ b/src/Autoload/Themes.gd
@@ -43,6 +43,7 @@ func remove_theme(theme: Theme) -> void:
 func change_theme(id: int) -> void:
 	theme_index = id
 	var theme := themes[id]
+	Global.theme_font_index = Global.theme_font_index  # Trigger the setter
 	if theme.default_font != Global.theme_font:
 		theme.default_font = Global.theme_font
 	theme.default_font_size = Global.font_size


### PR DESCRIPTION
if the theme was changed without the `theme_font_index` key present in `config.ini`. The wrong font would get chosen (The very first one in the list `Open Sans SemiBold` instead of `Roboto`, which for me is present in the 2nd position.)

i managed to narrow it down to the setter not being triggered on startup if it's entry is not present in config.ini (i assume the code in setter does some initialization which is required for fonts to change properly with theme)

https://github.com/user-attachments/assets/16a50850-536e-41d9-b286-192411381884

Due to the first font being *troublesome*, when it is selected this happens:
![image](https://github.com/user-attachments/assets/e215e9e7-e3b6-4471-9416-dbc57e7cff41)
