### PR TITLE
Make pixel grid redraw on visibility toggle

### DIFF
--- a/src/UI/TopMenuContainer/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer/TopMenuContainer.gd
@@ -990,6 +990,8 @@ func _toggle_show_grid() -> void:
 func _toggle_show_pixel_grid() -> void:
 	Global.draw_pixel_grid = !Global.draw_pixel_grid
 	view_menu.set_item_checked(Global.ViewMenu.SHOW_PIXEL_GRID, Global.draw_pixel_grid)
+	if Global.canvas.pixel_grid:
+		Global.canvas.pixel_grid.queue_redraw()
 
 
 func _toggle_show_pixel_indices() -> void:


### PR DESCRIPTION
When the (non-pixel) grid is toggled, it immediately updates to show the change.
Before, when the pixel grid was toggled, it would remain visible/hidden until updated by zooming. Add a queue_redraw call to fix.