### PR TITLE
New selection transformation system

### DIFF
--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -331,9 +331,12 @@ func get_transformed_bounds(image_size: Vector2i, transform: Transform2D) -> Rec
 	return Rect2(min_corner, max_corner - min_corner)
 
 
-func transform_image_with_transform2d(original_image: Image, transform_matrix: Transform2D, pivot: Vector2) -> void:
+func transform_image_with_transform2d(
+	original_image: Image, transform_matrix: Transform2D, pivot: Vector2
+) -> void:
 	# Compute the transformation with pivot support
-	var move_to_origin := Transform2D(Vector2(1, 0), Vector2(0, 1), -pivot)  # translate pivot to origin
+	# translate pivot to origin
+	var move_to_origin := Transform2D(Vector2(1, 0), Vector2(0, 1), -pivot)
 	var move_back := Transform2D(Vector2(1, 0), Vector2(0, 1), pivot)  # move pivot back
 	var full_transform := move_back * transform_matrix * move_to_origin
 
@@ -361,7 +364,9 @@ func transform_image_with_transform2d(original_image: Image, transform_matrix: T
 
 	# Draw the texture
 	var texture := RenderingServer.texture_2d_create(original_image)
-	RenderingServer.canvas_item_add_texture_rect(ci_rid, Rect2(Vector2.ZERO, original_image.get_size()), texture)
+	RenderingServer.canvas_item_add_texture_rect(
+		ci_rid, Rect2(Vector2.ZERO, original_image.get_size()), texture
+	)
 
 	# Render once
 	RenderingServer.viewport_set_update_mode(vp, RenderingServer.VIEWPORT_UPDATE_ONCE)
@@ -385,10 +390,7 @@ func transform_image_with_transform2d(original_image: Image, transform_matrix: T
 
 
 func transform_rectangle(
-	rect: Rect2,
-	matrix: Transform2D,
-	pivot := rect.size / 2,
-	anchor := Vector2(0.5, 0.5)  # normalized: (0,0)=top-left, (1,1)=bottom-right
+	rect: Rect2, matrix: Transform2D, pivot := rect.size / 2, anchor := Vector2(0.5, 0.5)
 ) -> Rect2:
 	var offset_rect := rect
 	var anchor_point := rect.position + rect.size * anchor

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -378,7 +378,7 @@ func transform_image_with_transform2d(original_image: Image, transform_matrix: T
 	if not is_instance_valid(viewport_texture):
 		return
 	viewport_texture.convert(original_image.get_format())
-	original_image.copy_from(viewport_texture)
+	original_image.copy_from(viewport_texture.get_region(viewport_texture.get_used_rect()))
 
 	if original_image is ImageExtended:
 		original_image.convert_rgb_to_indexed()

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -282,7 +282,7 @@ func transform_image_with_algorithm(
 		new_image_size = image.get_size()
 	var pivot: Vector2 = params.get("pivot", image.get_size() / 2)
 	if type_is_shader(algorithm):
-		transformation_matrix = TransformationHandles.transform_remove_scale(transformation_matrix)
+		transformation_matrix = transform_remove_scale(transformation_matrix)
 		params["transformation_matrix"] = transformation_matrix
 		params["pivot"] = pivot / Vector2(image.get_size())
 		var shader := rotxel_shader
@@ -306,25 +306,6 @@ func transform_image_with_algorithm(
 				fake_rotsprite(image, angle, pivot)
 	if image is ImageExtended:
 		image.convert_rgb_to_indexed()
-
-
-func type_is_shader(algorithm: RotationAlgorithm) -> bool:
-	return algorithm <= RotationAlgorithm.NNS
-
-
-func get_transformed_bounds(image_size: Vector2i, transform: Transform2D) -> Rect2:
-	var corners: Array[Vector2] = [
-		transform * (Vector2(0, 0)),
-		transform * (Vector2(image_size.x, 0)),
-		transform * (Vector2(0, image_size.y)),
-		transform * (Vector2(image_size.x, image_size.y))
-	]
-	var min_corner := corners[0]
-	var max_corner := corners[0]
-	for corner in corners:
-		min_corner = min_corner.min(corner)
-		max_corner = max_corner.max(corner)
-	return Rect2(min_corner, max_corner - min_corner)
 
 
 func transform_image_with_viewport(
@@ -401,6 +382,31 @@ func transform_image_with_viewport(
 
 	if original_image is ImageExtended:
 		original_image.convert_rgb_to_indexed()
+
+
+func type_is_shader(algorithm: RotationAlgorithm) -> bool:
+	return algorithm <= RotationAlgorithm.NNS
+
+
+func get_transformed_bounds(image_size: Vector2i, transform: Transform2D) -> Rect2:
+	var corners: Array[Vector2] = [
+		transform * (Vector2(0, 0)),
+		transform * (Vector2(image_size.x, 0)),
+		transform * (Vector2(0, image_size.y)),
+		transform * (Vector2(image_size.x, image_size.y))
+	]
+	var min_corner := corners[0]
+	var max_corner := corners[0]
+	for corner in corners:
+		min_corner = min_corner.min(corner)
+		max_corner = max_corner.max(corner)
+	return Rect2(min_corner, max_corner - min_corner)
+
+
+func transform_remove_scale(t: Transform2D) -> Transform2D:
+	var x := t.x.normalized()
+	var y := t.y.normalized()
+	return Transform2D(x, y, Vector2.ZERO)
 
 
 func rotxel(sprite: Image, angle: float, pivot: Vector2) -> void:

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -823,7 +823,7 @@ func crop_to_selection() -> void:
 	Global.canvas.selection.transform_content_confirm()
 	var redo_data := {}
 	var undo_data := {}
-	var rect: Rect2i = Global.canvas.selection.big_bounding_rectangle
+	var rect := Global.current_project.selection_map.get_selection_rect(Global.current_project)
 	# Loop through all the cels to crop them
 	for cel in Global.current_project.get_all_pixel_cels():
 		var cel_image := cel.get_image()

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -390,19 +390,6 @@ func transform_image_with_transform2d(
 		original_image.convert_rgb_to_indexed()
 
 
-func transform_rectangle(
-	rect: Rect2, matrix: Transform2D, pivot := rect.size / 2, anchor := Vector2(0.5, 0.5)
-) -> Rect2:
-	var offset_rect := rect
-	var anchor_point := rect.position + rect.size * anchor
-	var offset := anchor_point - pivot
-
-	offset_rect.position -= offset
-	offset_rect = offset_rect * matrix
-	offset_rect.position = pivot + (offset_rect.position - pivot) + offset
-	return offset_rect
-
-
 func rotxel(sprite: Image, angle: float, pivot: Vector2) -> void:
 	if is_zero_approx(angle) or is_equal_approx(angle, TAU):
 		return

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -332,7 +332,7 @@ func get_transformed_bounds(image_size: Vector2i, transform: Transform2D) -> Rec
 
 
 func transform_image_with_transform2d(
-	original_image: Image, transform_matrix: Transform2D, pivot: Vector2
+	original_image: Image, transform_matrix: Transform2D, pivot: Vector2, used_rect := Rect2i()
 ) -> void:
 	# Compute the transformation with pivot support
 	# translate pivot to origin
@@ -383,7 +383,8 @@ func transform_image_with_transform2d(
 	if not is_instance_valid(viewport_texture):
 		return
 	viewport_texture.convert(original_image.get_format())
-	original_image.copy_from(viewport_texture.get_region(viewport_texture.get_used_rect()))
+	var region := viewport_texture.get_used_rect() if used_rect == Rect2i() else used_rect
+	original_image.copy_from(viewport_texture.get_region(region))
 
 	if original_image is ImageExtended:
 		original_image.convert_rgb_to_indexed()

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -331,7 +331,7 @@ func get_transformed_bounds(image_size: Vector2i, transform: Transform2D) -> Rec
 	return Rect2(min_corner, max_corner - min_corner)
 
 
-func transform_image_with_transform2d(
+func transform_image_with_viewport(
 	original_image: Image, transform_matrix: Transform2D, pivot: Vector2, used_rect := Rect2i()
 ) -> void:
 	# Compute the transformation with pivot support

--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -384,12 +384,19 @@ func transform_image_with_transform2d(original_image: Image, transform_matrix: T
 		original_image.convert_rgb_to_indexed()
 
 
-func transform_rectangle(rect: Rect2, matrix: Transform2D, pivot := rect.size / 2) -> Rect2:
+func transform_rectangle(
+	rect: Rect2,
+	matrix: Transform2D,
+	pivot := rect.size / 2,
+	anchor := Vector2(0.5, 0.5)  # normalized: (0,0)=top-left, (1,1)=bottom-right
+) -> Rect2:
 	var offset_rect := rect
-	var offset_pos := -pivot
-	offset_rect.position = offset_pos
+	var anchor_point := rect.position + rect.size * anchor
+	var offset := anchor_point - pivot
+
+	offset_rect.position -= offset
 	offset_rect = offset_rect * matrix
-	offset_rect.position = rect.position + offset_rect.position - offset_pos
+	offset_rect.position = pivot + (offset_rect.position - pivot) + offset
 	return offset_rect
 
 

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -293,7 +293,9 @@ func process_animation(project := Global.current_project) -> void:
 			image.copy_from(blended_frames[frame])
 			if erase_unselected_area and project.has_selection:
 				var crop := project.new_empty_image()
-				var selection_image := project.selection_map.return_cropped_copy(project, project.size)
+				var selection_image := project.selection_map.return_cropped_copy(
+					project, project.size
+				)
 				crop.blit_rect_mask(
 					image, selection_image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO
 				)

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -293,7 +293,7 @@ func process_animation(project := Global.current_project) -> void:
 			image.copy_from(blended_frames[frame])
 			if erase_unselected_area and project.has_selection:
 				var crop := project.new_empty_image()
-				var selection_image = project.selection_map.return_cropped_copy(project.size)
+				var selection_image := project.selection_map.return_cropped_copy(project, project.size)
 				crop.blit_rect_mask(
 					image, selection_image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO
 				)

--- a/src/Autoload/ExtensionsApi.gd
+++ b/src/Autoload/ExtensionsApi.gd
@@ -517,7 +517,7 @@ class SelectionAPI:
 			Global.canvas.selection.transform_content_start()
 		var selection_rectangle: Rect2i = Global.canvas.selection.big_bounding_rectangle
 		var rel_direction := destination - selection_rectangle.position
-		Global.canvas.selection.move_content(rel_direction)
+		Global.canvas.selection.transformation_handles.move(rel_direction)
 		Global.canvas.selection.move_borders_end()
 		if not transform_standby and with_content:
 			Global.canvas.selection.transform_content_confirm()

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -183,7 +183,7 @@ func remove_backup_file() -> void:
 func commit_undo() -> void:
 	if not can_undo:
 		return
-	if Global.canvas.selection.is_moving_content:
+	if Global.canvas.selection.transformation_handles.is_transforming_content():
 		Global.canvas.selection.transform_content_cancel()
 	else:
 		undo_redo.undo()
@@ -232,8 +232,14 @@ func is_indexed() -> bool:
 func selection_map_changed() -> void:
 	var image_texture: ImageTexture
 	has_selection = !selection_map.is_invisible()
+	var transformation_handles := Global.canvas.selection.transformation_handles
 	if has_selection:
 		image_texture = ImageTexture.create_from_image(selection_map)
+		var used_map := SelectionMap.new()
+		used_map.copy_from(selection_map.get_region(selection_map.get_used_rect()))
+		transformation_handles.set_selection(used_map, selection_map.get_selection_rect(self))
+	else:
+		transformation_handles.set_selection(null, Rect2i())
 	Global.canvas.selection.marching_ants_outline.texture = image_texture
 	Global.top_menu_container.edit_menu.set_item_disabled(Global.EditMenu.NEW_BRUSH, !has_selection)
 	Global.top_menu_container.project_menu.set_item_disabled(

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -230,17 +230,14 @@ func is_indexed() -> bool:
 
 
 func selection_map_changed() -> void:
-	var image_texture: ImageTexture
 	has_selection = !selection_map.is_invisible()
 	var transformation_handles := Global.canvas.selection.transformation_handles
 	if has_selection:
-		image_texture = ImageTexture.create_from_image(selection_map)
 		var used_map := SelectionMap.new()
 		used_map.copy_from(selection_map.get_region(selection_map.get_used_rect()))
 		transformation_handles.set_selection(used_map, selection_map.get_selection_rect(self))
 	else:
 		transformation_handles.set_selection(null, Rect2i())
-	Global.canvas.selection.marching_ants_outline.texture = image_texture
 	Global.top_menu_container.edit_menu.set_item_disabled(Global.EditMenu.NEW_BRUSH, !has_selection)
 	Global.top_menu_container.project_menu.set_item_disabled(
 		Global.ProjectMenu.CROP_TO_SELECTION, !has_selection

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -124,6 +124,11 @@ func return_cropped_copy(project: Project, size: Vector2i) -> SelectionMap:
 	return selection_map_copy
 
 
+func blit_rect_custom(new_map: SelectionMap, rect: Rect2i, origin: Vector2i) -> void:
+	clear()
+	blit_rect(new_map, rect, origin)
+
+
 ## TODO: Add move_to as a parameter, or perhaps even remove this method completely.
 func move_bitmap_values(project: Project, move_offset := true) -> void:
 	var size := project.size

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -129,6 +129,17 @@ func blit_rect_custom(new_map: SelectionMap, rect: Rect2i, origin: Vector2i) -> 
 	blit_rect(new_map, rect, origin)
 
 
+func ensure_selection_fits(project: Project, rect: Rect2i) -> void:
+	var current_size := Rect2i(Vector2i.ZERO, get_size())
+	if current_size.encloses(rect):
+		project.selection_offset = Vector2.ZERO
+		return
+	var new_size := current_size.merge(rect).size
+	var offset := current_size.position.min(rect.position)
+	crop(new_size.x, new_size.y)
+	project.selection_offset = Vector2.ZERO.min(offset)
+
+
 ## TODO: Add move_to as a parameter, or perhaps even remove this method completely.
 func move_bitmap_values(project: Project, move_offset := true) -> void:
 	var size := project.size

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -5,7 +5,9 @@ const INVERT_SHADER := preload("res://src/Shaders/Effects/Invert.gdshader")
 const OUTLINE_INLINE_SHADER := preload("res://src/Shaders/Effects/OutlineInline.gdshader")
 
 
-func is_pixel_selected(pixel: Vector2i, calculate_offset := true, project := Global.current_project) -> bool:
+func is_pixel_selected(
+	pixel: Vector2i, calculate_offset := true, project := Global.current_project
+) -> bool:
 	if calculate_offset:
 		var selection_position := get_selection_rect(project).position
 		if selection_position.x < 0:

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -98,6 +98,13 @@ func invert() -> void:
 	gen.generate_image(self, INVERT_SHADER, params, get_size())
 
 
+func get_selection_rect(project: Project) -> Rect2i:
+	var rect := get_used_rect()
+	rect.position += project.selection_offset
+	rect.end += project.selection_offset
+	return rect
+
+
 ## Returns a copy of itself that is cropped to [param size].
 ## Used for when the selection map is bigger than the [Project] size.
 func return_cropped_copy(size: Vector2i) -> SelectionMap:
@@ -120,9 +127,9 @@ func return_cropped_copy(size: Vector2i) -> SelectionMap:
 
 func move_bitmap_values(project: Project, move_offset := true) -> void:
 	var size := project.size
-	var selection_rect := get_used_rect()
-	var selection_position := selection_rect.position + project.selection_offset
-	var selection_end := selection_rect.end + project.selection_offset
+	var selection_rect := get_selection_rect(project)
+	var selection_position := selection_rect.position
+	var selection_end := selection_rect.end
 	var smaller_image := get_region(selection_rect)
 	clear()
 	var dst := selection_position
@@ -161,8 +168,8 @@ func resize_bitmap_values(
 	project: Project, new_size: Vector2i, flip_hor: bool, flip_ver: bool
 ) -> void:
 	var size := project.size
-	var selection_rect := get_used_rect()
-	var selection_position := selection_rect.position + project.selection_offset
+	var selection_rect := get_selection_rect(project)
+	var selection_position := selection_rect.position
 	var dst := selection_position
 	var new_bitmap_size := size
 	new_bitmap_size.x = maxi(size.x, absi(selection_position.x) + new_size.x)

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -6,8 +6,8 @@ const OUTLINE_INLINE_SHADER := preload("res://src/Shaders/Effects/OutlineInline.
 
 
 func is_pixel_selected(pixel: Vector2i, calculate_offset := true) -> bool:
-	var selection_position: Vector2i = Global.canvas.selection.big_bounding_rectangle.position
 	if calculate_offset:
+		var selection_position: Vector2i = Global.canvas.selection.big_bounding_rectangle.position
 		if selection_position.x < 0:
 			pixel.x -= selection_position.x
 		if selection_position.y < 0:
@@ -120,11 +120,9 @@ func return_cropped_copy(size: Vector2i) -> SelectionMap:
 
 func move_bitmap_values(project: Project, move_offset := true) -> void:
 	var size := project.size
-	var selection_node = Global.canvas.selection
-	var selection_position: Vector2i = selection_node.big_bounding_rectangle.position
-	var selection_end: Vector2i = selection_node.big_bounding_rectangle.end
-
 	var selection_rect := get_used_rect()
+	var selection_position := selection_rect.position + project.selection_offset
+	var selection_end := selection_rect.end + project.selection_offset
 	var smaller_image := get_region(selection_rect)
 	clear()
 	var dst := selection_position
@@ -163,13 +161,12 @@ func resize_bitmap_values(
 	project: Project, new_size: Vector2i, flip_hor: bool, flip_ver: bool
 ) -> void:
 	var size := project.size
-	var selection_node: Node2D = Global.canvas.selection
-	var selection_position: Vector2i = selection_node.big_bounding_rectangle.position
+	var selection_rect := get_used_rect()
+	var selection_position := selection_rect.position + project.selection_offset
 	var dst := selection_position
 	var new_bitmap_size := size
 	new_bitmap_size.x = maxi(size.x, absi(selection_position.x) + new_size.x)
 	new_bitmap_size.y = maxi(size.y, absi(selection_position.y) + new_size.y)
-	var selection_rect := get_used_rect()
 	var smaller_image := get_region(selection_rect)
 	if selection_position.x <= 0:
 		project.selection_offset.x = selection_position.x

--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -142,7 +142,6 @@ func ensure_selection_fits(project: Project, rect: Rect2i) -> void:
 	project.selection_offset = Vector2.ZERO.min(offset)
 
 
-## TODO: Add move_to as a parameter, or perhaps even remove this method completely.
 func move_bitmap_values(project: Project, move_offset := true) -> void:
 	var size := project.size
 	var selection_rect := get_selection_rect(project)

--- a/src/Shaders/Effects/Rotation/CommonRotation.gdshaderinc
+++ b/src/Shaders/Effects/Rotation/CommonRotation.gdshaderinc
@@ -8,7 +8,7 @@ vec2 rotate(vec2 uv, float ratio) {
 	uv -= pivot;
 
 	// Rotate image
-	uv *= transformation_matrix;
+	uv = transformation_matrix * uv;
 	uv.x /= ratio;
 	uv += pivot;
 

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -34,11 +34,11 @@ func _ready() -> void:
 	set_confirm_buttons_visibility()
 	set_spinbox_values()
 	refresh_options()
-	selection_node.is_moving_content_changed.connect(set_confirm_buttons_visibility)
+	selection_node.transformation_handles.is_transforming_content_changed.connect(set_confirm_buttons_visibility)
 
 
 func set_confirm_buttons_visibility() -> void:
-	confirm_buttons.visible = selection_node.is_moving_content
+	confirm_buttons.visible = selection_node.transformation_handles.is_transforming_content()
 
 
 ## Ensure all items are added when we are selecting an option.
@@ -105,7 +105,7 @@ func draw_start(pos: Vector2i) -> void:
 		_move = true
 		if quick_copy:  # Move selection without cutting it from the original position (quick copy)
 			_move_content = true
-			if selection_node.is_moving_content:
+			if selection_node.transformation_handles.is_transforming_content():
 				for image in _get_selected_draw_images():
 					image.blit_rect_mask(
 						selection_node.preview_image,
@@ -139,7 +139,7 @@ func draw_start(pos: Vector2i) -> void:
 	else:  # No moving
 		selection_node.transform_content_confirm()
 
-	_content_transformation_check = selection_node.is_moving_content
+	_content_transformation_check = selection_node.transformation_handles.is_transforming_content()
 
 
 func draw_move(pos: Vector2i) -> void:
@@ -149,7 +149,7 @@ func draw_move(pos: Vector2i) -> void:
 		return
 	# This is true if content transformation has been confirmed (pressed Enter for example)
 	# while the content is being moved
-	if _content_transformation_check != selection_node.is_moving_content:
+	if _content_transformation_check != selection_node.transformation_handles.is_transforming_content():
 		return
 	if not _move:
 		return
@@ -193,7 +193,7 @@ func draw_end(pos: Vector2i) -> void:
 	super.draw_end(pos)
 	if selection_node.arrow_key_move:
 		return
-	if _content_transformation_check == selection_node.is_moving_content:
+	if _content_transformation_check == selection_node.transformation_handles.is_transforming_content():
 		if _move:
 			selection_node.move_borders_end()
 		else:
@@ -225,13 +225,11 @@ func select_tilemap_cell(
 
 
 func _on_confirm_button_pressed() -> void:
-	if selection_node.is_moving_content:
-		selection_node.transform_content_confirm()
+	selection_node.transform_content_confirm()
 
 
 func _on_cancel_button_pressed() -> void:
-	if selection_node.is_moving_content:
-		selection_node.transform_content_cancel()
+	selection_node.transform_content_cancel()
 
 
 func _on_Modes_item_selected(index: int) -> void:
@@ -269,7 +267,7 @@ func _on_Size_value_changed(value: Vector2i) -> void:
 
 	if timer.is_stopped():
 		undo_data = selection_node.get_undo_data(false)
-		if not selection_node.is_moving_content:
+		if not selection_node.transformation_handles.is_transforming_content():
 			selection_node.original_bitmap.copy_from(Global.current_project.selection_map)
 	timer.start()
 	if selection_node.resized_rect.position != selection_node.big_bounding_rectangle.position:
@@ -283,5 +281,5 @@ func _on_Size_ratio_toggled(button_pressed: bool) -> void:
 
 
 func _on_Timer_timeout() -> void:
-	if not selection_node.is_moving_content:
+	if not selection_node.transformation_handles.is_transforming_content():
 		selection_node.commit_undo("Move Selection", undo_data)

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -67,7 +67,8 @@ func update_config() -> void:
 
 func set_spinbox_values() -> void:
 	_skip_slider_logic = true
-	var select_rect: Rect2i = selection_node.big_bounding_rectangle
+	var project := Global.current_project
+	var select_rect := project.selection_map.get_selection_rect(project)
 	var has_selection := select_rect.has_area()
 	if not has_selection:
 		size_sliders.press_ratio_button(false)
@@ -84,6 +85,7 @@ func draw_start(pos: Vector2i) -> void:
 	if selection_node.arrow_key_move:
 		return
 	var project := Global.current_project
+	var select_rect := project.selection_map.get_selection_rect(project)
 	undo_data = selection_node.get_undo_data(false)
 	_intersect = Input.is_action_pressed("selection_intersect", true)
 	_add = Input.is_action_pressed("selection_add", true)
@@ -109,7 +111,7 @@ func draw_start(pos: Vector2i) -> void:
 						selection_node.preview_image,
 						selection_node.preview_image,
 						Rect2i(Vector2i.ZERO, project.selection_map.get_size()),
-						selection_node.big_bounding_rectangle.position
+						select_rect.position
 					)
 
 				project.selection_map.move_bitmap_values(project)
@@ -122,7 +124,7 @@ func draw_start(pos: Vector2i) -> void:
 						selection_node.preview_image,
 						selection_node.preview_image,
 						Rect2i(Vector2i.ZERO, project.selection_map.get_size()),
-						selection_node.big_bounding_rectangle.position
+						select_rect.position
 					)
 				Global.canvas.update_selected_cels_textures()
 
@@ -151,9 +153,10 @@ func draw_move(pos: Vector2i) -> void:
 		return
 	if not _move:
 		return
-
+	var project := Global.current_project
+	var select_rect := project.selection_map.get_selection_rect(project)
 	if Tools.is_placing_tiles():
-		var cel := Global.current_project.get_current_cel() as CelTileMap
+		var cel := project.get_current_cel() as CelTileMap
 		var grid_size := cel.get_tile_size()
 		var offset := cel.offset % grid_size
 		pos = Tools.snap_to_rectangular_grid_boundary(pos, grid_size, offset)
@@ -165,11 +168,9 @@ func draw_move(pos: Vector2i) -> void:
 			pos.x = _start_pos.x
 	if Input.is_action_pressed("transform_snap_grid"):
 		_offset = _offset.snapped(Global.grids[0].grid_size)
-		var prev_pos: Vector2i = selection_node.big_bounding_rectangle.position
-		selection_node.big_bounding_rectangle.position = prev_pos.snapped(Global.grids[0].grid_size)
-		selection_node.marching_ants_outline.offset += Vector2(
-			selection_node.big_bounding_rectangle.position - prev_pos
-		)
+		var prev_pos: Vector2i = select_rect.position
+		#big_bounding_rectangle.position = prev_pos.snapped(Global.grids[0].grid_size)
+		selection_node.marching_ants_outline.offset += Vector2(select_rect.position - prev_pos)
 		pos = pos.snapped(Global.grids[0].grid_size)
 		var grid_offset := Global.grids[0].grid_offset
 		grid_offset = Vector2i(
@@ -184,7 +185,7 @@ func draw_move(pos: Vector2i) -> void:
 		selection_node.move_borders(pos - _offset)
 
 	_offset = pos
-	_set_cursor_text(selection_node.big_bounding_rectangle)
+	_set_cursor_text(select_rect)
 
 
 func draw_end(pos: Vector2i) -> void:
@@ -254,7 +255,7 @@ func _on_Position_value_changed(value: Vector2i) -> void:
 	if timer.is_stopped():
 		undo_data = selection_node.get_undo_data(false)
 	timer.start()
-	selection_node.big_bounding_rectangle.position = value
+	#selection_node.big_bounding_rectangle.position = value
 
 	project.selection_map.move_bitmap_values(project)
 	project.selection_map_changed()

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -20,6 +20,7 @@ var _skip_slider_logic := false
 
 @onready var selection_node := Global.canvas.selection
 @onready var transformation_handles := selection_node.transformation_handles
+@onready var algorithm_option_button := $Algorithm as OptionButton
 @onready var position_sliders := $Position as ValueSliderV2
 @onready var size_sliders := $Size as ValueSliderV2
 @onready var rotation_slider := $Rotation as ValueSlider
@@ -28,6 +29,10 @@ var _skip_slider_logic := false
 
 func _ready() -> void:
 	super._ready()
+	algorithm_option_button.add_item("Viewport")
+	algorithm_option_button.add_item("cleanEdge", DrawingAlgos.RotationAlgorithm.CLEANEDGE)
+	algorithm_option_button.add_item("OmniScale", DrawingAlgos.RotationAlgorithm.OMNISCALE)
+	algorithm_option_button.select(0)
 	set_confirm_buttons_visibility()
 	set_spinbox_values()
 	refresh_options()
@@ -223,6 +228,11 @@ func _on_cancel_button_pressed() -> void:
 func _on_modes_item_selected(index: int) -> void:
 	_mode_selected = index
 	save_config()
+
+
+func _on_algorithm_item_selected(index: int) -> void:
+	var id := algorithm_option_button.get_item_id(index)
+	transformation_handles.transformation_algorithm = id
 
 
 func _set_cursor_text(rect: Rect2i) -> void:

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -90,7 +90,6 @@ func draw_start(pos: Vector2i) -> void:
 	if transformation_handles.arrow_key_move:
 		return
 	var project := Global.current_project
-	var select_rect := project.selection_map.get_selection_rect(project)
 	_intersect = Input.is_action_pressed("selection_intersect", true)
 	_add = Input.is_action_pressed("selection_add", true)
 	_subtract = Input.is_action_pressed("selection_subtract", true)
@@ -109,29 +108,18 @@ func draw_start(pos: Vector2i) -> void:
 		_move = true
 		if quick_copy:  # Move selection without cutting it from the original position (quick copy)
 			if transformation_handles.is_transforming_content():
-				for cel in _get_selected_draw_unlocked_cels():
-					var image := cel.get_image()
-					image.blit_rect_mask(
-						cel.transformed_content,
-						cel.transformed_content,
-						Rect2i(Vector2i.ZERO, project.selection_map.get_size()),
-						transformation_handles.get_transform_top_left()
-					)
-
-				project.selection_map.move_bitmap_values(project)
-				selection_node.commit_undo("Move Selection", selection_node.undo_data)
-				selection_node.undo_data = selection_node.get_undo_data(true)
-			else:
-				transformation_handles.begin_transform()
-				for cel in _get_selected_draw_unlocked_cels():
-					var image := cel.get_image()
-					image.blit_rect_mask(
-						cel.transformed_content,
-						cel.transformed_content,
-						Rect2i(Vector2i.ZERO, project.selection_map.get_size()),
-						select_rect.position
-					)
-				Global.canvas.queue_redraw()
+				selection_node.transform_content_confirm()
+			transformation_handles.begin_transform(null, project, true)
+			var select_rect := project.selection_map.get_selection_rect(project)
+			for cel in _get_selected_draw_unlocked_cels():
+				var image := cel.get_image()
+				image.blit_rect_mask(
+					cel.transformed_content,
+					cel.transformed_content,
+					Rect2i(Vector2i.ZERO, project.selection_map.get_size()),
+					select_rect.position
+				)
+			Global.canvas.queue_redraw()
 
 		else:
 			transformation_handles.begin_transform()

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -245,7 +245,7 @@ func _on_position_value_changed(value: Vector2) -> void:
 		return
 	if not transformation_handles.is_transforming_content():
 		transformation_handles.begin_transform()
-	transformation_handles.move(value - transformation_handles.preview_transform.origin)
+	transformation_handles.move_transform(value - transformation_handles.preview_transform.origin)
 
 
 func _on_size_value_changed(value: Vector2i) -> void:
@@ -257,4 +257,4 @@ func _on_size_value_changed(value: Vector2i) -> void:
 		transformation_handles.begin_transform()
 	var image_size := selection_node.preview_selection_map.get_used_rect().size
 	var delta := value - image_size
-	transformation_handles.resize(delta)
+	transformation_handles.resize_transform(delta)

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -31,12 +31,12 @@ func _ready() -> void:
 	set_confirm_buttons_visibility()
 	set_spinbox_values()
 	refresh_options()
-	selection_node.transformation_handles.preview_transform_changed.connect(set_confirm_buttons_visibility)
+	transformation_handles.preview_transform_changed.connect(set_confirm_buttons_visibility)
 
 
 func set_confirm_buttons_visibility() -> void:
 	await get_tree().process_frame
-	confirm_buttons.visible = selection_node.transformation_handles.is_transforming_content()
+	confirm_buttons.visible = transformation_handles.is_transforming_content()
 
 
 ## Ensure all items are added when we are selecting an option.
@@ -93,7 +93,7 @@ func draw_start(pos: Vector2i) -> void:
 
 	var quick_copy := Input.is_action_pressed("transform_copy_selection_content", true)
 	if (
-		transformation_handles.is_position_inside_selection(pos)
+		selection_node.preview_selection_map.is_pixel_selected(pos)
 		and (!_add and !_subtract and !_intersect or quick_copy)
 		and !_ongoing_selection
 	):
@@ -102,7 +102,7 @@ func draw_start(pos: Vector2i) -> void:
 		# Move current selection
 		_move = true
 		if quick_copy:  # Move selection without cutting it from the original position (quick copy)
-			if selection_node.transformation_handles.is_transforming_content():
+			if transformation_handles.is_transforming_content():
 				for image in _get_selected_draw_images():
 					image.blit_rect_mask(
 						selection_node.preview_image,
@@ -250,7 +250,7 @@ func _on_Size_value_changed(value: Vector2i) -> void:
 
 	if timer.is_stopped():
 		undo_data = selection_node.get_undo_data(false)
-		if not selection_node.transformation_handles.is_transforming_content():
+		if not transformation_handles.is_transforming_content():
 			selection_node.original_bitmap.copy_from(Global.current_project.selection_map)
 	timer.start()
 	if selection_node.resized_rect.position != selection_node.big_bounding_rectangle.position:
@@ -264,5 +264,5 @@ func _on_Size_ratio_toggled(button_pressed: bool) -> void:
 
 
 func _on_Timer_timeout() -> void:
-	if not selection_node.transformation_handles.is_transforming_content():
+	if not transformation_handles.is_transforming_content():
 		selection_node.commit_undo("Move Selection", undo_data)

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -5,7 +5,6 @@ enum Mode { DEFAULT, ADD, SUBTRACT, INTERSECT }
 
 var undo_data: Dictionary
 var _move := false
-var _move_content := true
 var _start_pos := Vector2i.ZERO
 var _offset := Vector2i.ZERO
 ## For tools such as the Polygon selection tool where you have to
@@ -102,7 +101,6 @@ func draw_start(pos: Vector2i) -> void:
 		# Move current selection
 		_move = true
 		if quick_copy:  # Move selection without cutting it from the original position (quick copy)
-			_move_content = true
 			if selection_node.transformation_handles.is_transforming_content():
 				for image in _get_selected_draw_images():
 					image.blit_rect_mask(
@@ -126,12 +124,12 @@ func draw_start(pos: Vector2i) -> void:
 					)
 				Global.canvas.update_selected_cels_textures()
 
-		elif Input.is_action_pressed("transform_move_selection_only", true):  # Doesn't move content
-			selection_node.transform_content_confirm()
-			_move_content = false
-			selection_node.move_borders_start()
-		else:  # Move selection and content normally
-			_move_content = true
+		else:
+			# Doesn't move content
+			if Input.is_action_pressed("transform_move_selection_only", true):
+				selection_node.transform_content_confirm()
+				selection_node.move_borders_start()
+			transformation_handles.begin_transform()
 
 	else:  # No moving
 		selection_node.transform_content_confirm()
@@ -170,11 +168,7 @@ func draw_move(pos: Vector2i) -> void:
 		)
 		pos += grid_offset
 
-	if _move_content:
-		transformation_handles.move(pos - _offset)
-	else:
-		transformation_handles.move(pos - _offset)
-
+	transformation_handles.move(pos - _offset)
 	_offset = pos
 	_set_cursor_text(select_rect)
 

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -86,7 +86,6 @@ func draw_start(pos: Vector2i) -> void:
 		return
 	var project := Global.current_project
 	var select_rect := project.selection_map.get_selection_rect(project)
-	undo_data = selection_node.get_undo_data(false)
 	_intersect = Input.is_action_pressed("selection_intersect", true)
 	_add = Input.is_action_pressed("selection_add", true)
 	_subtract = Input.is_action_pressed("selection_subtract", true)
@@ -134,6 +133,7 @@ func draw_start(pos: Vector2i) -> void:
 
 	else:  # No moving
 		selection_node.transform_content_confirm()
+	undo_data = selection_node.get_undo_data(false)
 
 
 func draw_move(pos: Vector2i) -> void:

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -17,9 +17,6 @@ var _add := false  ## Shift + Mouse Click
 var _subtract := false  ## Ctrl + Mouse Click
 var _intersect := false  ## Shift + Ctrl + Mouse Click
 
-## Used to check if the state of content transformation has been changed
-## while draw_move() is being called. For example, pressing Enter while still moving content
-var _content_transformation_check := false
 var _skip_slider_logic := false
 
 @onready var selection_node := Global.canvas.selection
@@ -139,17 +136,11 @@ func draw_start(pos: Vector2i) -> void:
 	else:  # No moving
 		selection_node.transform_content_confirm()
 
-	_content_transformation_check = selection_node.transformation_handles.is_transforming_content()
-
 
 func draw_move(pos: Vector2i) -> void:
 	pos = snap_position(pos)
 	super.draw_move(pos)
 	if selection_node.arrow_key_move:
-		return
-	# This is true if content transformation has been confirmed (pressed Enter for example)
-	# while the content is being moved
-	if _content_transformation_check != selection_node.transformation_handles.is_transforming_content():
 		return
 	if not _move:
 		return
@@ -193,9 +184,8 @@ func draw_end(pos: Vector2i) -> void:
 	super.draw_end(pos)
 	if selection_node.arrow_key_move:
 		return
-	if _content_transformation_check == selection_node.transformation_handles.is_transforming_content():
-		if not _move:
-			apply_selection(pos)
+	if not _move:
+		apply_selection(pos)
 
 	_move = false
 	cursor_text = ""

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -31,10 +31,11 @@ func _ready() -> void:
 	set_confirm_buttons_visibility()
 	set_spinbox_values()
 	refresh_options()
-	selection_node.transformation_handles.is_transforming_content_changed.connect(set_confirm_buttons_visibility)
+	selection_node.transformation_handles.preview_transform_changed.connect(set_confirm_buttons_visibility)
 
 
 func set_confirm_buttons_visibility() -> void:
+	await get_tree().process_frame
 	confirm_buttons.visible = selection_node.transformation_handles.is_transforming_content()
 
 

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -29,7 +29,7 @@ var _skip_slider_logic := false
 
 func _ready() -> void:
 	super._ready()
-	algorithm_option_button.add_item("Viewport")
+	algorithm_option_button.add_item("Nearest Neighbor")
 	algorithm_option_button.add_item("cleanEdge", DrawingAlgos.RotationAlgorithm.CLEANEDGE)
 	algorithm_option_button.add_item("OmniScale", DrawingAlgos.RotationAlgorithm.OMNISCALE)
 	algorithm_option_button.select(0)

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -80,7 +80,7 @@ func set_spinbox_values() -> void:
 func draw_start(pos: Vector2i) -> void:
 	pos = snap_position(pos)
 	super.draw_start(pos)
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	var project := Global.current_project
 	var select_rect := project.selection_map.get_selection_rect(project)
@@ -141,7 +141,7 @@ func draw_start(pos: Vector2i) -> void:
 func draw_move(pos: Vector2i) -> void:
 	pos = snap_position(pos)
 	super.draw_move(pos)
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	if not _move:
 		return
@@ -179,7 +179,7 @@ func draw_move(pos: Vector2i) -> void:
 func draw_end(pos: Vector2i) -> void:
 	pos = snap_position(pos)
 	super.draw_end(pos)
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	if not _move:
 		apply_selection(pos)

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -128,10 +128,6 @@ func draw_start(pos: Vector2i) -> void:
 				Global.canvas.queue_redraw()
 
 		else:
-			# Doesn't move content
-			if Input.is_action_pressed("transform_move_selection_only", true):
-				selection_node.transform_content_confirm()
-				selection_node.move_borders_start()
 			transformation_handles.begin_transform()
 
 	else:  # No moving

--- a/src/Tools/BaseSelectionTool.tscn
+++ b/src/Tools/BaseSelectionTool.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=10 format=3 uid="uid://bd62qfjn380wf"]
+[gd_scene load_steps=11 format=3 uid="uid://bd62qfjn380wf"]
 
 [ext_resource type="PackedScene" uid="uid://ctfgfelg0sho8" path="res://src/Tools/BaseTool.tscn" id="1"]
 [ext_resource type="Script" uid="uid://coj8ex4hmag1m" path="res://src/Tools/BaseSelectionTool.gd" id="2"]
 [ext_resource type="Texture2D" uid="uid://d267xalp3p7ru" path="res://assets/graphics/misc/check_plain.png" id="3_mtv71"]
 [ext_resource type="PackedScene" uid="uid://bbnqcxa20a5a5" path="res://src/UI/Nodes/Sliders/ValueSliderV2.tscn" id="4"]
 [ext_resource type="Texture2D" uid="uid://bnc78807k1xjv" path="res://assets/graphics/misc/close.png" id="4_ad04n"]
+[ext_resource type="Script" uid="uid://tfdhqto6j5j0" path="res://src/UI/Nodes/Sliders/ValueSlider.gd" id="6_2bdjf"]
 
 [sub_resource type="InputEventAction" id="InputEventAction_gfv4x"]
 action = &"transformation_confirm"
@@ -21,7 +22,7 @@ events = [SubResource("InputEventAction_nadbx")]
 [node name="ToolOptions" instance=ExtResource("1")]
 script = ExtResource("2")
 
-[node name="ConfirmButtons" type="HBoxContainer" parent="." index="2"]
+[node name="ConfirmButtons" type="HBoxContainer" parent="." index="2" groups=["ShowOnActiveTransformation"]]
 layout_mode = 2
 
 [node name="ConfirmButton" type="Button" parent="ConfirmButtons" index="0"]
@@ -88,8 +89,48 @@ show_ratio = true
 prefix_x = "Width:"
 prefix_y = "Height:"
 
+[node name="RotationLabel" type="Label" parent="." index="9" groups=["ShowOnActiveTransformation"]]
+layout_mode = 2
+text = "Rotation:"
+
+[node name="Rotation" type="TextureProgressBar" parent="." index="10" groups=["ShowOnActiveTransformation"]]
+custom_minimum_size = Vector2(0, 24)
+layout_mode = 2
+focus_mode = 2
+mouse_default_cursor_shape = 2
+theme_type_variation = &"ValueSlider"
+min_value = -180.0
+max_value = 180.0
+nine_patch_stretch = true
+stretch_margin_left = 3
+stretch_margin_top = 3
+stretch_margin_right = 3
+stretch_margin_bottom = 3
+script = ExtResource("6_2bdjf")
+suffix = "°"
+metadata/_custom_type_script = "uid://tfdhqto6j5j0"
+
+[node name="Shear" type="TextureProgressBar" parent="." index="11" groups=["ShowOnActiveTransformation"]]
+custom_minimum_size = Vector2(0, 24)
+layout_mode = 2
+focus_mode = 2
+mouse_default_cursor_shape = 2
+theme_type_variation = &"ValueSlider"
+min_value = -90.0
+max_value = 90.0
+nine_patch_stretch = true
+stretch_margin_left = 3
+stretch_margin_top = 3
+stretch_margin_right = 3
+stretch_margin_bottom = 3
+script = ExtResource("6_2bdjf")
+suffix = "°"
+metadata/_custom_type_script = "uid://tfdhqto6j5j0"
+
 [connection signal="pressed" from="ConfirmButtons/ConfirmButton" to="." method="_on_confirm_button_pressed"]
 [connection signal="pressed" from="ConfirmButtons/CancelButton" to="." method="_on_cancel_button_pressed"]
 [connection signal="item_selected" from="Modes" to="." method="_on_modes_item_selected"]
 [connection signal="value_changed" from="Position" to="." method="_on_position_value_changed"]
 [connection signal="value_changed" from="Size" to="." method="_on_size_value_changed"]
+[connection signal="value_changed" from="Rotation" to="." method="_on_rotation_value_changed"]
+[connection signal="value_changed" from="Shear" to="." method="_on_shear_value_changed"]

--- a/src/Tools/BaseSelectionTool.tscn
+++ b/src/Tools/BaseSelectionTool.tscn
@@ -67,20 +67,24 @@ text = "Mode:"
 layout_mode = 2
 mouse_default_cursor_shape = 2
 
-[node name="PositionLabel" type="Label" parent="." index="5"]
+[node name="Algorithm" type="OptionButton" parent="." index="5"]
+layout_mode = 2
+mouse_default_cursor_shape = 2
+
+[node name="PositionLabel" type="Label" parent="." index="6"]
 layout_mode = 2
 text = "Position:"
 
-[node name="Position" parent="." index="6" instance=ExtResource("4")]
+[node name="Position" parent="." index="7" instance=ExtResource("4")]
 layout_mode = 2
 allow_greater = true
 allow_lesser = true
 
-[node name="SizeLabel" type="Label" parent="." index="7"]
+[node name="SizeLabel" type="Label" parent="." index="8"]
 layout_mode = 2
 text = "Size:"
 
-[node name="Size" parent="." index="8" instance=ExtResource("4")]
+[node name="Size" parent="." index="9" instance=ExtResource("4")]
 layout_mode = 2
 value = Vector2(1, 1)
 min_value = Vector2(1, 1)
@@ -89,11 +93,11 @@ show_ratio = true
 prefix_x = "Width:"
 prefix_y = "Height:"
 
-[node name="RotationLabel" type="Label" parent="." index="9" groups=["ShowOnActiveTransformation"]]
+[node name="RotationLabel" type="Label" parent="." index="10" groups=["ShowOnActiveTransformation"]]
 layout_mode = 2
 text = "Rotation:"
 
-[node name="Rotation" type="TextureProgressBar" parent="." index="10" groups=["ShowOnActiveTransformation"]]
+[node name="Rotation" type="TextureProgressBar" parent="." index="11" groups=["ShowOnActiveTransformation"]]
 custom_minimum_size = Vector2(0, 24)
 layout_mode = 2
 focus_mode = 2
@@ -110,7 +114,7 @@ script = ExtResource("6_2bdjf")
 suffix = "°"
 metadata/_custom_type_script = "uid://tfdhqto6j5j0"
 
-[node name="Shear" type="TextureProgressBar" parent="." index="11" groups=["ShowOnActiveTransformation"]]
+[node name="Shear" type="TextureProgressBar" parent="." index="12" groups=["ShowOnActiveTransformation"]]
 custom_minimum_size = Vector2(0, 24)
 layout_mode = 2
 focus_mode = 2
@@ -130,6 +134,7 @@ metadata/_custom_type_script = "uid://tfdhqto6j5j0"
 [connection signal="pressed" from="ConfirmButtons/ConfirmButton" to="." method="_on_confirm_button_pressed"]
 [connection signal="pressed" from="ConfirmButtons/CancelButton" to="." method="_on_cancel_button_pressed"]
 [connection signal="item_selected" from="Modes" to="." method="_on_modes_item_selected"]
+[connection signal="item_selected" from="Algorithm" to="." method="_on_algorithm_item_selected"]
 [connection signal="value_changed" from="Position" to="." method="_on_position_value_changed"]
 [connection signal="value_changed" from="Size" to="." method="_on_size_value_changed"]
 [connection signal="value_changed" from="Rotation" to="." method="_on_rotation_value_changed"]

--- a/src/Tools/BaseSelectionTool.tscn
+++ b/src/Tools/BaseSelectionTool.tscn
@@ -88,14 +88,8 @@ show_ratio = true
 prefix_x = "Width:"
 prefix_y = "Height:"
 
-[node name="Timer" type="Timer" parent="." index="9"]
-wait_time = 0.2
-one_shot = true
-
 [connection signal="pressed" from="ConfirmButtons/ConfirmButton" to="." method="_on_confirm_button_pressed"]
 [connection signal="pressed" from="ConfirmButtons/CancelButton" to="." method="_on_cancel_button_pressed"]
-[connection signal="item_selected" from="Modes" to="." method="_on_Modes_item_selected"]
-[connection signal="value_changed" from="Position" to="." method="_on_Position_value_changed"]
-[connection signal="ratio_toggled" from="Size" to="." method="_on_Size_ratio_toggled"]
-[connection signal="value_changed" from="Size" to="." method="_on_Size_value_changed"]
-[connection signal="timeout" from="Timer" to="." method="_on_Timer_timeout"]
+[connection signal="item_selected" from="Modes" to="." method="_on_modes_item_selected"]
+[connection signal="value_changed" from="Position" to="." method="_on_position_value_changed"]
+[connection signal="value_changed" from="Size" to="." method="_on_size_value_changed"]

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -283,7 +283,7 @@ func fill_in_selection() -> void:
 			var selection_map_copy := project.selection_map.return_cropped_copy(
 				project, project.size
 			)
-			var rect: Rect2i = selection_map_copy.get_used_rect()
+			var rect := selection_map_copy.get_used_rect()
 			for image in images:
 				image.blit_rect_mask(filler, selection_map_copy, rect, rect.position)
 				image.convert_rgb_to_indexed()

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -280,7 +280,9 @@ func fill_in_selection() -> void:
 		if project.has_selection:
 			var filler := project.new_empty_image()
 			filler.fill(tool_slot.color)
-			var selection_map_copy := project.selection_map.return_cropped_copy(project, project.size)
+			var selection_map_copy := project.selection_map.return_cropped_copy(
+				project, project.size
+			)
 			var rect: Rect2i = selection_map_copy.get_used_rect()
 			for image in images:
 				image.blit_rect_mask(filler, selection_map_copy, rect, rect.position)

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -157,6 +157,7 @@ func draw_start(pos: Vector2i) -> void:
 		_pick_color(pos)
 		return
 	_picking_color = false
+	Global.canvas.selection.transform_content_confirm()
 	_undo_data = _get_undo_data()
 	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
 		return
@@ -171,7 +172,6 @@ func draw_move(pos: Vector2i) -> void:
 		if Input.is_action_pressed(&"draw_color_picker", true):
 			_pick_color(pos)
 		return
-	Global.canvas.selection.transform_content_confirm()
 	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
 		return
 	if not Global.current_project.can_pixel_get_drawn(pos):

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -233,7 +233,7 @@ func fill_in_color(pos: Vector2i) -> void:
 		var selection: Image
 		var selection_tex: ImageTexture
 		if project.has_selection:
-			selection = project.selection_map.return_cropped_copy(project.size)
+			selection = project.selection_map.return_cropped_copy(project, project.size)
 		else:
 			selection = project.new_empty_image()
 			selection.fill(Color(1, 1, 1, 1))
@@ -280,8 +280,8 @@ func fill_in_selection() -> void:
 		if project.has_selection:
 			var filler := project.new_empty_image()
 			filler.fill(tool_slot.color)
-			var rect: Rect2i = Global.canvas.selection.big_bounding_rectangle
-			var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
+			var selection_map_copy := project.selection_map.return_cropped_copy(project, project.size)
+			var rect: Rect2i = selection_map_copy.get_used_rect()
 			for image in images:
 				image.blit_rect_mask(filler, selection_map_copy, rect, rect.position)
 				image.convert_rgb_to_indexed()
@@ -299,7 +299,7 @@ func fill_in_selection() -> void:
 		var selection: Image
 		var selection_tex: ImageTexture
 		if project.has_selection:
-			selection = project.selection_map.return_cropped_copy(project.size)
+			selection = project.selection_map.return_cropped_copy(project, project.size)
 		else:
 			selection = project.new_empty_image()
 			selection.fill(Color(1, 1, 1, 1))

--- a/src/Tools/SelectionTools/ColorSelect.gd
+++ b/src/Tools/SelectionTools/ColorSelect.gd
@@ -73,5 +73,4 @@ func apply_selection(pos: Vector2i) -> void:
 		cel_image.convert(Image.FORMAT_LA8)
 
 		project.selection_map.copy_from(cel_image)
-	Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	Global.canvas.selection.commit_undo("Select", undo_data)

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -24,7 +24,7 @@ func _input(event: InputEvent) -> void:
 
 
 func draw_move(pos: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	pos = snap_position(pos)
 	super.draw_move(pos)
@@ -37,7 +37,7 @@ func draw_move(pos: Vector2i) -> void:
 
 
 func draw_end(pos: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	pos = snap_position(pos)
 	super.draw_end(pos)

--- a/src/Tools/SelectionTools/EllipseSelect.gd
+++ b/src/Tools/SelectionTools/EllipseSelect.gd
@@ -107,7 +107,6 @@ func apply_selection(_position: Vector2i) -> void:
 			mirror_rect.end = mirror_ends[i]
 			set_ellipse(project.selection_map, mirror_rect.abs().position)
 
-		Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 		Global.canvas.selection.commit_undo("Select", undo_data)
 	Global.canvas.previews_sprite.texture = null
 

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -72,7 +72,6 @@ func apply_selection(_position) -> void:
 		# Handle mirroring
 		var callable := lasso_selection.bind(project, previous_selection_map)
 		mirror_array(_draw_points, callable)
-		Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	else:
 		if !cleared:
 			Global.canvas.selection.clear_selection()

--- a/src/Tools/SelectionTools/Lasso.gd
+++ b/src/Tools/SelectionTools/Lasso.gd
@@ -13,7 +13,7 @@ func draw_start(pos: Vector2i) -> void:
 
 
 func draw_move(pos_i: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	var pos := _get_stabilized_position(pos_i)
 	pos = snap_position(pos)
@@ -26,7 +26,7 @@ func draw_move(pos_i: Vector2i) -> void:
 
 
 func draw_end(pos: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	pos = snap_position(pos)
 	super.draw_end(pos)

--- a/src/Tools/SelectionTools/MagicWand.gd
+++ b/src/Tools/SelectionTools/MagicWand.gd
@@ -39,7 +39,6 @@ func apply_selection(pos: Vector2i) -> void:
 	for mirror_pos in Tools.get_mirrored_positions(pos):
 		_flood_fill(mirror_pos, cel_image, project, previous_selection_map)
 
-	Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	Global.canvas.selection.commit_undo("Select", undo_data)
 
 

--- a/src/Tools/SelectionTools/PaintSelect.gd
+++ b/src/Tools/SelectionTools/PaintSelect.gd
@@ -102,7 +102,6 @@ func apply_selection(pos: Vector2i) -> void:
 		# Handle mirroring
 		var mirror := mirror_array(_draw_points)
 		paint_selection(project, previous_selection_map, mirror)
-		Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	else:
 		if !cleared:
 			Global.canvas.selection.clear_selection()

--- a/src/Tools/SelectionTools/PaintSelect.gd
+++ b/src/Tools/SelectionTools/PaintSelect.gd
@@ -41,7 +41,7 @@ func draw_start(pos: Vector2i) -> void:
 
 
 func draw_move(pos_i: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	var pos := _get_stabilized_position(pos_i)
 	pos = snap_position(pos)
@@ -55,7 +55,7 @@ func draw_move(pos_i: Vector2i) -> void:
 
 
 func draw_end(pos: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	pos = snap_position(pos)
 	super.draw_end(pos)

--- a/src/Tools/SelectionTools/PolygonSelect.gd
+++ b/src/Tools/SelectionTools/PolygonSelect.gd
@@ -40,14 +40,14 @@ func draw_start(pos: Vector2i) -> void:
 
 
 func draw_move(pos: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	pos = snap_position(pos)
 	super.draw_move(pos)
 
 
 func draw_end(pos: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	pos = snap_position(pos)
 	if !_move and _draw_points:

--- a/src/Tools/SelectionTools/PolygonSelect.gd
+++ b/src/Tools/SelectionTools/PolygonSelect.gd
@@ -112,7 +112,6 @@ func apply_selection(pos: Vector2i) -> void:
 		# Handle mirroring
 		var callable := lasso_selection.bind(project, previous_selection_map)
 		mirror_array(_draw_points, callable)
-		Global.canvas.selection.big_bounding_rectangle = project.selection_map.get_used_rect()
 	else:
 		if !cleared:
 			Global.canvas.selection.clear_selection()

--- a/src/Tools/SelectionTools/RectSelect.gd
+++ b/src/Tools/SelectionTools/RectSelect.gd
@@ -24,7 +24,7 @@ func _input(event: InputEvent) -> void:
 
 
 func draw_move(pos: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	pos = snap_position(pos)
 	super.draw_move(pos)
@@ -37,7 +37,7 @@ func draw_move(pos: Vector2i) -> void:
 
 
 func draw_end(pos: Vector2i) -> void:
-	if selection_node.arrow_key_move:
+	if transformation_handles.arrow_key_move:
 		return
 	pos = snap_position(pos)
 	super.draw_end(pos)

--- a/src/Tools/UtilityTools/Move.gd
+++ b/src/Tools/UtilityTools/Move.gd
@@ -2,9 +2,6 @@ extends BaseTool
 
 var _start_pos: Vector2i
 var _offset: Vector2i
-## Used to check if the state of content transformation has been changed
-## while draw_move() is being called. For example, pressing Enter while still moving content
-var _content_transformation_check := false
 var _snap_to_grid := false  ## Mouse Click + Ctrl
 var _undo_data := {}
 
@@ -51,7 +48,6 @@ func draw_start(pos: Vector2i) -> void:
 	else:
 		if Global.current_project.has_selection:
 			selection_node.transformation_handles.begin_transform()
-	_content_transformation_check = selection_node.transformation_handles.is_transforming_content()
 	Global.canvas.sprite_changed_this_frame = true
 	Global.canvas.measurements.update_measurement(Global.MeasurementMode.MOVE)
 
@@ -59,10 +55,6 @@ func draw_start(pos: Vector2i) -> void:
 func draw_move(pos: Vector2i) -> void:
 	super.draw_move(pos)
 	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
-		return
-	# This is true if content transformation has been confirmed (pressed Enter for example)
-	# while the content is being moved
-	if _content_transformation_check != selection_node.transformation_handles.is_transforming_content():
 		return
 	pos = _snap_position(pos)
 
@@ -86,10 +78,7 @@ func draw_end(pos: Vector2i) -> void:
 	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
 		super.draw_end(pos)
 		return
-	if (
-		_start_pos != Vector2i(Vector2.INF)
-		and _content_transformation_check == selection_node.transformation_handles.is_transforming_content()
-	):
+	if _start_pos != Vector2i(Vector2.INF):
 		pos = _snap_position(pos)
 		if not (Global.current_project.has_selection and not Tools.is_placing_tiles()):
 			var pixel_diff := pos - _start_pos

--- a/src/Tools/UtilityTools/Move.gd
+++ b/src/Tools/UtilityTools/Move.gd
@@ -50,7 +50,7 @@ func draw_start(pos: Vector2i) -> void:
 			(cel as CelTileMap).prev_offset = (cel as CelTileMap).offset
 	else:
 		if Global.current_project.has_selection:
-			selection_node.transform_content_start()
+			selection_node.transformation_handles.begin_transform()
 	_content_transformation_check = selection_node.transformation_handles.is_transforming_content()
 	Global.canvas.sprite_changed_this_frame = true
 	Global.canvas.measurements.update_measurement(Global.MeasurementMode.MOVE)
@@ -74,7 +74,7 @@ func draw_move(pos: Vector2i) -> void:
 		Global.canvas.move_preview_location = pos - _start_pos
 	else:
 		if Global.current_project.has_selection:
-			selection_node.move_content(pos - _offset)
+			selection_node.transformation_handles.move(pos - _offset)
 		else:
 			Global.canvas.move_preview_location = pos - _start_pos
 	_offset = pos
@@ -91,9 +91,7 @@ func draw_end(pos: Vector2i) -> void:
 		and _content_transformation_check == selection_node.transformation_handles.is_transforming_content()
 	):
 		pos = _snap_position(pos)
-		if Global.current_project.has_selection and not Tools.is_placing_tiles():
-			selection_node.move_borders_end()
-		else:
+		if not (Global.current_project.has_selection and not Tools.is_placing_tiles()):
 			var pixel_diff := pos - _start_pos
 			Global.canvas.move_preview_location = Vector2i.ZERO
 			var images := _get_selected_draw_images()

--- a/src/Tools/UtilityTools/Move.gd
+++ b/src/Tools/UtilityTools/Move.gd
@@ -51,7 +51,7 @@ func draw_move(pos: Vector2i) -> void:
 		Global.canvas.move_preview_location = pos - _start_pos
 	else:
 		if Global.current_project.has_selection:
-			selection_node.transformation_handles.move(pos - _offset)
+			selection_node.transformation_handles.move_transform(pos - _offset)
 		else:
 			Global.canvas.move_preview_location = pos - _start_pos
 	_offset = pos

--- a/src/Tools/UtilityTools/Move.gd
+++ b/src/Tools/UtilityTools/Move.gd
@@ -14,24 +14,6 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("transform_snap_grid"):
 		_snap_to_grid = true
 		_offset = _offset.snapped(Global.grids[0].grid_size)
-		if (
-			Global.current_project.has_selection
-			and selection_node.transformation_handles.is_transforming_content()
-		):
-			var prev_pos: Vector2i = selection_node.big_bounding_rectangle.position
-			selection_node.big_bounding_rectangle.position = Vector2i(
-				prev_pos.snapped(Global.grids[0].grid_size)
-			)
-			# The first time transform_snap_grid is enabled then _snap_position() is not called
-			# and the selection had wrong offset, so do selection offsetting here
-			var grid_offset := Vector2i(
-				fmod(Global.grids[0].grid_offset.x, Global.grids[0].grid_size.x),
-				fmod(Global.grids[0].grid_offset.y, Global.grids[0].grid_size.y)
-			)
-			selection_node.big_bounding_rectangle.position += grid_offset
-			selection_node.marching_ants_outline.offset += Vector2(
-				selection_node.big_bounding_rectangle.position - prev_pos
-			)
 	elif event.is_action_released("transform_snap_grid"):
 		_snap_to_grid = false
 

--- a/src/Tools/UtilityTools/Move.gd
+++ b/src/Tools/UtilityTools/Move.gd
@@ -14,7 +14,10 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("transform_snap_grid"):
 		_snap_to_grid = true
 		_offset = _offset.snapped(Global.grids[0].grid_size)
-		if Global.current_project.has_selection and selection_node.transformation_handles.is_transforming_content():
+		if (
+			Global.current_project.has_selection
+			and selection_node.transformation_handles.is_transforming_content()
+		):
 			var prev_pos: Vector2i = selection_node.big_bounding_rectangle.position
 			selection_node.big_bounding_rectangle.position = Vector2i(
 				prev_pos.snapped(Global.grids[0].grid_size)

--- a/src/Tools/UtilityTools/Move.gd
+++ b/src/Tools/UtilityTools/Move.gd
@@ -17,7 +17,7 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("transform_snap_grid"):
 		_snap_to_grid = true
 		_offset = _offset.snapped(Global.grids[0].grid_size)
-		if Global.current_project.has_selection and selection_node.is_moving_content:
+		if Global.current_project.has_selection and selection_node.transformation_handles.is_transforming_content():
 			var prev_pos: Vector2i = selection_node.big_bounding_rectangle.position
 			selection_node.big_bounding_rectangle.position = Vector2i(
 				prev_pos.snapped(Global.grids[0].grid_size)
@@ -51,7 +51,7 @@ func draw_start(pos: Vector2i) -> void:
 	else:
 		if Global.current_project.has_selection:
 			selection_node.transform_content_start()
-	_content_transformation_check = selection_node.is_moving_content
+	_content_transformation_check = selection_node.transformation_handles.is_transforming_content()
 	Global.canvas.sprite_changed_this_frame = true
 	Global.canvas.measurements.update_measurement(Global.MeasurementMode.MOVE)
 
@@ -62,7 +62,7 @@ func draw_move(pos: Vector2i) -> void:
 		return
 	# This is true if content transformation has been confirmed (pressed Enter for example)
 	# while the content is being moved
-	if _content_transformation_check != selection_node.is_moving_content:
+	if _content_transformation_check != selection_node.transformation_handles.is_transforming_content():
 		return
 	pos = _snap_position(pos)
 
@@ -88,7 +88,7 @@ func draw_end(pos: Vector2i) -> void:
 		return
 	if (
 		_start_pos != Vector2i(Vector2.INF)
-		and _content_transformation_check == selection_node.is_moving_content
+		and _content_transformation_check == selection_node.transformation_handles.is_transforming_content()
 	):
 		pos = _snap_position(pos)
 		if Global.current_project.has_selection and not Tools.is_placing_tiles():

--- a/src/UI/Canvas/Canvas.tscn
+++ b/src/UI/Canvas/Canvas.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3 uid="uid://ba24iuv55m4l3"]
+[gd_scene load_steps=26 format=3 uid="uid://ba24iuv55m4l3"]
 
 [ext_resource type="Script" uid="uid://xagqbybf2bic" path="res://src/UI/Canvas/Canvas.gd" id="1"]
 [ext_resource type="Shader" uid="uid://b3cj543ir4o23" path="res://src/Shaders/BlendLayers.gdshader" id="1_253dh"]
@@ -10,6 +10,7 @@
 [ext_resource type="Script" uid="uid://df031dm6pgp2j" path="res://src/UI/Canvas/Previews.gd" id="7"]
 [ext_resource type="Script" uid="uid://bcxi23cv8j5vr" path="res://src/UI/Canvas/Selection.gd" id="8"]
 [ext_resource type="Shader" uid="uid://droyxrcawbpcn" path="res://src/Shaders/MarchingAntsOutline.gdshader" id="9"]
+[ext_resource type="Script" uid="uid://dtu2ddt5gojeb" path="res://src/UI/Canvas/TransformationHandles.gd" id="10_crpat"]
 [ext_resource type="PackedScene" uid="uid://no3w7e2264u4" path="res://src/UI/Canvas/MouseGuideContainer.tscn" id="11"]
 [ext_resource type="Script" uid="uid://dpem6717iqxdc" path="res://src/UI/Canvas/OnionSkinning.gd" id="12"]
 [ext_resource type="Script" uid="uid://c17sncjk3paec" path="res://src/UI/Canvas/CropRect.gd" id="13"]
@@ -78,6 +79,9 @@ script = ExtResource("2")
 
 [node name="Selection" type="Node2D" parent="."]
 script = ExtResource("8")
+
+[node name="TransformationHandles" type="Node2D" parent="Selection"]
+script = ExtResource("10_crpat")
 
 [node name="MarchingAntsOutline" type="Sprite2D" parent="Selection"]
 material = SubResource("2")

--- a/src/UI/Canvas/Measurements.gd
+++ b/src/UI/Canvas/Measurements.gd
@@ -66,9 +66,9 @@ func _prepare_movement_rect() -> void:
 	var project := Global.current_project
 	if project.has_selection:
 		rect_bounds = canvas.selection.preview_image.get_used_rect()
-		rect_bounds.position += Vector2i(canvas.selection.big_bounding_rectangle.position)
+		rect_bounds.position += Vector2i(project.selection_map.get_selection_rect(project).position)
 		if !rect_bounds.has_area():
-			rect_bounds = canvas.selection.big_bounding_rectangle
+			rect_bounds = project.selection_map.get_selection_rect(project)
 		return
 	if rect_bounds.has_area():
 		return

--- a/src/UI/Canvas/Measurements.gd
+++ b/src/UI/Canvas/Measurements.gd
@@ -65,8 +65,8 @@ func _prepare_cel_rect() -> void:
 func _prepare_movement_rect() -> void:
 	var project := Global.current_project
 	if project.has_selection:
-		rect_bounds = canvas.selection.preview_image.get_used_rect()
-		rect_bounds.position += Vector2i(project.selection_map.get_selection_rect(project).position)
+		rect_bounds = canvas.selection.preview_selection_map.get_used_rect()
+		rect_bounds.position = Vector2i(canvas.selection.transformation_handles.preview_transform.origin)
 		if !rect_bounds.has_area():
 			rect_bounds = project.selection_map.get_selection_rect(project)
 		return

--- a/src/UI/Canvas/Measurements.gd
+++ b/src/UI/Canvas/Measurements.gd
@@ -66,7 +66,9 @@ func _prepare_movement_rect() -> void:
 	var project := Global.current_project
 	if project.has_selection:
 		rect_bounds = canvas.selection.preview_selection_map.get_used_rect()
-		rect_bounds.position = Vector2i(canvas.selection.transformation_handles.preview_transform.origin)
+		rect_bounds.position = Vector2i(
+			canvas.selection.transformation_handles.preview_transform.origin
+		)
 		if !rect_bounds.has_area():
 			rect_bounds = project.selection_map.get_selection_rect(project)
 		return

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -106,13 +106,13 @@ func transform_content_confirm() -> void:
 				continue
 			var tilemap := cel as CelTileMap
 			@warning_ignore("integer_division")
-			var horizontal_size := preview_image.get_width() / tilemap.get_tile_size().x
+			var horizontal_size := selection_rect.size.x / tilemap.get_tile_size().x
 			@warning_ignore("integer_division")
-			var vertical_size := preview_image.get_height() / tilemap.get_tile_size().y
+			var vertical_size := selection_rect.size.y / tilemap.get_tile_size().y
 			var selected_cells := tilemap.resize_selection(
 				transformation_handles.pre_transform_tilemap_cells, horizontal_size, vertical_size
 			)
-			src.crop(preview_image.get_width(), preview_image.get_height())
+			src.crop(selection_rect.size.x, selection_rect.size.y)
 			tilemap.apply_resizing_to_image(src, selected_cells, selection_rect, true)
 		else:
 			transformation_handles.bake_transform_to_image(src, selection_size_rect)

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -172,7 +172,7 @@ func transform_content_confirm() -> void:
 	#project.selection_map.blit_rect_custom(transformed_selection, selection_size_rect, transformation_origin)
 	var selection_rect := project.selection_map.get_selection_rect(project)
 	var selection_size_rect := Rect2i(Vector2i.ZERO, selection_rect.size)
-	for cel in _get_selected_draw_cels():
+	for cel in get_selected_draw_cels():
 		var cel_image := cel.get_image()
 		var src := Image.new()
 		src.copy_from(preview_image)
@@ -218,7 +218,7 @@ func transform_content_cancel() -> void:
 
 	#project.selection_map.copy_from(original_bitmap)
 	project.selection_map_changed()
-	for cel in _get_selected_draw_cels():
+	for cel in get_selected_draw_cels():
 		var cel_image := cel.get_image()
 		if !is_pasting:
 			cel_image.blit_rect_mask(
@@ -273,7 +273,7 @@ func get_undo_data(undo_image: bool) -> Dictionary:
 	data["undo_image"] = undo_image
 
 	if undo_image:
-		Global.current_project.serialize_cel_undo_data(_get_selected_draw_cels(), data)
+		Global.current_project.serialize_cel_undo_data(get_selected_draw_cels(), data)
 	return data
 
 
@@ -286,7 +286,7 @@ func _update_marching_ants() -> void:
 
 # TODO: Change BaseCel to PixelCel if Godot ever fixes issues
 # with typed arrays being cast into other types.
-func _get_selected_draw_cels() -> Array[BaseCel]:
+func get_selected_draw_cels() -> Array[BaseCel]:
 	var cels: Array[BaseCel] = []
 	var project := Global.current_project
 	for cel_index in project.selected_cels:
@@ -321,7 +321,7 @@ func get_enclosed_image() -> Image:
 	if transformation_handles.is_transforming_content():
 		enclosed_img.copy_from(transformation_handles.transformed_image)
 	else:
-		enclosed_img = _get_selected_image(image)
+		enclosed_img = get_selected_image(image)
 	return enclosed_img
 
 
@@ -617,7 +617,7 @@ func _project_switched() -> void:
 	queue_redraw()
 
 
-func _get_selected_image(cel_image: Image) -> Image:
+func get_selected_image(cel_image: Image) -> Image:
 	var project := Global.current_project
 	var selection_rect := project.selection_map.get_selection_rect(project)
 	var image := Image.create(

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -404,7 +404,12 @@ func resize_selection() -> void:
 	var size := resized_rect.size.abs()
 	var scale_amount := Vector2(size) / Vector2(original_preview_image.get_size())
 	var transformation_matrix := Transform2D(angle, Vector2.ZERO).scaled(scale_amount)
-	big_bounding_rectangle = DrawingAlgos.transform_rectangle(original_big_bounding_rectangle, transformation_matrix, original_big_bounding_rectangle.size / 2.0, Vector2(0.5, 0.5))
+	big_bounding_rectangle = DrawingAlgos.transform_rectangle(
+		original_big_bounding_rectangle,
+		transformation_matrix,
+		original_big_bounding_rectangle.size / 2.0,
+		Vector2(0.5, 0.5)
+	)
 	content_pivot = size / 2.0
 	if original_bitmap.is_empty():
 		print("original_bitmap is empty, this shouldn't happen.")
@@ -429,7 +434,9 @@ func resize_selection() -> void:
 		else:
 			var params := {"transformation_matrix": transformation_matrix, "pivot": content_pivot}
 			#preview_image.resize(size.x, size.y, Image.INTERPOLATE_NEAREST)
-			DrawingAlgos.transform_image_with_transform2d(preview_image, transformation_matrix, content_pivot)
+			DrawingAlgos.transform_image_with_transform2d(
+				preview_image, transformation_matrix, content_pivot
+			)
 			if temp_rect.size.x < 0:
 				preview_image.flip_x()
 			if temp_rect.size.y < 0:
@@ -440,24 +447,28 @@ func resize_selection() -> void:
 
 	var bitmap_params := {"transformation_matrix": transformation_matrix, "pivot": content_pivot}
 	#project.selection_map.resize_bitmap_values(
-		#project, size, temp_rect.size.x < 0, temp_rect.size.y < 0
+	#project, size, temp_rect.size.x < 0, temp_rect.size.y < 0
 	#)
 	var transformed_map := Image.new()
 	transformed_map = project.selection_map.get_region(project.selection_map.get_used_rect())
 	project.selection_map.clear()
-	DrawingAlgos.transform_image_with_transform2d(transformed_map, transformation_matrix, content_pivot)
+	DrawingAlgos.transform_image_with_transform2d(
+		transformed_map, transformation_matrix, content_pivot
+	)
 	var dst := big_bounding_rectangle.position
 	if dst.x < 0:
 		dst.x = 0
 	if dst.y < 0:
 		dst.y = 0
 	var new_bitmap_size := project.selection_map.get_size()
-	new_bitmap_size.x = maxi(project.selection_map.get_size().x, absi(big_bounding_rectangle.position.x) + size.x)
-	new_bitmap_size.y = maxi(project.selection_map.get_size().y, absi(big_bounding_rectangle.position.y) + size.y)
-	project.selection_map.crop(new_bitmap_size.x, new_bitmap_size.y)
-	project.selection_map.blit_rect(
-		transformed_map, Rect2i(Vector2i.ZERO, new_bitmap_size), dst
+	new_bitmap_size.x = maxi(
+		project.selection_map.get_size().x, absi(big_bounding_rectangle.position.x) + size.x
 	)
+	new_bitmap_size.y = maxi(
+		project.selection_map.get_size().y, absi(big_bounding_rectangle.position.y) + size.y
+	)
+	project.selection_map.crop(new_bitmap_size.x, new_bitmap_size.y)
+	project.selection_map.blit_rect(transformed_map, Rect2i(Vector2i.ZERO, new_bitmap_size), dst)
 	project.selection_map_changed()
 	queue_redraw()
 	canvas.queue_redraw()

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -351,8 +351,7 @@ func copy() -> void:
 		var selection_rect := project.selection_map.get_selection_rect(project)
 		if transformation_handles.is_transforming_content():
 			to_copy.copy_from(transformation_handles.transformed_image)
-			project.selection_map.move_bitmap_values(project, false)
-			cl_selection_map = project.selection_map
+			cl_selection_map = preview_selection_map
 		else:
 			to_copy = image.get_region(selection_rect)
 			# Remove unincluded pixels if the selection is not a single rectangle

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -10,6 +10,7 @@ const CLIPBOARD_FILE_PATH := "user://clipboard.txt"
 # flags (additional properties of selection that can be toggled)
 var flag_tilemode := false
 
+var undo_data: Dictionary
 var is_moving_content := false:
 	set(value):
 		is_moving_content = value
@@ -17,83 +18,10 @@ var is_moving_content := false:
 var arrow_key_move := false
 var is_pasting := false
 ## The bounding rectangle of the selection. Always has a non-negative size.
-var big_bounding_rectangle := Rect2i():
-	set(value):
-		big_bounding_rectangle = value
-		if value.size == Vector2i(0, 0):
-			set_process_input(false)
-			_set_default_cursor()
-			dragged_gizmo = null
-			Global.can_draw = true
-		else:
-			set_process_input(true)
-		for slot in Tools._slots.values():
-			if slot.tool_node is BaseSelectionTool:
-				slot.tool_node.set_spinbox_values()
-		_update_gizmos()
-var image_current_pixel := Vector2.ZERO  ## The pixel coordinates of the cursor
-
-## Same as [member big_bounding_rectangle], but allows for negative sizes during transformations,
-## to check if the selected content should be flipped.
-var temp_rect := Rect2()
-var rect_aspect_ratio := 0.0
-var temp_rect_pivot := Vector2.ZERO
-## A [Rect2i] that is used during resizing.
-## Together with a transformation matrix constructed by [member angle], it determines the final
-## size of [member big_bounding_rectangle] at the end of the transformation.
-var resized_rect := Rect2i()
-
-var original_big_bounding_rectangle := Rect2i()
-var original_preview_image := Image.new()
-var original_bitmap := SelectionMap.new()
-var original_offset := Vector2.ZERO
-var original_selected_tilemap_cells: Array[Array]
-
-var preview_image := Image.new()
-var preview_image_texture := ImageTexture.new()
-var undo_data: Dictionary
-var gizmos: Array[Gizmo] = []
-var dragged_gizmo: Gizmo = null
-var angle := 0.0
-var rotation_algorithm := DrawingAlgos.RotationAlgorithm.NNS
-var content_pivot := Vector2.ZERO
-var mouse_pos_on_gizmo_drag := Vector2.ZERO
-var resize_keep_ratio := false
 
 @onready var canvas := get_parent() as Canvas
-@onready var marching_ants_outline: Sprite2D = $MarchingAntsOutline
-
-
-class Gizmo:
-	enum Type { SCALE, ROTATE }
-
-	var rect: Rect2
-	var direction := Vector2i.ZERO
-	var type: int
-
-	func _init(_type: int = Type.SCALE, _direction := Vector2i.ZERO) -> void:
-		type = _type
-		direction = _direction
-
-	func get_cursor() -> Input.CursorShape:
-		var cursor := Input.CURSOR_MOVE
-		if direction == Vector2i.ZERO:
-			return Input.CURSOR_POINTING_HAND
-		elif direction == Vector2i(-1, -1) or direction == Vector2i(1, 1):  # Top left or bottom right
-			if Global.mirror_view:
-				cursor = Input.CURSOR_BDIAGSIZE
-			else:
-				cursor = Input.CURSOR_FDIAGSIZE
-		elif direction == Vector2i(1, -1) or direction == Vector2i(-1, 1):  # Top right or bottom left
-			if Global.mirror_view:
-				cursor = Input.CURSOR_FDIAGSIZE
-			else:
-				cursor = Input.CURSOR_BDIAGSIZE
-		elif direction == Vector2i(0, -1) or direction == Vector2i(0, 1):  # Center top or center bottom
-			cursor = Input.CURSOR_VSIZE
-		elif direction == Vector2i(-1, 0) or direction == Vector2i(1, 0):  # Center left or center right
-			cursor = Input.CURSOR_HSIZE
-		return cursor
+@onready var transformation_handles := $TransformationHandles as TransformationHandles
+@onready var marching_ants_outline := $MarchingAntsOutline as Sprite2D
 
 
 func _ready() -> void:
@@ -101,151 +29,62 @@ func _ready() -> void:
 	# It's being set to true only when the big_bounding_rectangle has a size larger than 0
 	set_process_input(false)
 	Global.camera.zoom_changed.connect(_update_on_zoom)
-	gizmos.append(Gizmo.new(Gizmo.Type.SCALE, Vector2i(-1, -1)))  # Top left
-	gizmos.append(Gizmo.new(Gizmo.Type.SCALE, Vector2i(0, -1)))  # Center top
-	gizmos.append(Gizmo.new(Gizmo.Type.SCALE, Vector2i(1, -1)))  # Top right
-	gizmos.append(Gizmo.new(Gizmo.Type.SCALE, Vector2i(1, 0)))  # Center right
-	gizmos.append(Gizmo.new(Gizmo.Type.SCALE, Vector2i(1, 1)))  # Bottom right
-	gizmos.append(Gizmo.new(Gizmo.Type.SCALE, Vector2i(0, 1)))  # Center bottom
-	gizmos.append(Gizmo.new(Gizmo.Type.SCALE, Vector2i(-1, 1)))  # Bottom left
-	gizmos.append(Gizmo.new(Gizmo.Type.SCALE, Vector2i(-1, 0)))  # Center left
-	gizmos.append(Gizmo.new(Gizmo.Type.ROTATE))  # Rotation gizmo (temp)
 
 
-func _input(event: InputEvent) -> void:
-	var project := Global.current_project
-	image_current_pixel = canvas.current_pixel
-	if Global.mirror_view:
-		image_current_pixel.x = Global.current_project.size.x - image_current_pixel.x
-	if is_moving_content:
-		if Input.is_action_just_pressed(&"transformation_confirm"):
-			transform_content_confirm()
-		elif Input.is_action_just_pressed(&"transformation_cancel"):
-			transform_content_cancel()
-	if not project.layers[project.current_layer].can_layer_get_drawn():
-		return
-	if event is InputEventKey:
-		_move_with_arrow_keys(event)
-
-	if not event is InputEventMouse:
-		return
-	var gizmo_hover: Gizmo
-	if big_bounding_rectangle.size != Vector2i.ZERO:
-		for g in gizmos:
-			if g.rect.has_point(image_current_pixel):
-				gizmo_hover = Gizmo.new(g.type, g.direction)
-				break
-
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
-		if event.pressed:
-			if gizmo_hover and not dragged_gizmo:  # Select a gizmo
-				Global.can_draw = false
-				mouse_pos_on_gizmo_drag = image_current_pixel
-				dragged_gizmo = gizmo_hover
-				if Input.is_action_pressed("transform_move_selection_only"):
-					transform_content_confirm()
-				if not is_moving_content:
-					original_bitmap.copy_from(Global.current_project.selection_map)
-					original_big_bounding_rectangle = big_bounding_rectangle
-					if Input.is_action_pressed("transform_move_selection_only"):
-						undo_data = get_undo_data(false)
-						temp_rect = big_bounding_rectangle
-					else:
-						transform_content_start()
-					project.selection_offset = Vector2.ZERO
-				else:
-					var horizontal_flip := signi(temp_rect.size.x)
-					var vertical_flip := signi(temp_rect.size.y)
-					dragged_gizmo.direction.x *= horizontal_flip
-					dragged_gizmo.direction.y *= vertical_flip
-					resized_rect.position = big_bounding_rectangle.position
-					temp_rect = resized_rect
-					# If temp_rect had negative size, switch the position and end points
-					if horizontal_flip < 0:
-						var pos := temp_rect.position.x
-						temp_rect.position.x = temp_rect.end.x
-						temp_rect.end.x = pos
-					if vertical_flip < 0:
-						var pos := temp_rect.position.y
-						temp_rect.position.y = temp_rect.end.y
-						temp_rect.end.y = pos
-				rect_aspect_ratio = absf(temp_rect.size.y / temp_rect.size.x)
-				temp_rect_pivot = temp_rect.get_center()
-
-		elif dragged_gizmo:  # Mouse released, deselect gizmo
-			Global.can_draw = true
-			dragged_gizmo = null
-			if not is_moving_content:
-				original_bitmap = SelectionMap.new()
-				commit_undo("Select", undo_data)
-				angle = 0.0
-
-	if dragged_gizmo:
-		if dragged_gizmo.type == Gizmo.Type.SCALE:
-			_gizmo_resize()
-		else:
-			_gizmo_rotate()
-	else:  # Set the appropriate cursor
-		if gizmo_hover:
-			Input.set_default_cursor_shape(gizmo_hover.get_cursor())
-		else:
-			_set_default_cursor()
+#func _input(event: InputEvent) -> void:
+	#var project := Global.current_project
+	#if is_moving_content:
+		#if event.is_action_pressed(&"transformation_confirm"):
+			#transform_content_confirm()
+		#elif event.is_action_pressed(&"transformation_cancel"):
+			#transform_content_cancel()
+	#if not project.layers[project.current_layer].can_layer_get_drawn():
+		#return
+	#if event is InputEventKey:
+		#_move_with_arrow_keys(event)
 
 
-func _set_default_cursor() -> void:
-	var project := Global.current_project
-	var cursor := Input.CURSOR_ARROW
-	if Global.cross_cursor:
-		cursor = Input.CURSOR_CROSS
-	var layer: BaseLayer = project.layers[project.current_layer]
-	if not layer.can_layer_get_drawn():
-		cursor = Input.CURSOR_FORBIDDEN
-
-	if DisplayServer.cursor_get_shape() != cursor:
-		Input.set_default_cursor_shape(cursor)
-
-
-func _move_with_arrow_keys(event: InputEvent) -> void:
-	var selection_tool_selected := false
-	for slot in Tools._slots.values():
-		if slot.tool_node is BaseSelectionTool:
-			selection_tool_selected = true
-			break
-	if !selection_tool_selected:
-		return
-	if not Global.current_project.has_selection:
-		return
-	if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
-		return
-	if _is_action_direction_pressed(event) and !arrow_key_move:
-		arrow_key_move = true
-		if Input.is_key_pressed(KEY_ALT):
-			transform_content_confirm()
-			move_borders_start()
-		else:
-			transform_content_start()
-	if _is_action_direction_released(event) and arrow_key_move:
-		arrow_key_move = false
-		move_borders_end()
-
-	if _is_action_direction(event) and arrow_key_move:
-		var step := Vector2.ONE
-		if Input.is_key_pressed(KEY_CTRL):
-			step = Global.grids[0].grid_size
-		var input := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
-		var move := input.rotated(snappedf(Global.camera.rotation, PI / 2))
-		# These checks are needed to fix a bug where the selection got stuck
-		# to the canvas boundaries when they were 1px away from them
-		if is_zero_approx(absf(move.x)):
-			move.x = 0
-		if is_zero_approx(absf(move.y)):
-			move.y = 0
-		var final_direction := (move * step).round()
-		if Tools.is_placing_tiles():
-			var tilemap_cel := Global.current_project.get_current_cel() as CelTileMap
-			var grid_size := tilemap_cel.get_tile_size()
-			final_direction *= Vector2(grid_size)
-		move_content(final_direction)
+#func _move_with_arrow_keys(event: InputEvent) -> void:
+	#var selection_tool_selected := false
+	#for slot in Tools._slots.values():
+		#if slot.tool_node is BaseSelectionTool:
+			#selection_tool_selected = true
+			#break
+	#if !selection_tool_selected:
+		#return
+	#if not Global.current_project.has_selection:
+		#return
+	#if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
+		#return
+	#if _is_action_direction_pressed(event) and !arrow_key_move:
+		#arrow_key_move = true
+		#if Input.is_key_pressed(KEY_ALT):
+			#transform_content_confirm()
+			#move_borders_start()
+		#else:
+			#transform_content_start()
+	#if _is_action_direction_released(event) and arrow_key_move:
+		#arrow_key_move = false
+		#move_borders_end()
+#
+	#if _is_action_direction(event) and arrow_key_move:
+		#var step := Vector2.ONE
+		#if Input.is_key_pressed(KEY_CTRL):
+			#step = Global.grids[0].grid_size
+		#var input := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
+		#var move := input.rotated(snappedf(Global.camera.rotation, PI / 2))
+		## These checks are needed to fix a bug where the selection got stuck
+		## to the canvas boundaries when they were 1px away from them
+		#if is_zero_approx(absf(move.x)):
+			#move.x = 0
+		#if is_zero_approx(absf(move.y)):
+			#move.y = 0
+		#var final_direction := (move * step).round()
+		#if Tools.is_placing_tiles():
+			#var tilemap_cel := Global.current_project.get_current_cel() as CelTileMap
+			#var grid_size := tilemap_cel.get_tile_size()
+			#final_direction *= Vector2(grid_size)
+		#move_content(final_direction)
 
 
 ## Check if an event is a ui_up/down/left/right event pressed
@@ -273,50 +112,7 @@ func _is_action_direction_released(event: InputEvent) -> bool:
 
 
 func _draw() -> void:
-	if big_bounding_rectangle.size == Vector2i.ZERO:
-		return
-	var position_tmp := position
-	var scale_tmp := scale
-	if Global.mirror_view:
-		position_tmp.x = position_tmp.x + Global.current_project.size.x
-		scale_tmp.x = -1
-	draw_set_transform(position_tmp, rotation, scale_tmp)
-	for gizmo in gizmos:  # Draw gizmos
-		draw_rect(gizmo.rect, Global.selection_border_color_2)
-		var filled_rect: Rect2 = gizmo.rect
-		var filled_size: Vector2 = gizmo.rect.size * Vector2(0.2, 0.2)
-		filled_rect.position += filled_size
-		filled_rect.size -= filled_size * 2
-		draw_rect(filled_rect, Global.selection_border_color_1)  # Filled white square
-
-	if is_moving_content and !preview_image.is_empty():
-		draw_texture(preview_image_texture, big_bounding_rectangle.position, Color(1, 1, 1, 0.5))
-	draw_set_transform(position, rotation, scale)
-
-
-func _update_gizmos() -> void:
-	var rect_pos: Vector2 = big_bounding_rectangle.position
-	var rect_end: Vector2 = big_bounding_rectangle.end
-	var size: Vector2 = Vector2.ONE / Global.camera.zoom * 10
-	# Clockwise, starting from top-left corner
-	gizmos[0].rect = Rect2(rect_pos - size, size)
-	gizmos[1].rect = Rect2(
-		Vector2((rect_end.x + rect_pos.x - size.x) / 2, rect_pos.y - size.y), size
-	)
-	gizmos[2].rect = Rect2(Vector2(rect_end.x, rect_pos.y - size.y), size)
-	gizmos[3].rect = Rect2(Vector2(rect_end.x, (rect_end.y + rect_pos.y - size.y) / 2), size)
-	gizmos[4].rect = Rect2(rect_end, size)
-	gizmos[5].rect = Rect2(Vector2((rect_end.x + rect_pos.x - size.x) / 2, rect_end.y), size)
-	gizmos[6].rect = Rect2(Vector2(rect_pos.x - size.x, rect_end.y), size)
-	gizmos[7].rect = Rect2(
-		Vector2(rect_pos.x - size.x, (rect_end.y + rect_pos.y - size.y) / 2), size
-	)
-
-	# Rotation gizmo (temp)
-	gizmos[8].rect = Rect2(
-		Vector2((rect_end.x + rect_pos.x - size.x) / 2, rect_pos.y - size.y - (size.y * 2)), size
-	)
-	queue_redraw()
+	transformation_handles.queue_redraw()
 
 
 func _update_on_zoom() -> void:
@@ -327,160 +123,6 @@ func _update_on_zoom() -> void:
 	)
 	marching_ants_outline.material.set_shader_parameter("width", 1.0 / zoom)
 	marching_ants_outline.material.set_shader_parameter("frequency", zoom * 10 * size / 64)
-	for gizmo in gizmos:
-		if gizmo.rect.size == Vector2.ZERO:
-			return
-	_update_gizmos()
-
-
-func _gizmo_resize() -> void:
-	var dir := dragged_gizmo.direction
-	var mouse_pos := image_current_pixel
-	if Tools.is_placing_tiles():
-		var tilemap := Global.current_project.get_current_cel() as CelTileMap
-		if tilemap.get_tile_shape() != TileSet.TILE_SHAPE_SQUARE:
-			return
-		var offset := tilemap.offset % tilemap.get_tile_size()
-		mouse_pos = mouse_pos.snapped(tilemap.get_tile_size()) + Vector2(offset)
-	if Input.is_action_pressed("shape_center"):
-		# Code inspired from https://github.com/GDQuest/godot-open-rpg
-		if dir.x != 0 and dir.y != 0:  # Border gizmos
-			temp_rect.size = ((mouse_pos - temp_rect_pivot) * 2.0 * Vector2(dir))
-		elif dir.y == 0:  # Center left and right gizmos
-			temp_rect.size.x = (mouse_pos.x - temp_rect_pivot.x) * 2.0 * dir.x
-		elif dir.x == 0:  # Center top and bottom gizmos
-			temp_rect.size.y = (mouse_pos.y - temp_rect_pivot.y) * 2.0 * dir.y
-		temp_rect = Rect2(-1.0 * temp_rect.size / 2 + temp_rect_pivot, temp_rect.size)
-	else:
-		_resize_rect(mouse_pos, dir)
-
-	if Input.is_action_pressed("shape_perfect") or resize_keep_ratio:  # Maintain aspect ratio
-		var end_y := temp_rect.end.y
-		if dir == Vector2i(1, -1) or dir.x == 0:  # Top right corner, center top and center bottom
-			var size := temp_rect.size.y
-			# Needed in order for resizing to work properly in negative sizes
-			if signf(size) != signf(temp_rect.size.x):
-				size = absf(size) if temp_rect.size.x > 0 else -absf(size)
-			temp_rect.size.x = size / rect_aspect_ratio
-
-		else:  # The rest of the corners
-			var size := temp_rect.size.x
-			# Needed in order for resizing to work properly in negative sizes
-			if signf(size) != signf(temp_rect.size.y):
-				size = absf(size) if temp_rect.size.y > 0 else -absf(size)
-			temp_rect.size.y = size * rect_aspect_ratio
-
-		# Inspired by the solution answered in https://stackoverflow.com/a/50271547
-		if dir == Vector2i(-1, -1):  # Top left corner
-			temp_rect.position.y = end_y - temp_rect.size.y
-
-	resized_rect = temp_rect.abs()
-	if resized_rect.size.x == 0:
-		resized_rect.size.x = 1
-	if resized_rect.size.y == 0:
-		resized_rect.size.y = 1
-
-	resize_selection()
-
-
-func _resize_rect(pos: Vector2, dir: Vector2) -> void:
-	if dir.x > 0:
-		temp_rect.size.x = pos.x - temp_rect.position.x
-	elif dir.x < 0:
-		var end_x := temp_rect.end.x
-		temp_rect.position.x = pos.x
-		temp_rect.end.x = end_x
-
-	if dir.y > 0:
-		temp_rect.size.y = pos.y - temp_rect.position.y
-	elif dir.y < 0:
-		var end_y := temp_rect.end.y
-		temp_rect.position.y = pos.y
-		temp_rect.end.y = end_y
-
-
-func resize_selection() -> void:
-	var project := Global.current_project
-	var size := resized_rect.size.abs()
-	var scale_amount := Vector2(size) / Vector2(original_preview_image.get_size())
-	var transformation_matrix := Transform2D(angle, Vector2.ZERO).scaled(scale_amount)
-	big_bounding_rectangle = DrawingAlgos.transform_rectangle(
-		original_big_bounding_rectangle,
-		transformation_matrix,
-		original_big_bounding_rectangle.size / 2.0,
-		Vector2(0.5, 0.5)
-	)
-	content_pivot = size / 2.0
-	if original_bitmap.is_empty():
-		print("original_bitmap is empty, this shouldn't happen.")
-	else:
-		project.selection_map.copy_from(original_bitmap)
-	if is_moving_content:
-		preview_image.copy_from(original_preview_image)
-		if Tools.is_placing_tiles():
-			for cel in _get_selected_draw_cels():
-				if cel is not CelTileMap:
-					continue
-				var tilemap := cel as CelTileMap
-				var horizontal_size := size.x / tilemap.get_tile_size().x
-				var vertical_size := size.y / tilemap.get_tile_size().y
-				var selected_cells := tilemap.resize_selection(
-					original_selected_tilemap_cells, horizontal_size, vertical_size
-				)
-				preview_image.crop(size.x, size.y)
-				tilemap.apply_resizing_to_image(
-					preview_image, selected_cells, big_bounding_rectangle, false
-				)
-		else:
-			var params := {"transformation_matrix": transformation_matrix, "pivot": content_pivot}
-			#preview_image.resize(size.x, size.y, Image.INTERPOLATE_NEAREST)
-			DrawingAlgos.transform_image_with_transform2d(
-				preview_image, transformation_matrix, content_pivot
-			)
-			if temp_rect.size.x < 0:
-				preview_image.flip_x()
-			if temp_rect.size.y < 0:
-				preview_image.flip_y()
-		preview_image_texture = ImageTexture.create_from_image(preview_image)
-
-	project.selection_map.copy_from(original_bitmap)
-
-	var bitmap_params := {"transformation_matrix": transformation_matrix, "pivot": content_pivot}
-	#project.selection_map.resize_bitmap_values(
-	#project, size, temp_rect.size.x < 0, temp_rect.size.y < 0
-	#)
-	var transformed_map := Image.new()
-	transformed_map = project.selection_map.get_region(project.selection_map.get_used_rect())
-	project.selection_map.clear()
-	DrawingAlgos.transform_image_with_transform2d(
-		transformed_map, transformation_matrix, content_pivot
-	)
-	var dst := big_bounding_rectangle.position
-	if dst.x < 0:
-		dst.x = 0
-	if dst.y < 0:
-		dst.y = 0
-	var new_bitmap_size := project.selection_map.get_size()
-	new_bitmap_size.x = maxi(
-		project.selection_map.get_size().x, absi(big_bounding_rectangle.position.x) + size.x
-	)
-	new_bitmap_size.y = maxi(
-		project.selection_map.get_size().y, absi(big_bounding_rectangle.position.y) + size.y
-	)
-	project.selection_map.crop(new_bitmap_size.x, new_bitmap_size.y)
-	project.selection_map.blit_rect(transformed_map, Rect2i(Vector2i.ZERO, new_bitmap_size), dst)
-	project.selection_map_changed()
-	queue_redraw()
-	canvas.queue_redraw()
-
-
-func _gizmo_rotate() -> void:
-	if Tools.is_placing_tiles():
-		return
-	var pivot_in_world_coords := content_pivot + Vector2(big_bounding_rectangle.position)
-	angle = image_current_pixel.angle_to_point(pivot_in_world_coords) - PI / 2
-	angle = snappedf(angle, PI / 64)
-	resize_selection()
 
 
 func select_rect(rect: Rect2i, operation := SelectionOperation.ADD) -> void:
@@ -488,15 +130,14 @@ func select_rect(rect: Rect2i, operation := SelectionOperation.ADD) -> void:
 	# Used only if the selection is outside of the canvas boundaries,
 	# on the left and/or above (negative coords)
 	var offset_position := Vector2i.ZERO
-	if big_bounding_rectangle.position.x < 0:
-		rect.position.x -= big_bounding_rectangle.position.x
-		offset_position.x = big_bounding_rectangle.position.x
-	if big_bounding_rectangle.position.y < 0:
-		rect.position.y -= big_bounding_rectangle.position.y
-		offset_position.y = big_bounding_rectangle.position.y
+	if project.selection_offset.x < 0:
+		rect.position.x -= project.selection_offset.x
+		offset_position.x = project.selection_offset.x
+	if project.selection_offset.y < 0:
+		rect.position.y -= project.selection_offset.y
+		offset_position.y = project.selection_offset.y
 
 	if offset_position != Vector2i.ZERO:
-		big_bounding_rectangle.position -= offset_position
 		project.selection_map.move_bitmap_values(project)
 
 	if operation == SelectionOperation.ADD:
@@ -515,75 +156,9 @@ func select_rect(rect: Rect2i, operation := SelectionOperation.ADD) -> void:
 				project.selection_map.select_pixel(
 					pos, previous_selection_map.is_pixel_selected(pos, false)
 				)
-	big_bounding_rectangle = project.selection_map.get_used_rect()
 
-	if offset_position != Vector2i.ZERO and big_bounding_rectangle.get_area() != 0:
-		big_bounding_rectangle.position += offset_position
+	if offset_position != Vector2i.ZERO and project.has_selection:
 		project.selection_map.move_bitmap_values(project)
-
-	big_bounding_rectangle = big_bounding_rectangle  # call getter method
-
-
-func move_borders_start() -> void:
-	undo_data = get_undo_data(false)
-	content_pivot = original_big_bounding_rectangle.size / 2.0
-
-
-func move_borders(move: Vector2i) -> void:
-	if move == Vector2i.ZERO:
-		return
-	marching_ants_outline.offset += Vector2(move)
-	big_bounding_rectangle.position += move
-	if Tools.is_placing_tiles():
-		var grid_size := (Global.current_project.get_current_cel() as CelTileMap).get_tile_size()
-		marching_ants_outline.offset = Tools.snap_to_rectangular_grid_boundary(
-			marching_ants_outline.offset, grid_size
-		)
-		big_bounding_rectangle.position = Vector2i(
-			Tools.snap_to_rectangular_grid_boundary(big_bounding_rectangle.position, grid_size)
-		)
-	queue_redraw()
-
-
-func move_borders_end() -> void:
-	Global.current_project.selection_map.move_bitmap_values(Global.current_project)
-	if not is_moving_content:
-		commit_undo("Select", undo_data)
-	else:
-		Global.current_project.selection_map_changed()
-	queue_redraw()
-	canvas.queue_redraw()
-
-
-func transform_content_start() -> void:
-	if is_moving_content:
-		return
-	var project := Global.current_project
-	var current_cel := project.get_current_cel()
-	if current_cel is CelTileMap and Tools.is_placing_tiles():
-		if current_cel.get_tile_shape() != TileSet.TILE_SHAPE_SQUARE:
-			undo_data = get_undo_data(false)
-			return
-		original_selected_tilemap_cells = (current_cel as CelTileMap).get_selected_cells(
-			project.selection_map, big_bounding_rectangle
-		)
-	undo_data = get_undo_data(true)
-	temp_rect = big_bounding_rectangle
-	resized_rect = big_bounding_rectangle
-	_get_preview_image()
-	if original_preview_image.is_empty():
-		undo_data = get_undo_data(false)
-		return
-	is_moving_content = true
-	original_bitmap.copy_from(project.selection_map)
-	original_big_bounding_rectangle = big_bounding_rectangle
-	original_offset = project.selection_offset
-	queue_redraw()
-	canvas.queue_redraw()
-
-
-func move_content(move: Vector2) -> void:
-	move_borders(move)
 
 
 func transform_content_confirm() -> void:
@@ -645,7 +220,6 @@ func transform_content_confirm() -> void:
 	original_selected_tilemap_cells.clear()
 	is_moving_content = false
 	is_pasting = false
-	angle = 0.0
 	queue_redraw()
 	canvas.queue_redraw()
 
@@ -768,9 +342,6 @@ func get_enclosed_image() -> Image:
 	var enclosed_img := Image.new()
 	if is_moving_content:
 		enclosed_img.copy_from(preview_image)
-		var selection_map_copy := SelectionMap.new()
-		selection_map_copy.copy_from(project.selection_map)
-		selection_map_copy.move_bitmap_values(project, false)
 	else:
 		enclosed_img = _get_selected_image(image)
 	return enclosed_img

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -163,7 +163,7 @@ func transform_content_confirm() -> void:
 	var project := Global.current_project
 	var preview_image := transformation_handles.transformed_image
 	transformation_handles.bake_transform_to_selection(project.selection_map)
-	#var matrix := transformation_handles.preview_transform
+	var matrix := transformation_handles.preview_transform
 	#var transformed_selection := SelectionMap.new()
 	#transformed_selection.copy_from(transformation_handles.transformed_selection_map)
 	#var transformation_origin := DrawingAlgos.get_transformed_bounds(transformed_selection.get_size(), matrix).position.ceil()
@@ -176,8 +176,10 @@ func transform_content_confirm() -> void:
 		var cel_image := cel.get_image()
 		var src := Image.new()
 		src.copy_from(preview_image)
+		var transformation_origin := DrawingAlgos.get_transformed_bounds(src.get_size(), matrix).position.ceil()
 		if not is_pasting:
 			src.copy_from(cel.transformed_content)
+			transformation_origin = DrawingAlgos.get_transformed_bounds(src.get_size(), matrix).position.ceil()
 			cel.transformed_content = null
 			if Tools.is_placing_tiles():
 				if cel is not CelTileMap:
@@ -191,14 +193,14 @@ func transform_content_confirm() -> void:
 				#src.crop(preview_image.get_width(), preview_image.get_height())
 				#tilemap.apply_resizing_to_image(src, selected_cells, selection_rect, true)
 			else:
-				transformation_handles.bake_transform_to_image(src)
+				transformation_handles.bake_transform_to_image(src, selection_size_rect)
 
 		if Tools.is_placing_tiles():
 			if cel.get_tile_shape() != TileSet.TILE_SHAPE_SQUARE:
 				continue
-			cel_image.blit_rect(src, selection_size_rect, selection_rect.position)
+			cel_image.blit_rect(src, selection_size_rect, transformation_origin)
 		else:
-			cel_image.blit_rect_mask(src, src, selection_size_rect, selection_rect.position)
+			cel_image.blit_rect_mask(src, src, selection_size_rect, transformation_origin)
 		cel_image.convert_rgb_to_indexed()
 	project.selection_map_changed()
 	commit_undo("Move Selection", undo_data)

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -419,7 +419,10 @@ func delete(selected_cels := true) -> void:
 	if !project.layers[project.current_layer].can_layer_get_drawn():
 		return
 	if transformation_handles.is_transforming_content():
-		if transformation_handles.transformed_image.is_empty() or transformation_handles.transformed_image.is_invisible():
+		if (
+			transformation_handles.transformed_image.is_empty()
+			or transformation_handles.transformed_image.is_invisible()
+		):
 			transform_content_confirm()
 		else:
 			transformation_handles.reset_transform()

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -2,14 +2,12 @@ class_name SelectionNode
 extends Node2D
 
 enum SelectionOperation { ADD, SUBTRACT, INTERSECT }
-const KEY_MOVE_ACTION_NAMES: PackedStringArray = [&"ui_up", &"ui_down", &"ui_left", &"ui_right"]
 const CLIPBOARD_FILE_PATH := "user://clipboard.txt"
 
 # flags (additional properties of selection that can be toggled)
 var flag_tilemode := false
 
 var undo_data: Dictionary
-var arrow_key_move := false
 var is_pasting := false
 
 var preview_selection_map := SelectionMap.new()
@@ -28,83 +26,11 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
-	#var project := Global.current_project
 	if transformation_handles.is_transforming_content():
 		if event.is_action_pressed(&"transformation_confirm"):
 			transform_content_confirm()
 		elif event.is_action_pressed(&"transformation_cancel"):
 			transform_content_cancel()
-	#if not project.layers[project.current_layer].can_layer_get_drawn():
-		#return
-	#if event is InputEventKey:
-		#_move_with_arrow_keys(event)
-
-
-#func _move_with_arrow_keys(event: InputEvent) -> void:
-	#var selection_tool_selected := false
-	#for slot in Tools._slots.values():
-		#if slot.tool_node is BaseSelectionTool:
-			#selection_tool_selected = true
-			#break
-	#if !selection_tool_selected:
-		#return
-	#if not Global.current_project.has_selection:
-		#return
-	#if !Global.current_project.layers[Global.current_project.current_layer].can_layer_get_drawn():
-		#return
-	#if _is_action_direction_pressed(event) and !arrow_key_move:
-		#arrow_key_move = true
-		#if Input.is_key_pressed(KEY_ALT):
-			#transform_content_confirm()
-			#move_borders_start()
-		#else:
-			#transformation_handles.begin_transform()
-	#if _is_action_direction_released(event) and arrow_key_move:
-		#arrow_key_move = false
-		#move_borders_end()
-#
-	#if _is_action_direction(event) and arrow_key_move:
-		#var step := Vector2.ONE
-		#if Input.is_key_pressed(KEY_CTRL):
-			#step = Global.grids[0].grid_size
-		#var input := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
-		#var move := input.rotated(snappedf(Global.camera.rotation, PI / 2))
-		## These checks are needed to fix a bug where the selection got stuck
-		## to the canvas boundaries when they were 1px away from them
-		#if is_zero_approx(absf(move.x)):
-			#move.x = 0
-		#if is_zero_approx(absf(move.y)):
-			#move.y = 0
-		#var final_direction := (move * step).round()
-		#if Tools.is_placing_tiles():
-			#var tilemap_cel := Global.current_project.get_current_cel() as CelTileMap
-			#var grid_size := tilemap_cel.get_tile_size()
-			#final_direction *= Vector2(grid_size)
-		#transformation_handles.move(pos - _offset)(final_direction)
-
-
-## Check if an event is a ui_up/down/left/right event pressed
-func _is_action_direction_pressed(event: InputEvent) -> bool:
-	for action in KEY_MOVE_ACTION_NAMES:
-		if event.is_action_pressed(action, false, true):
-			return true
-	return false
-
-
-## Check if an event is a ui_up/down/left/right event
-func _is_action_direction(event: InputEvent) -> bool:
-	for action in KEY_MOVE_ACTION_NAMES:
-		if event.is_action(action, true):
-			return true
-	return false
-
-
-## Check if an event is a ui_up/down/left/right event release
-func _is_action_direction_released(event: InputEvent) -> bool:
-	for action in KEY_MOVE_ACTION_NAMES:
-		if event.is_action_released(action, true):
-			return true
-	return false
 
 
 func _draw() -> void:

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -420,7 +420,7 @@ func delete(selected_cels := true) -> void:
 	if !project.layers[project.current_layer].can_layer_get_drawn():
 		return
 	if transformation_handles.is_transforming_content():
-		if transformation_handles.transformed_image.is_empty():
+		if transformation_handles.transformed_image.is_empty() or transformation_handles.transformed_image.is_invisible():
 			transform_content_confirm()
 		else:
 			transformation_handles.reset_transform()

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -176,24 +176,23 @@ func transform_content_confirm() -> void:
 		var cel_image := cel.get_image()
 		var src := Image.new()
 		src.copy_from(preview_image)
-		var transformation_origin := transformation_handles.get_transform_top_left(src.get_size())
 		if not is_pasting:
 			src.copy_from(cel.transformed_content)
-			transformation_origin = transformation_handles.get_transform_top_left(src.get_size())
 			cel.transformed_content = null
-			if Tools.is_placing_tiles():
-				if cel is not CelTileMap:
-					continue
-				#var tilemap := cel as CelTileMap
-				#var horizontal_size := preview_image.get_width() / tilemap.get_tile_size().x
-				#var vertical_size := preview_image.get_height() / tilemap.get_tile_size().y
-				#var selected_cells := tilemap.resize_selection(
-					#original_selected_tilemap_cells, horizontal_size, vertical_size
-				#)
-				#src.crop(preview_image.get_width(), preview_image.get_height())
-				#tilemap.apply_resizing_to_image(src, selected_cells, selection_rect, true)
-			else:
-				transformation_handles.bake_transform_to_image(src, selection_size_rect)
+		var transformation_origin := transformation_handles.get_transform_top_left(src.get_size())
+		if Tools.is_placing_tiles():
+			if cel is not CelTileMap:
+				continue
+			#var tilemap := cel as CelTileMap
+			#var horizontal_size := preview_image.get_width() / tilemap.get_tile_size().x
+			#var vertical_size := preview_image.get_height() / tilemap.get_tile_size().y
+			#var selected_cells := tilemap.resize_selection(
+				#original_selected_tilemap_cells, horizontal_size, vertical_size
+			#)
+			#src.crop(preview_image.get_width(), preview_image.get_height())
+			#tilemap.apply_resizing_to_image(src, selected_cells, selection_rect, true)
+		else:
+			transformation_handles.bake_transform_to_image(src, selection_size_rect)
 
 		if Tools.is_placing_tiles():
 			if cel.get_tile_shape() != TileSet.TILE_SHAPE_SQUARE:
@@ -457,8 +456,8 @@ func paste(in_place := false) -> void:
 			#)
 
 	is_pasting = true
-	transformation_handles.begin_transform(clipboard.image)
 	project.selection_map_changed()
+	transformation_handles.begin_transform(clipboard.image)
 
 
 func paste_from_clipboard() -> void:
@@ -489,9 +488,9 @@ func paste_from_clipboard() -> void:
 
 	project.selection_map.copy_from(clip_map)
 	project.selection_map.crop(max_size.x, max_size.y)
+	project.selection_map_changed()
 	transformation_handles.begin_transform(clipboard_image)
 	is_pasting = true
-	project.selection_map_changed()
 
 
 ## Deletes the drawing enclosed within the selection's area.

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -89,13 +89,6 @@ func transform_content_confirm() -> void:
 	var project := Global.current_project
 	var preview_image := transformation_handles.pre_transformed_image
 	transformation_handles.bake_transform_to_selection(project.selection_map)
-	var matrix := transformation_handles.preview_transform
-	#var transformed_selection := SelectionMap.new()
-	#transformed_selection.copy_from(transformation_handles.transformed_selection_map)
-	#var transformation_origin := DrawingAlgos.get_transformed_bounds(transformed_selection.get_size(), matrix).position.ceil()
-	#transformation_handles.bake_transform_to_image(transformed_selection)
-	#var selection_size_rect := Rect2i(Vector2i.ZERO, transformed_selection.get_size())
-	#project.selection_map.blit_rect_custom(transformed_selection, selection_size_rect, transformation_origin)
 	var selection_rect := project.selection_map.get_selection_rect(project)
 	var selection_size_rect := Rect2i(Vector2i.ZERO, selection_rect.size)
 	for cel in get_selected_draw_cels():
@@ -103,6 +96,8 @@ func transform_content_confirm() -> void:
 		var src := Image.new()
 		src.copy_from(preview_image)
 		if not is_pasting:
+			if not is_instance_valid(cel.transformed_content):
+				continue
 			src.copy_from(cel.transformed_content)
 			cel.transformed_content = null
 		var transformation_origin := transformation_handles.get_transform_top_left(src.get_size())
@@ -544,10 +539,10 @@ func _project_switched() -> void:
 
 func get_selected_image(cel_image: Image) -> Image:
 	var project := Global.current_project
-	var selection_rect := project.selection_map.get_selection_rect(project)
+	var selection_map_copy := project.selection_map.return_cropped_copy(project, project.size)
+	var selection_rect := selection_map_copy.get_selection_rect(project)
 	var image := Image.create(
 		selection_rect.size.x, selection_rect.size.y, false, project.get_image_format()
 	)
-	var selection_map_copy := project.selection_map.return_cropped_copy(project, project.size)
 	image.blit_rect_mask(cel_image, selection_map_copy, selection_rect, Vector2i.ZERO)
 	return image

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -515,7 +515,7 @@ func delete(selected_cels := true) -> void:
 
 	if project.has_selection:
 		var blank := project.new_empty_image()
-		var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
+		var selection_map_copy := project.selection_map.return_cropped_copy(project, project.size)
 		var selection_rect := project.selection_map.get_selection_rect(project)
 		for image in images:
 			image.blit_rect_mask(blank, selection_map_copy, selection_rect, selection_rect.position)
@@ -622,6 +622,6 @@ func _get_selected_image(cel_image: Image) -> Image:
 	var image := Image.create(
 		selection_rect.size.x, selection_rect.size.y, false, project.get_image_format()
 	)
-	var selection_map_copy := project.selection_map.return_cropped_copy(project.size)
+	var selection_map_copy := project.selection_map.return_cropped_copy(project, project.size)
 	image.blit_rect_mask(cel_image, selection_map_copy, selection_rect, Vector2i.ZERO)
 	return image

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -391,6 +391,7 @@ func paste_from_clipboard() -> void:
 	undo_data = get_undo_data(true)
 	clear_selection()
 	var project := Global.current_project
+	clipboard_image.convert(project.get_image_format())
 	var clip_map := SelectionMap.new()
 	clip_map.copy_from(
 		Image.create(

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -420,11 +420,16 @@ func delete(selected_cels := true) -> void:
 	if !project.layers[project.current_layer].can_layer_get_drawn():
 		return
 	if transformation_handles.is_transforming_content():
-		transformation_handles.reset_transform()
-		is_pasting = false
-		queue_redraw()
-		commit_undo("Draw", undo_data)
-		return
+		if transformation_handles.transformed_image.is_empty():
+			transform_content_confirm()
+		else:
+			transformation_handles.reset_transform()
+			clear_selection()
+			transformation_handles.set_selection(null, Rect2())
+			is_pasting = false
+			queue_redraw()
+			commit_undo("Draw", undo_data)
+			return
 
 	var undo_data_tmp := get_undo_data(true)
 	var images: Array[ImageExtended]
@@ -436,7 +441,7 @@ func delete(selected_cels := true) -> void:
 	if project.has_selection:
 		var blank := project.new_empty_image()
 		var selection_map_copy := project.selection_map.return_cropped_copy(project, project.size)
-		var selection_rect := project.selection_map.get_selection_rect(project)
+		var selection_rect := selection_map_copy.get_used_rect()
 		for image in images:
 			image.blit_rect_mask(blank, selection_map_copy, selection_rect, selection_rect.position)
 			image.convert_rgb_to_indexed()
@@ -444,6 +449,7 @@ func delete(selected_cels := true) -> void:
 		for image in images:
 			image.fill(0)
 			image.convert_rgb_to_indexed()
+	clear_selection()
 	commit_undo("Draw", undo_data_tmp)
 
 

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -422,7 +422,7 @@ func paste(in_place := false) -> void:
 	project.selection_map.crop(max_size.x, max_size.y)
 	var selection_rect := project.selection_map.get_selection_rect(project)
 	project.selection_offset = clipboard.selection_offset
-	#big_bounding_rectangle = clipboard.big_bounding_rectangle
+	var transform_origin: Vector2 = clipboard.big_bounding_rectangle.position
 	if not in_place:  # If "Paste" is selected, and not "Paste in Place"
 		var camera_center := Global.camera.camera_screen_center
 		camera_center -= Vector2(selection_rect.size) / 2.0
@@ -435,13 +435,13 @@ func paste(in_place := false) -> void:
 			camera_center.y = clampf(camera_center.y, 0, max_pos.y)
 		else:
 			camera_center.y = 0
-		#big_bounding_rectangle.position = Vector2i(camera_center.floor())
+		transform_origin = Vector2i(camera_center.floor())
 		if Tools.is_placing_tiles():
 			var tilemap_cel := Global.current_project.get_current_cel() as CelTileMap
 			var grid_size := tilemap_cel.get_tile_size()
-			#big_bounding_rectangle.position = Vector2i(
-				#Tools.snap_to_rectangular_grid_boundary(big_bounding_rectangle.position, grid_size)
-			#)
+			transform_origin = Vector2i(
+				Tools.snap_to_rectangular_grid_boundary(transform_origin, grid_size)
+			)
 		project.selection_map.move_bitmap_values(Global.current_project, false)
 	else:
 		if Tools.is_placing_tiles():
@@ -450,13 +450,14 @@ func paste(in_place := false) -> void:
 			project.selection_offset = Tools.snap_to_rectangular_grid_boundary(
 				project.selection_offset, grid_size
 			)
-			#big_bounding_rectangle.position = Vector2i(
-				#Tools.snap_to_rectangular_grid_boundary(big_bounding_rectangle.position, grid_size)
-			#)
+			transform_origin = Vector2i(
+				Tools.snap_to_rectangular_grid_boundary(transform_origin, grid_size)
+			)
 
 	is_pasting = true
 	project.selection_map_changed()
 	transformation_handles.begin_transform(clipboard.image)
+	transformation_handles.preview_transform.origin = transform_origin
 
 
 func paste_from_clipboard() -> void:

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -124,7 +124,6 @@ func transform_content_confirm() -> void:
 		else:
 			cel_image.blit_rect_mask(src, src, selection_size_rect, transformation_origin)
 		cel_image.convert_rgb_to_indexed()
-	project.selection_map_changed()
 	commit_undo("Move Selection", undo_data)
 
 	is_pasting = false
@@ -137,8 +136,6 @@ func transform_content_cancel() -> void:
 		return
 	var project := Global.current_project
 	project.selection_offset = transformation_handles.pre_transform_selection_offset
-
-	#project.selection_map.copy_from(original_bitmap)
 	project.selection_map_changed()
 	for cel in get_selected_draw_cels():
 		var cel_image := cel.get_image()

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -404,7 +404,7 @@ func resize_selection() -> void:
 	var size := resized_rect.size.abs()
 	var scale_amount := Vector2(size) / Vector2(original_preview_image.get_size())
 	var transformation_matrix := Transform2D(angle, Vector2.ZERO).scaled(scale_amount)
-	big_bounding_rectangle = DrawingAlgos.transform_rectangle(original_big_bounding_rectangle, transformation_matrix)
+	big_bounding_rectangle = DrawingAlgos.transform_rectangle(original_big_bounding_rectangle, transformation_matrix, original_big_bounding_rectangle.size / 2.0, Vector2(0.5, 0.5))
 	content_pivot = size / 2.0
 	if original_bitmap.is_empty():
 		print("original_bitmap is empty, this shouldn't happen.")

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -104,14 +104,16 @@ func transform_content_confirm() -> void:
 		if Tools.is_placing_tiles():
 			if cel is not CelTileMap:
 				continue
-			#var tilemap := cel as CelTileMap
-			#var horizontal_size := preview_image.get_width() / tilemap.get_tile_size().x
-			#var vertical_size := preview_image.get_height() / tilemap.get_tile_size().y
-			#var selected_cells := tilemap.resize_selection(
-				#original_selected_tilemap_cells, horizontal_size, vertical_size
-			#)
-			#src.crop(preview_image.get_width(), preview_image.get_height())
-			#tilemap.apply_resizing_to_image(src, selected_cells, selection_rect, true)
+			var tilemap := cel as CelTileMap
+			@warning_ignore("integer_division")
+			var horizontal_size := preview_image.get_width() / tilemap.get_tile_size().x
+			@warning_ignore("integer_division")
+			var vertical_size := preview_image.get_height() / tilemap.get_tile_size().y
+			var selected_cells := tilemap.resize_selection(
+				transformation_handles.pre_transform_tilemap_cells, horizontal_size, vertical_size
+			)
+			src.crop(preview_image.get_width(), preview_image.get_height())
+			tilemap.apply_resizing_to_image(src, selected_cells, selection_rect, true)
 		else:
 			transformation_handles.bake_transform_to_image(src, selection_size_rect)
 

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -161,7 +161,7 @@ func transform_content_confirm() -> void:
 	if not transformation_handles.is_transforming_content():
 		return
 	var project := Global.current_project
-	var preview_image := transformation_handles.transformed_image
+	var preview_image := transformation_handles.pre_transformed_image
 	transformation_handles.bake_transform_to_selection(project.selection_map)
 	var matrix := transformation_handles.preview_transform
 	#var transformed_selection := SelectionMap.new()
@@ -176,10 +176,10 @@ func transform_content_confirm() -> void:
 		var cel_image := cel.get_image()
 		var src := Image.new()
 		src.copy_from(preview_image)
-		var transformation_origin := DrawingAlgos.get_transformed_bounds(src.get_size(), matrix).position.ceil()
+		var transformation_origin := transformation_handles.get_transform_top_left(src.get_size())
 		if not is_pasting:
 			src.copy_from(cel.transformed_content)
-			transformation_origin = DrawingAlgos.get_transformed_bounds(src.get_size(), matrix).position.ceil()
+			transformation_origin = transformation_handles.get_transform_top_left(src.get_size())
 			cel.transformed_content = null
 			if Tools.is_placing_tiles():
 				if cel is not CelTileMap:

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -58,7 +58,7 @@ func _input(event: InputEvent) -> void:
 			#transform_content_confirm()
 			#move_borders_start()
 		#else:
-			#transform_content_start()
+			#transformation_handles.begin_transform()
 	#if _is_action_direction_released(event) and arrow_key_move:
 		#arrow_key_move = false
 		#move_borders_end()
@@ -80,7 +80,7 @@ func _input(event: InputEvent) -> void:
 			#var tilemap_cel := Global.current_project.get_current_cel() as CelTileMap
 			#var grid_size := tilemap_cel.get_tile_size()
 			#final_direction *= Vector2(grid_size)
-		#move_content(final_direction)
+		#transformation_handles.move(pos - _offset)(final_direction)
 
 
 ## Check if an event is a ui_up/down/left/right event pressed

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -546,7 +546,7 @@ func _project_switched() -> void:
 func get_selected_image(cel_image: Image) -> Image:
 	var project := Global.current_project
 	var selection_map_copy := project.selection_map.return_cropped_copy(project, project.size)
-	var selection_rect := selection_map_copy.get_selection_rect(project)
+	var selection_rect := selection_map_copy.get_used_rect()
 	var image := Image.create(
 		selection_rect.size.x, selection_rect.size.y, false, project.get_image_format()
 	)

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -8,6 +8,7 @@ const RS_HANDLE_DISTANCE := 2
 const KEY_MOVE_ACTION_NAMES: PackedStringArray = [&"ui_up", &"ui_down", &"ui_left", &"ui_right"]
 
 var arrow_key_move := false
+var only_transforms_selection := false
 var transformed_selection_map: SelectionMap:
 	set(value):
 		transformed_selection_map = value
@@ -189,10 +190,6 @@ func _move_with_arrow_keys(event: InputEvent) -> void:
 		return
 	if _is_action_direction_pressed(event) and !arrow_key_move:
 		arrow_key_move = true
-		#if Input.is_key_pressed(KEY_ALT):
-			#transform_content_confirm()
-			#move_borders_start()
-		#else:
 		begin_transform()
 	if _is_action_direction_released(event) and arrow_key_move:
 		arrow_key_move = false
@@ -482,6 +479,13 @@ func set_selection(selection_map: SelectionMap, selection_rect: Rect2i) -> void:
 
 
 func begin_transform(image: Image = null, project := Global.current_project) -> void:
+	if Input.is_action_pressed(&"transform_move_selection_only"):
+		only_transforms_selection = true
+		return
+	else:
+		if only_transforms_selection:
+			selection_node.transform_content_confirm()
+			only_transforms_selection = false
 	if not pre_transformed_image.is_empty():
 		return
 	if is_instance_valid(image):

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -265,7 +265,9 @@ func _is_action_direction_released(event: InputEvent) -> bool:
 	return false
 
 
-func clamp_transform_image_space(t: Transform2D, image_size: Vector2, min_pixels := 1.0) -> Transform2D:
+func clamp_transform_image_space(
+	t: Transform2D, image_size: Vector2, min_pixels := 1.0
+) -> Transform2D:
 	var bounds := DrawingAlgos.get_transformed_bounds(image_size, t)
 	var width := bounds.size.x
 	var height := bounds.size.y
@@ -304,9 +306,7 @@ func _on_preview_transform_changed() -> void:
 					pre_transform_tilemap_cells, horizontal_size, vertical_size
 				)
 				transformed_image.crop(bounds.size.x, bounds.size.y)
-				tilemap.apply_resizing_to_image(
-					transformed_image, selected_cells, bounds, false
-				)
+				tilemap.apply_resizing_to_image(transformed_image, selected_cells, bounds, false)
 		else:
 			bounds.position -= bounds.position
 			bake_transform_to_image(transformed_image, bounds)
@@ -362,7 +362,9 @@ func transform_around(t: Transform2D, m: Transform2D, pivot_local: Vector2) -> T
 	return back * m * to_origin * t
 
 
-func get_no_pivot_transform(pivot_transform := preview_transform, pivot_local := pivot) -> Transform2D:
+func get_no_pivot_transform(
+	pivot_transform := preview_transform, pivot_local := pivot
+) -> Transform2D:
 	var pivot_world := pivot_transform * pivot_local
 	var to_origin := Transform2D(Vector2(1, 0), Vector2(0, 1), -pivot_world)
 	var back := Transform2D(Vector2(1, 0), Vector2(0, 1), pivot_world)
@@ -519,7 +521,7 @@ func angle_to_cursor(angle: float) -> Input.CursorShape:
 	if deg < 337.5:
 		if Global.mirror_view:
 			return Input.CURSOR_FDIAGSIZE
-		return Input.CURSOR_BDIAGSIZE # Top-right
+		return Input.CURSOR_BDIAGSIZE  # Top-right
 
 	return Input.CURSOR_ARROW
 
@@ -622,7 +624,9 @@ func bake_transform_to_image(image: Image, used_rect := Rect2i()) -> void:
 
 
 func bake_transform_to_selection(map: SelectionMap) -> void:
-	var bounds := DrawingAlgos.get_transformed_bounds(transformed_selection_map.get_size(), preview_transform)
+	var bounds := DrawingAlgos.get_transformed_bounds(
+		transformed_selection_map.get_size(), preview_transform
+	)
 	map.ensure_selection_fits(Global.current_project, bounds)
 	bounds.position -= bounds.position
 	var transformed_selection := SelectionMap.new()

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -386,6 +386,13 @@ func move(pos: Vector2) -> void:
 	queue_redraw()
 
 
+## Called by the sliders in the selection tool options.
+func resize(delta: Vector2) -> void:
+	var bottom_right_handle := handles[5]
+	preview_transform = apply_resize(preview_transform, bottom_right_handle, delta)
+	queue_redraw()
+
+
 func apply_resize(t: Transform2D, handle: TransformHandle, delta: Vector2) -> Transform2D:
 	if Tools.is_placing_tiles():
 		var tilemap := Global.current_project.get_current_cel() as CelTileMap

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -213,6 +213,8 @@ func _circle_to_square(center: Vector2, radius: Vector2) -> Rect2:
 
 
 func is_transforming_content() -> bool:
+	if selection_node.is_pasting:
+		return true
 	return preview_transform != original_selection_transform
 
 
@@ -407,6 +409,8 @@ func begin_transform(image: Image = null, project := Global.current_project) -> 
 		return
 	if is_instance_valid(image):
 		pre_transformed_image = image
+		transformed_image.copy_from(pre_transformed_image)
+		image_texture.set_image(transformed_image)
 		return
 	var blended_image := project.new_empty_image()
 	DrawingAlgos.blend_layers(
@@ -449,11 +453,6 @@ func reset_transform() -> void:
 
 
 func get_transform_top_left(size := transformed_selection_map.get_size()) -> Vector2:
-	var move_to_origin := Transform2D(Vector2(1, 0), Vector2(0, 1), -pivot)
-	var move_back := Transform2D(Vector2(1, 0), Vector2(0, 1), pivot)  # move pivot back
-	var full_transform := move_back * preview_transform * move_to_origin
-
-	# Estimate new bounding box
 	var bounds := DrawingAlgos.get_transformed_bounds(size, preview_transform)
 	return bounds.position.ceil()
 

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -571,6 +571,7 @@ func set_selection(selection_map: SelectionMap, selection_rect: Rect2i) -> void:
 	queue_redraw()
 
 
+## Called when a transformation begins to happen.
 func begin_transform(
 	image: Image = null,
 	project := Global.current_project,
@@ -658,7 +659,7 @@ func get_transform_top_left(size := transformed_selection_map.get_size()) -> Vec
 
 
 func bake_transform_to_image(image: Image, used_rect := Rect2i()) -> void:
-	DrawingAlgos.transform_image_with_transform2d(image, preview_transform, pivot, used_rect)
+	DrawingAlgos.transform_image_with_viewport(image, preview_transform, pivot, used_rect)
 
 
 func bake_transform_to_selection(map: SelectionMap) -> void:

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -251,6 +251,7 @@ func get_no_pivot_transform(pivot_transform := preview_transform, pivot_local :=
 func begin_drag(mouse_pos: Vector2) -> void:
 	drag_start = mouse_pos
 	start_transform = preview_transform
+	begin_transform()
 
 
 func move(pos: Vector2) -> void:

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -544,10 +544,11 @@ func bake_transform_to_image(image: Image, used_rect := Rect2i()) -> void:
 
 func bake_transform_to_selection(map: SelectionMap) -> void:
 	var bounds := DrawingAlgos.get_transformed_bounds(transformed_selection_map.get_size(), preview_transform)
+	map.ensure_selection_fits(Global.current_project, bounds)
 	bounds.position -= bounds.position
 	var transformed_selection := SelectionMap.new()
 	transformed_selection.copy_from(transformed_selection_map)
-	var transformation_origin := get_transform_top_left()
+	var transformation_origin := get_transform_top_left().max(Vector2.ZERO)
 	bake_transform_to_image(transformed_selection, bounds)
 	var selection_size_rect := Rect2i(Vector2i.ZERO, transformed_selection.get_size())
 	map.blit_rect_custom(transformed_selection, selection_size_rect, transformation_origin)

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -67,6 +67,8 @@ var pivot := Vector2.ZERO:
 		if is_instance_valid(transformed_selection_map):
 			var image_size := transformed_selection_map.get_size() as Vector2
 			handles[0].pos = pivot / image_size
+
+@onready var selection_node := get_parent() as SelectionNode
 @onready var canvas := get_parent().get_parent() as Canvas
 
 
@@ -417,6 +419,24 @@ func begin_transform(image: Image = null, project := Global.current_project) -> 
 	)
 	pre_transformed_image.blit_rect_mask(blended_image, map_copy, selection_rect, Vector2i.ZERO)
 	image_texture.set_image(pre_transformed_image)
+	# Remove content from the cels
+	var clear_image := Image.create(
+		pre_transformed_image.get_width(),
+		pre_transformed_image.get_height(),
+		pre_transformed_image.has_mipmaps(),
+		pre_transformed_image.get_format()
+	)
+	for cel in selection_node.get_selected_draw_cels():
+		var cel_image := cel.get_image()
+		cel.transformed_content = selection_node.get_selected_image(cel_image)
+		cel_image.blit_rect_mask(
+			clear_image,
+			cel.transformed_content,
+			Rect2i(Vector2i.ZERO, project.selection_map.get_size()),
+			selection_rect.position
+		)
+	for cel_index in project.selected_cels:
+		canvas.update_texture(cel_index[1])
 
 
 func reset_transform() -> void:

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -571,9 +571,11 @@ func set_selection(selection_map: SelectionMap, selection_rect: Rect2i) -> void:
 	queue_redraw()
 
 
-func begin_transform(image: Image = null, project := Global.current_project) -> void:
+func begin_transform(
+	image: Image = null, project := Global.current_project, force_move_content := false
+) -> void:
 	currently_transforming = true
-	if Input.is_action_pressed(&"transform_move_selection_only"):
+	if Input.is_action_pressed(&"transform_move_selection_only", true) and not force_move_content:
 		if not only_transforms_selection:
 			selection_node.undo_data = selection_node.get_undo_data(false)
 			only_transforms_selection = true

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -367,15 +367,6 @@ func transform_around(t: Transform2D, m: Transform2D, pivot_local: Vector2) -> T
 	return back * m * to_origin * t
 
 
-func get_no_pivot_transform(
-	pivot_transform := preview_transform, pivot_local := pivot
-) -> Transform2D:
-	var pivot_world := pivot_transform * pivot_local
-	var to_origin := Transform2D(Vector2(1, 0), Vector2(0, 1), -pivot_world)
-	var back := Transform2D(Vector2(1, 0), Vector2(0, 1), pivot_world)
-	return back.affine_inverse() * pivot_transform * to_origin.affine_inverse()
-
-
 func begin_drag(mouse_pos: Vector2) -> void:
 	drag_start = mouse_pos
 	start_transform = preview_transform

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -23,13 +23,15 @@ var transformed_image: Image:
 var pre_transform_selection_offset: Vector2
 var image_texture: ImageTexture
 
-# Preview transform, not yet applied to transformed_image
+## Preview transform, not yet applied to transformed_image
 var preview_transform := Transform2D():
 	set(value):
 		preview_transform = value
 		preview_transform_changed.emit()
 
-# Tracking handles
+var original_selection_transform := Transform2D()
+
+## Tracking handles
 var active_handle: TransformHandle:
 	set(value):
 		active_handle = value
@@ -194,8 +196,7 @@ func _circle_to_square(center: Vector2, radius: Vector2) -> Rect2:
 
 
 func is_transforming_content() -> bool:
-	var transform_no_origin := preview_transform.translated(-preview_transform.origin)
-	return transform_no_origin != Transform2D.IDENTITY
+	return preview_transform != original_selection_transform
 
 
 func is_position_inside_selection(pos: Vector2) -> bool:
@@ -372,6 +373,7 @@ func set_selection(selection_map: SelectionMap, selection_rect: Rect2i) -> void:
 		preview_transform = Transform2D().translated(selection_rect.position)
 	else:
 		preview_transform = Transform2D.IDENTITY
+	original_selection_transform = preview_transform
 	queue_redraw()
 
 

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -17,7 +17,7 @@ var transformed_image: Image:
 		if is_instance_valid(transformed_image):
 			image_texture = ImageTexture.create_from_image(transformed_image)
 		queue_redraw()
-
+var pre_transform_selection_offset: Vector2
 var image_texture: ImageTexture
 
 # Preview transform, not yet applied to transformed_image
@@ -361,6 +361,17 @@ func angle_to_cursor(angle: float) -> Input.CursorShape:
 		return Input.CURSOR_BDIAGSIZE  # Top-right
 
 	return Input.CURSOR_ARROW
+
+
+func begin_transform(image: Image = null, project := Global.current_project) -> void:
+	preview_transform = Transform2D()
+	if is_instance_valid(image):
+		transformed_image = image
+		return
+	transformed_image = project.new_empty_image()
+	DrawingAlgos.blend_layers(
+		transformed_image, project.frames[project.current_frame], Vector2i.ZERO, project, true
+	)
 
 
 func cancel_transform() -> void:

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -165,12 +165,17 @@ func _draw() -> void:
 				_circle_to_square(pos, (HANDLE_RADIUS - 0.3) * zoom_value),
 				Global.selection_border_color_1
 			)
-		elif handle.type == TransformHandle.Type.ROTATE:
-			draw_circle(pos, HANDLE_RADIUS * zoom_value.x, Color.ORANGE)
-		elif handle.type == TransformHandle.Type.SKEW:
-			draw_circle(pos, HANDLE_RADIUS * zoom_value.x, Color.GREEN)
 		elif handle.type == TransformHandle.Type.PIVOT:
-			draw_circle(pos, HANDLE_RADIUS * zoom_value.x, Color.WHITE)
+			if is_rotated_or_skewed():
+				var final_size := HANDLE_RADIUS * zoom_value.x * 2
+				draw_arc(pos, final_size * 0.25, 0, 360, 360, Color.YELLOW)
+				draw_arc(pos, final_size * 0.5, 0, 360, 360, Color.WHITE)
+				draw_line(
+					pos - Vector2.UP * final_size, pos - Vector2.DOWN * final_size, Color.WHITE
+				)
+				draw_line(
+					pos - Vector2.RIGHT * final_size, pos - Vector2.LEFT * final_size, Color.WHITE
+				)
 
 
 func _move_with_arrow_keys(event: InputEvent) -> void:
@@ -214,6 +219,8 @@ func _move_with_arrow_keys(event: InputEvent) -> void:
 func _get_hovered_handle(mouse_pos: Vector2) -> TransformHandle:
 	var zoom_value := Vector2.ONE / Global.camera.zoom * 10
 	for handle in handles:
+		if handle.type == TransformHandle.Type.PIVOT and not is_rotated_or_skewed():
+			continue
 		if get_handle_position(handle).distance_to(mouse_pos) < HANDLE_RADIUS * zoom_value.x:
 			return handle
 	return null
@@ -329,6 +336,10 @@ func _set_default_cursor() -> void:
 func _circle_to_square(center: Vector2, radius: Vector2) -> Rect2:
 	var rect := Rect2(center - radius / 2, radius)
 	return rect
+
+
+func is_rotated_or_skewed() -> bool:
+	return preview_transform.get_rotation() != 0 or preview_transform.get_skew() != 0
 
 
 func is_transforming_content() -> bool:

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -266,7 +266,7 @@ func apply_rotate(t: Transform2D, mouse_pos: Vector2) -> Transform2D:
 func apply_shear(t: Transform2D, delta: Vector2, handle: TransformHandle) -> Transform2D:
 	var image_size := base_image.get_size() as Vector2
 	var handle_global_position := get_handle_position(handle)
-	var center := pivot * t
+	var center := t * pivot
 	var handle_vector := (handle_global_position - center).normalized()
 	var handle_angle := rad_to_deg(fposmod(handle_vector.angle(), TAU))
 	var is_horizontal := true

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -353,17 +353,11 @@ func get_handle_position(handle: TransformHandle, t := preview_transform) -> Vec
 	var world_pos := t * local
 	if handle.type == TransformHandle.Type.ROTATE or handle.type == TransformHandle.Type.SKEW:
 		# Determine direction of offset from center
-		var rot_and_skew := transform_remove_scale(t)
+		var rot_and_skew := DrawingAlgos.transform_remove_scale(t)
 		var offset := rot_and_skew.basis_xform(handle.get_direction() * RS_HANDLE_DISTANCE)
 		offset = offset.normalized() * RS_HANDLE_DISTANCE
 		world_pos += offset
 	return world_pos
-
-
-static func transform_remove_scale(t: Transform2D) -> Transform2D:
-	var x := t.x.normalized()
-	var y := t.y.normalized()
-	return Transform2D(x, y, Vector2.ZERO)
 
 
 ## Apply an affine transform [param m] around [param pivot_local] onto [param t].

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -525,11 +525,13 @@ func begin_transform(image: Image = null, project := Global.current_project) -> 
 
 
 func reset_transform() -> void:
-	preview_transform = Transform2D()
+	preview_transform = original_selection_transform
 	if is_instance_valid(transformed_selection_map):
 		pivot = transformed_selection_map.get_size() / 2
 	pre_transformed_image = Image.new()
 	transformed_image = Image.new()
+	for cel in selection_node.get_selected_draw_cels():
+		cel.transformed_content = null
 	queue_redraw()
 
 

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -393,16 +393,31 @@ func resize_transform(delta: Vector2) -> void:
 	queue_redraw()
 
 
-## Rotation around pivot based on initial drag.
+## Called by the sliders in the selection tool options.
 func rotate_transform(angle: float) -> void:
 	if Tools.is_placing_tiles():
 		return
 	var delta_ang := angle - preview_transform.get_rotation()
 	var m := Transform2D().rotated(delta_ang)
 	preview_transform = transform_around(preview_transform, m, pivot)
+	queue_redraw()
 
 
-func resize_transform_handle(t: Transform2D, handle: TransformHandle, delta: Vector2) -> Transform2D:
+## Called by the sliders in the selection tool options.
+func shear_transform(angle: float) -> void:
+	if Tools.is_placing_tiles():
+		return
+	var t_rotation := preview_transform.get_rotation()
+	var t_scale := preview_transform.get_scale()
+	var t_origin := preview_transform.origin
+
+	preview_transform = Transform2D(t_rotation, t_scale, angle, t_origin)
+	queue_redraw()
+
+
+func resize_transform_handle(
+	t: Transform2D, handle: TransformHandle, delta: Vector2
+) -> Transform2D:
 	if Tools.is_placing_tiles():
 		var tilemap := Global.current_project.get_current_cel() as CelTileMap
 		if tilemap.get_tile_shape() != TileSet.TILE_SHAPE_SQUARE:

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -1,7 +1,6 @@
 class_name TransformationHandles
 extends Node2D
 
-signal is_transforming_content_changed
 signal preview_transform_changed
 
 const HANDLE_RADIUS := 1.0
@@ -394,7 +393,6 @@ func set_selection(selection_map: SelectionMap, selection_rect: Rect2i) -> void:
 func begin_transform(image: Image = null, project := Global.current_project) -> void:
 	if not transformed_image.is_empty():
 		return
-	is_transforming_content_changed.emit()
 	if is_instance_valid(image):
 		transformed_image = image
 		return
@@ -417,7 +415,6 @@ func reset_transform() -> void:
 		pivot = transformed_selection_map.get_size() / 2
 	transformed_image = Image.new()
 	image_texture.set_image(transformed_image)
-	is_transforming_content_changed.emit()
 	queue_redraw()
 
 

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -219,7 +219,10 @@ func _get_hovered_handle(mouse_pos: Vector2) -> TransformHandle:
 	for handle in handles:
 		if handle.type == TransformHandle.Type.PIVOT and not is_rotated_or_skewed():
 			continue
-		if get_handle_position(handle).distance_to(mouse_pos) < HANDLE_RADIUS * zoom_value.x:
+		var total_radius := HANDLE_RADIUS * zoom_value.x
+		if handle.type == TransformHandle.Type.ROTATE or handle.type == TransformHandle.Type.SKEW:
+			total_radius *= 2
+		if get_handle_position(handle).distance_to(mouse_pos) < total_radius:
 			return handle
 	return null
 

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -167,15 +167,9 @@ func _draw() -> void:
 			)
 		elif handle.type == TransformHandle.Type.PIVOT:
 			if is_rotated_or_skewed():
-				var final_size := HANDLE_RADIUS * zoom_value.x * 2
-				draw_arc(pos, final_size * 0.25, 0, 360, 360, Color.YELLOW)
-				draw_arc(pos, final_size * 0.5, 0, 360, 360, Color.WHITE)
-				draw_line(
-					pos - Vector2.UP * final_size, pos - Vector2.DOWN * final_size, Color.WHITE
-				)
-				draw_line(
-					pos - Vector2.RIGHT * final_size, pos - Vector2.LEFT * final_size, Color.WHITE
-				)
+				var final_size := HANDLE_RADIUS * zoom_value.x
+				draw_circle(pos, final_size, Color.WHITE, false)
+				draw_circle(pos, final_size * 0.25, Color.WHITE)
 
 
 func _move_with_arrow_keys(event: InputEvent) -> void:

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -353,7 +353,7 @@ func get_handle_position(handle: TransformHandle, t := preview_transform) -> Vec
 	return world_pos
 
 
-func transform_remove_scale(t: Transform2D) -> Transform2D:
+static func transform_remove_scale(t: Transform2D) -> Transform2D:
 	var x := t.x.normalized()
 	var y := t.y.normalized()
 	return Transform2D(x, y, Vector2.ZERO)

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -469,9 +469,11 @@ func bake_transform_to_image(image: Image, used_rect := Rect2i()) -> void:
 
 
 func bake_transform_to_selection(map: SelectionMap) -> void:
+	var bounds := DrawingAlgos.get_transformed_bounds(transformed_selection_map.get_size(), preview_transform)
+	bounds.position -= bounds.position
 	var transformed_selection := SelectionMap.new()
 	transformed_selection.copy_from(transformed_selection_map)
 	var transformation_origin := get_transform_top_left()
-	bake_transform_to_image(transformed_selection)
+	bake_transform_to_image(transformed_selection, bounds)
 	var selection_size_rect := Rect2i(Vector2i.ZERO, transformed_selection.get_size())
 	map.blit_rect_custom(transformed_selection, selection_size_rect, transformation_origin)

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -225,14 +225,6 @@ func is_transforming_content() -> bool:
 	return preview_transform != original_selection_transform
 
 
-func is_position_inside_selection(pos: Vector2) -> bool:
-	if not is_instance_valid(transformed_selection_map):
-		return false
-	var local_click := preview_transform.affine_inverse() * pos
-	var img_rect := Rect2(Vector2.ZERO, transformed_selection_map.get_size())
-	return img_rect.has_point(local_click)
-
-
 func get_handle_position(handle: TransformHandle, t := preview_transform) -> Vector2:
 	var image_size := transformed_selection_map.get_size()
 	var local := Vector2(image_size.x * handle.pos.x, image_size.y * handle.pos.y)

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -108,6 +108,8 @@ func _input(event: InputEvent) -> void:
 	if not project.layers[project.current_layer].can_layer_get_drawn():
 		return
 	var mouse_pos := canvas.current_pixel
+	if Global.mirror_view:
+		mouse_pos.x = Global.current_project.size.x - mouse_pos.x
 	var hovered_handle := _get_hovered_handle(mouse_pos)
 	if is_instance_valid(hovered_handle):
 		if hovered_handle.type == TransformHandle.Type.PIVOT:
@@ -139,12 +141,17 @@ func _draw() -> void:
 	if not is_instance_valid(transformed_selection_map):
 		return
 	var zoom_value := Vector2.ONE / Global.camera.zoom * 10
+	var position_tmp := position
+	var position_top_left := position + get_transform_top_left()
+	var scale_tmp := scale
+	if Global.mirror_view:
+		position_tmp.x = Global.current_project.size.x - position_tmp.x
+		position_top_left.x = Global.current_project.size.x - position_top_left.x
+		scale_tmp.x = -1
 	if is_instance_valid(transformed_image) and not transformed_image.is_empty():
-		#draw_set_transform_matrix(preview_transform)
-		draw_set_transform_matrix(Transform2D.IDENTITY.translated(get_transform_top_left()))
+		draw_set_transform(position_top_left, rotation, scale_tmp)
 		draw_texture(image_texture, Vector2.ZERO, Color(1, 1, 1, 0.5))
-		draw_set_transform_matrix(Transform2D.IDENTITY)
-
+	draw_set_transform(position_tmp, rotation, scale_tmp)
 	# Draw handles
 	for handle in handles:
 		var pos := get_handle_position(handle)
@@ -375,19 +382,27 @@ func angle_to_cursor(angle: float) -> Input.CursorShape:
 	if deg >= 337.5 or deg < 22.5:
 		return Input.CURSOR_HSIZE  # Right
 	if deg < 67.5:
+		if Global.mirror_view:
+			return Input.CURSOR_BDIAGSIZE
 		return Input.CURSOR_FDIAGSIZE  # Bottom-right
 	if deg < 112.5:
 		return Input.CURSOR_VSIZE  # Down
 	if deg < 157.5:
+		if Global.mirror_view:
+			return Input.CURSOR_FDIAGSIZE
 		return Input.CURSOR_BDIAGSIZE  # Bottom-left
 	if deg < 202.5:
 		return Input.CURSOR_HSIZE  # Left
 	if deg < 247.5:
+		if Global.mirror_view:
+			return Input.CURSOR_BDIAGSIZE
 		return Input.CURSOR_FDIAGSIZE  # Top-left
 	if deg < 292.5:
 		return Input.CURSOR_VSIZE  # Up
 	if deg < 337.5:
-		return Input.CURSOR_BDIAGSIZE  # Top-right
+		if Global.mirror_view:
+			return Input.CURSOR_FDIAGSIZE
+		return Input.CURSOR_BDIAGSIZE # Top-right
 
 	return Input.CURSOR_ARROW
 

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -30,6 +30,10 @@ var preview_transform := Transform2D():
 		preview_transform_changed.emit()
 
 var original_selection_transform := Transform2D()
+var transformation_algorithm := 0:
+	set(value):
+		transformation_algorithm = value
+		preview_transform_changed.emit()
 
 ## Tracking handles
 var active_handle: TransformHandle:
@@ -655,7 +659,9 @@ func get_transform_top_left(size := transformed_selection_map.get_size()) -> Vec
 
 
 func bake_transform_to_image(image: Image, used_rect := Rect2i()) -> void:
-	DrawingAlgos.transform_image_with_viewport(image, preview_transform, pivot, used_rect)
+	DrawingAlgos.transform_image_with_viewport(
+		image, preview_transform, pivot, transformation_algorithm, used_rect
+	)
 
 
 func bake_transform_to_selection(map: SelectionMap) -> void:

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -1,0 +1,264 @@
+class_name TransformationHandles
+extends Node2D
+
+const ICON := preload("res://assets/graphics/splash_screen/orama_64x64.png")
+const HANDLE_RADIUS := 2.0
+const RS_HANDLE_DISTANCE := 0.1
+
+# Raw image data and baked texture
+var base_image: Image
+var image_texture: ImageTexture
+
+# Preview transform, not yet applied to base_image
+var preview_transform := Transform2D()
+
+# Tracking handles
+var active_handle: TransformHandle
+
+var handles: Array[TransformHandle] = [
+	TransformHandle.new(TransformHandle.Type.MOVE),  # Not a visible handle
+	TransformHandle.new(TransformHandle.Type.SCALE, Vector2(0, 0)),  # Top left
+	TransformHandle.new(TransformHandle.Type.SCALE, Vector2(0.5, 0)),  # Center top
+	TransformHandle.new(TransformHandle.Type.SCALE, Vector2(1, 0)),  # Top right
+	TransformHandle.new(TransformHandle.Type.SCALE, Vector2(1, 0.5)),  # Center right
+	TransformHandle.new(TransformHandle.Type.SCALE, Vector2(1, 1)),  # Bottom right
+	TransformHandle.new(TransformHandle.Type.SCALE, Vector2(0.5, 1)),  # Center bottom
+	TransformHandle.new(TransformHandle.Type.SCALE, Vector2(0, 1)),  # Bottom left
+	TransformHandle.new(TransformHandle.Type.SCALE, Vector2(0, 0.5)),  # Center left
+
+	TransformHandle.new(TransformHandle.Type.ROTATE, Vector2(0 - RS_HANDLE_DISTANCE, 0 - RS_HANDLE_DISTANCE)),  # Top left
+	TransformHandle.new(TransformHandle.Type.ROTATE, Vector2(1 + RS_HANDLE_DISTANCE, 0 - RS_HANDLE_DISTANCE)),  # Top right
+	TransformHandle.new(TransformHandle.Type.ROTATE, Vector2(1 + RS_HANDLE_DISTANCE, 1 + RS_HANDLE_DISTANCE)),  # Bottom right
+	TransformHandle.new(TransformHandle.Type.ROTATE, Vector2(0 - RS_HANDLE_DISTANCE, 1 + RS_HANDLE_DISTANCE)),  # Bottom left
+
+	TransformHandle.new(TransformHandle.Type.SKEW, Vector2(0.5, 0 - RS_HANDLE_DISTANCE)),  # Center top
+	TransformHandle.new(TransformHandle.Type.SKEW, Vector2(1 + RS_HANDLE_DISTANCE, 0.5)),  # Center right
+	TransformHandle.new(TransformHandle.Type.SKEW, Vector2(0.5, 1 + RS_HANDLE_DISTANCE)),  # Center bottom
+	TransformHandle.new(TransformHandle.Type.SKEW, Vector2(0 - RS_HANDLE_DISTANCE, 0.5))  # Center left
+]
+var drag_start: Vector2
+var start_transform := Transform2D()
+
+## The transformation's pivot. By default it is set to the center of the image.
+var pivot := Vector2.ZERO
+@onready var canvas := get_parent().get_parent() as Canvas
+
+class TransformHandle:
+	enum Type { SCALE, ROTATE, SKEW, MOVE }
+
+	var type := Type.SCALE
+	var pos := Vector2(0.5, 0.5)
+
+	func _init(_type: Type, _pos := Vector2(0.5, 0.5)) -> void:
+		type = _type
+		pos = _pos
+
+	func get_anchor() -> Vector2:
+		var anchor := pos
+		if pos.x == 0:
+			anchor.x = 1
+		elif pos.x == 1:
+			anchor.x = 0
+		if pos.y == 0:
+			anchor.y = 1
+		elif pos.y == 1:
+			anchor.y = 0
+		return anchor
+
+
+func _ready() -> void:
+	var img := ICON.get_image()
+	base_image = Image.create_from_data(ICON.get_width(), ICON.get_height(), false, img.get_format(), img.get_data())
+	image_texture = ImageTexture.create_from_image(base_image)
+	pivot = base_image.get_size() / 2
+	queue_redraw()
+
+
+func _input(event: InputEvent):
+	var mouse_pos := canvas.current_pixel
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		if event.pressed:
+			_handle_mouse_press(mouse_pos)
+		else:
+		# On release, bake the transform if needed
+			#if active_handle != -1:
+				#bake_transform()
+			active_handle = null
+	elif event is InputEventMouseMotion and active_handle != null:
+		_handle_mouse_drag(mouse_pos)
+	elif event.is_action_pressed(&"ui_accept"):  # TEMP
+		bake_transform()
+
+
+func _handle_mouse_press(mouse_pos: Vector2) -> void:
+	# Begin dragging handle or moving the image.
+	var clicked_handle: TransformHandle = null
+	for handle in handles:
+		if get_handle_position(handle).distance_to(mouse_pos) < HANDLE_RADIUS:
+			clicked_handle = handle
+			break
+	if clicked_handle != null:
+		active_handle = clicked_handle
+	else:
+		# Start moving if clicked inside image.
+		var local_click := preview_transform.affine_inverse() * mouse_pos
+		var img_rect := Rect2(Vector2.ZERO, base_image.get_size())
+		if img_rect.has_point(local_click):
+			active_handle = handles[0]
+		else:
+			active_handle = null
+	if active_handle != null:
+		drag_start = mouse_pos
+		start_transform = preview_transform
+
+
+func _handle_mouse_drag(mouse_pos: Vector2) -> void:
+	# Update preview_transform based which handle we're dragging, or moving the image
+	preview_transform = start_transform
+	var delta := mouse_pos - drag_start
+	match active_handle.type:
+		TransformHandle.Type.MOVE:
+			preview_transform = preview_transform.translated(delta)
+		TransformHandle.Type.SCALE:
+			preview_transform = apply_resize(preview_transform, active_handle, delta)
+		TransformHandle.Type.ROTATE:
+			preview_transform = apply_rotate(preview_transform, mouse_pos)
+		TransformHandle.Type.SKEW:
+			preview_transform = apply_shear(preview_transform, delta, active_handle)
+	queue_redraw()
+
+
+func _draw() -> void:
+	image_texture.set_image(base_image)
+	draw_set_transform_matrix(preview_transform)
+	draw_texture(image_texture, Vector2.ZERO)
+	draw_set_transform_matrix(Transform2D.IDENTITY)
+
+	# Draw handles
+	for handle in handles:
+		var pos := get_handle_position(handle)
+		var color := Color.RED
+		if handle.type == TransformHandle.Type.MOVE:
+			continue
+		elif handle.type == TransformHandle.Type.ROTATE:
+			color = Color.ORANGE
+		elif handle.type == TransformHandle.Type.SKEW:
+			color = Color.GREEN
+		draw_circle(pos, HANDLE_RADIUS, color)
+
+
+func get_handle_position(handle: TransformHandle) -> Vector2:
+	var image_size := base_image.get_size()
+	var local := Vector2(image_size.x * handle.pos.x, image_size.y * handle.pos.y)
+	return preview_transform * local
+
+
+## Apply an affine transform [param m] around [param pivot_local] onto [param t].
+func transform_around(t: Transform2D, m: Transform2D, pivot_local: Vector2) -> Transform2D:
+	var pivot_world := t * pivot_local
+	var to_origin := Transform2D(Vector2(1, 0), Vector2(0, 1), -pivot_world)
+	var back := Transform2D(Vector2(1, 0), Vector2(0, 1), pivot_world)
+	return back * m * to_origin * t
+
+
+func apply_resize(t: Transform2D, handle: TransformHandle, delta: Vector2) -> Transform2D:
+	var image_size := base_image.get_size() as Vector2
+	# Step 1: Convert drag to local space
+	var local_start := t.affine_inverse() * drag_start
+	var local_now := t.affine_inverse() * (drag_start + delta)
+	var local_delta := local_now - local_start
+
+	# Step 2: Determine resize axis and direction
+	var scale_x := 1.0
+	var scale_y := 1.0
+	var anchor_norm := handle.get_anchor()
+	if anchor_norm.x == 0:
+		scale_x = (image_size.x + local_delta.x) / image_size.x
+	elif anchor_norm.x == 1:
+		scale_x = (image_size.x - local_delta.x) / image_size.x
+	if anchor_norm.y == 0:
+		scale_y = (image_size.y + local_delta.y) / image_size.y
+	elif anchor_norm.y == 1:
+		scale_y = (image_size.y - local_delta.y) / image_size.y
+
+	if Input.is_action_pressed("shape_center"):
+		anchor_norm = Vector2(0.5, 0.5)
+	if Input.is_action_pressed("shape_perfect"):
+		var u := 1.0 + maxf(local_delta.x / image_size.x, local_delta.y / image_size.y)
+		scale_x = u
+		scale_y = u
+	# Step 3: Build scaled basis vectors from original
+	var bx := t.x.normalized() * t.x.length() * scale_x
+	var by := t.y.normalized() * t.y.length() * scale_y
+	var new_t := Transform2D(bx, by, t.origin)
+
+	# Step 4: Keep anchor in place
+	var local_anchor := anchor_norm * image_size
+	var world_anchor_before := t * local_anchor
+	var world_anchor_after := new_t * local_anchor
+	new_t.origin += world_anchor_before - world_anchor_after
+
+	return new_t
+
+
+## Rotation around pivot based on initial drag.
+func apply_rotate(t: Transform2D, mouse_pos: Vector2) -> Transform2D:
+	# Compute initial and current angles
+	var start_vec := drag_start - pivot
+	var curr_vec := mouse_pos - pivot
+	var delta_ang := fposmod(curr_vec.angle() - start_vec.angle(), TAU)
+	var m := Transform2D().rotated(delta_ang)
+	return transform_around(t, m, pivot)
+
+
+func apply_shear(t: Transform2D, delta: Vector2, handle: TransformHandle) -> Transform2D:
+	var image_size := base_image.get_size() as Vector2
+	var handle_global_position := get_handle_position(handle)
+	var center := pivot * t
+	var handle_vector := (handle_global_position - center).normalized()
+	var handle_angle := rad_to_deg(fposmod(handle_vector.angle(), TAU))
+	var is_horizontal := true
+	if in_range(handle_angle, 315, 45):
+		is_horizontal = false
+	elif in_range(handle_angle, 45, 135):
+		is_horizontal = true
+	elif in_range(handle_angle, 135, 225):
+		is_horizontal = false
+		delta.y = -delta.y
+	elif in_range(handle_angle, 225, 315):
+		is_horizontal = true
+		delta.x = -delta.x
+
+	var shear_matrix := Transform2D.IDENTITY
+	if is_horizontal:
+		# Slant Y axis based on X movement (horizontal shear)
+		var shear_amount := delta.x / image_size.x
+		shear_matrix = Transform2D(Vector2(1, 0), Vector2(shear_amount, 1), Vector2())
+	else:
+		# Slant X axis based on Y movement (vertical shear)
+		var shear_amount := delta.y / image_size.y
+		shear_matrix = Transform2D(Vector2(1, shear_amount), Vector2(0, 1), Vector2())
+
+	# Apply the shear matrix in local space around pivot
+	return transform_around(start_transform, shear_matrix, pivot)
+
+
+## Checks if [param angle] is between [param lower] and [param upper] degrees.
+func in_range(angle: float, lower: float, upper: float) -> bool:
+	angle = fmod(angle, 360)
+	lower = fmod(lower, 360)
+	upper = fmod(upper, 360)
+	if lower > upper:
+		return angle >= lower or angle <= upper
+	return angle > lower and angle < upper
+
+
+func bake_transform() -> void:
+	# Destructively apply preview_transform to base_image
+	DrawingAlgos.transform_image_with_transform2d(base_image, preview_transform, pivot)
+	pivot = base_image.get_size() / 2
+	# Reset preview_transform
+	#var offset := preview_transform.get_origin()
+	preview_transform = Transform2D()
+	#preview_transform = Transform2D().translated(offset)
+	queue_redraw()

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -519,7 +519,9 @@ func set_selection(selection_map: SelectionMap, selection_rect: Rect2i) -> void:
 func begin_transform(image: Image = null, project := Global.current_project) -> void:
 	currently_transforming = true
 	if Input.is_action_pressed(&"transform_move_selection_only"):
-		only_transforms_selection = true
+		if not only_transforms_selection:
+			selection_node.undo_data = selection_node.get_undo_data(false)
+			only_transforms_selection = true
 		return
 	else:
 		if only_transforms_selection:
@@ -532,6 +534,7 @@ func begin_transform(image: Image = null, project := Global.current_project) -> 
 		transformed_image.copy_from(pre_transformed_image)
 		image_texture.set_image(transformed_image)
 		return
+	selection_node.undo_data = selection_node.get_undo_data(true)
 	var map_copy := project.selection_map.return_cropped_copy(project, project.size)
 	var selection_rect := map_copy.get_used_rect()
 	var current_cel := project.get_current_cel()

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -572,10 +572,15 @@ func set_selection(selection_map: SelectionMap, selection_rect: Rect2i) -> void:
 
 
 func begin_transform(
-	image: Image = null, project := Global.current_project, force_move_content := false
+	image: Image = null,
+	project := Global.current_project,
+	force_move_content := false,
+	force_move_selection_only := false
 ) -> void:
 	currently_transforming = true
-	if Input.is_action_pressed(&"transform_move_selection_only", true) and not force_move_content:
+	var selection_only_action := Input.is_action_pressed(&"transform_move_selection_only", true)
+	var move_selection_only := selection_only_action or force_move_selection_only
+	if move_selection_only and not force_move_content:
 		if not only_transforms_selection:
 			selection_node.undo_data = selection_node.get_undo_data(false)
 			only_transforms_selection = true

--- a/src/UI/Canvas/TransformationHandles.gd.uid
+++ b/src/UI/Canvas/TransformationHandles.gd.uid
@@ -1,0 +1,1 @@
+uid://dtu2ddt5gojeb

--- a/src/UI/Dialogs/ImageEffects/BrightnessContrastDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/BrightnessContrastDialog.gd
@@ -32,7 +32,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 	)
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/ColorCurvesDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/ColorCurvesDialog.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/DesaturateDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DesaturateDialog.gd
@@ -18,7 +18,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/DropShadowDialog.gd
@@ -29,7 +29,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 	var offset_y := animate_panel.get_animated_value(commit_idx, Animate.OFFSET_Y)
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
@@ -25,7 +25,7 @@ func _flip_image(cel: Image, affect_selection: bool, project: Project) -> void:
 	else:
 		# Create a temporary image that only has the selected pixels in it
 		var selected := Image.new()
-		var rectangle: Rect2i = Global.canvas.selection.big_bounding_rectangle
+		var rectangle: Rect2i = project.selection_map.get_selection_rect(project)
 		if project != Global.current_project:
 			rectangle = project.selection_map.get_used_rect()
 		selected = cel.get_region(rectangle)

--- a/src/UI/Dialogs/ImageEffects/GaussianBlur.gd
+++ b/src/UI/Dialogs/ImageEffects/GaussianBlur.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/GradientDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/GradientDialog.gd
@@ -40,7 +40,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var center := Vector2(

--- a/src/UI/Dialogs/ImageEffects/GradientMapDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/GradientMapDialog.gd
@@ -13,7 +13,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {"selection": selection_tex, "gradient_map": $VBoxContainer/GradientEdit.texture}

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.gd
@@ -30,7 +30,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 	var val = animate_panel.get_animated_value(commit_idx, Animate.VALUE) / 100
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {"hue": hue, "saturation": sat, "value": val, "selection": selection_tex}

--- a/src/UI/Dialogs/ImageEffects/InvertColorsDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/InvertColorsDialog.gd
@@ -18,7 +18,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/OffsetImage.gd
+++ b/src/UI/Dialogs/ImageEffects/OffsetImage.gd
@@ -31,7 +31,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 	var offset := Vector2(offset_x, offset_y)
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {"offset": offset, "wrap_around": wrap_around, "selection": selection_tex}

--- a/src/UI/Dialogs/ImageEffects/OutlineDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/OutlineDialog.gd
@@ -25,7 +25,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 	var anim_thickness := animate_panel.get_animated_value(commit_idx, Animate.THICKNESS)
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {

--- a/src/UI/Dialogs/ImageEffects/PalettizeDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/PalettizeDialog.gd
@@ -13,7 +13,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	if not is_instance_valid(Palettes.current_palette):

--- a/src/UI/Dialogs/ImageEffects/PixelizeDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/PixelizeDialog.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {"pixel_size": pixel_size, "selection": selection_tex}

--- a/src/UI/Dialogs/ImageEffects/Posterize.gd
+++ b/src/UI/Dialogs/ImageEffects/Posterize.gd
@@ -15,7 +15,7 @@ func _ready() -> void:
 func commit_action(cel: Image, project := Global.current_project) -> void:
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 	var params := {"colors": levels, "dither_intensity": dither, "selection": selection_tex}

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -114,9 +114,9 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 				preview.material.set_shader_parameter(param, params[param])
 		else:
 			params["preview"] = false
-			DrawingAlgos.transform(cel, params, rotation_algorithm)
+			DrawingAlgos.transform_image_with_algorithm(cel, params, rotation_algorithm)
 	else:
-		DrawingAlgos.transform(image, params, rotation_algorithm)
+		DrawingAlgos.transform_image_with_algorithm(image, params, rotation_algorithm)
 		if project.has_selection and selection_checkbox.button_pressed:
 			cel.blend_rect(image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO)
 		else:

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -99,7 +99,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 			)
 	var transformation_matrix := Transform2D(angle, Vector2.ZERO)
 	var params := {
-		"transformation_matrix": transformation_matrix,
+		"transformation_matrix": transformation_matrix.affine_inverse(),
 		"pivot": pivot,
 		"selection_tex": selection_tex,
 		"initial_angle": init_angle,

--- a/src/UI/Dialogs/ImageEffects/RotateImage.gd
+++ b/src/UI/Dialogs/ImageEffects/RotateImage.gd
@@ -85,7 +85,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 	var image := Image.new()
 	image.copy_from(cel)
 	if project.has_selection and selection_checkbox.button_pressed:
-		var selection := project.selection_map.return_cropped_copy(project.size)
+		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
 		if not DrawingAlgos.type_is_shader(rotation_algorithm):

--- a/src/UI/Dialogs/ModifySelection.gd
+++ b/src/UI/Dialogs/ModifySelection.gd
@@ -37,7 +37,6 @@ func _on_confirmed() -> void:
 		project.selection_map.shrink(width, brush)
 	else:
 		project.selection_map.border(width, brush)
-	selection_node.big_bounding_rectangle = project.selection_map.get_used_rect()
 	project.selection_offset = Vector2.ZERO
 	selection_node.commit_undo("Modify Selection", undo_data_tmp)
 	selection_node.queue_redraw()

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -137,18 +137,21 @@ func _notification(what: int) -> void:
 func _input(event: InputEvent) -> void:
 	var project := Global.current_project
 	if event.is_action_pressed(&"go_to_previous_layer"):
+		Global.canvas.selection.transform_content_confirm()
 		project.selected_cels.clear()
 		if project.current_layer > 0:
 			project.change_cel(-1, project.current_layer - 1)
 		else:
 			project.change_cel(-1, project.layers.size() - 1)
 	elif event.is_action_pressed(&"go_to_next_layer"):
+		Global.canvas.selection.transform_content_confirm()
 		project.selected_cels.clear()
 		if project.current_layer < project.layers.size() - 1:
 			project.change_cel(-1, project.current_layer + 1)
 		else:
 			project.change_cel(-1, 0)
 	elif event.is_action_pressed(&"go_to_next_frame_with_same_tag"):
+		Global.canvas.selection.transform_content_confirm()
 		project.selected_cels.clear()
 		var from := 0
 		var to := project.frames.size() - 1
@@ -161,6 +164,7 @@ func _input(event: InputEvent) -> void:
 		else:
 			project.change_cel(from, -1)
 	elif event.is_action_pressed(&"go_to_previous_frame_with_same_tag"):
+		Global.canvas.selection.transform_content_confirm()
 		project.selected_cels.clear()
 		var from := 0
 		var to := project.frames.size() - 1
@@ -817,6 +821,7 @@ func play_animation(play: bool, forward_dir: bool) -> void:
 
 
 func _on_NextFrame_pressed() -> void:
+	Global.canvas.selection.transform_content_confirm()
 	var project := Global.current_project
 	project.selected_cels.clear()
 	if project.current_frame < project.frames.size() - 1:
@@ -826,6 +831,7 @@ func _on_NextFrame_pressed() -> void:
 
 
 func _on_PreviousFrame_pressed() -> void:
+	Global.canvas.selection.transform_content_confirm()
 	var project := Global.current_project
 	project.selected_cels.clear()
 	if project.current_frame > 0:
@@ -835,11 +841,13 @@ func _on_PreviousFrame_pressed() -> void:
 
 
 func _on_LastFrame_pressed() -> void:
+	Global.canvas.selection.transform_content_confirm()
 	Global.current_project.selected_cels.clear()
 	Global.current_project.change_cel(Global.current_project.frames.size() - 1, -1)
 
 
 func _on_FirstFrame_pressed() -> void:
+	Global.canvas.selection.transform_content_confirm()
 	Global.current_project.selected_cels.clear()
 	Global.current_project.change_cel(0, -1)
 


### PR DESCRIPTION
Completely remade the selection transformation system in order to finally support selection rotation & shearing, with the option to change the pivot. I first made the new system in a separate project (https://github.com/OverloadedOrama/TransformHandles2D) and then implemented it to Pixelorama.

![Peek 2025-05-21 20-08](https://github.com/user-attachments/assets/56c73b7e-af44-43f8-83fe-d787ae89701e)

Users can choose between Nearest Neighbor, cleanEdge and OmniScale transformation algorithms. Rotxel is not supported because it works with an angle value and not a matrix.

Transforming a selection without image content now acts the same as transforming with image content, meaning that you need to confirm the change, and you are able to cancel it.

Fixes:
- The canvas rotation now affects the direction of the arrow keys
- Applying the bucket now confirms transformation
- Transformed content no longer gets lost when pressing Control + arrow key
- Fix bug where pasting images from the clipboard sometimes did not work, due to them being in different formats than the project image.

Tested:
- ✅ Resizing from all 8 handles,
- ✅ Resizing while holding Shift and/or Control
- ✅ Moving with the selection tool
- ✅ Moving with the move tool
- ✅ Moving with the selection tool while holding Shift and/or Control
- ✅ Moving with the move tool while holding Shift and/or Control
- ✅ Rotating from all 4 handles
- ✅ Skewing from all 4 handles
- ✅ Handles work as expected if the image is flipped
- ✅ Handles work as expected if the image is rotated/skewed
- ✅ Transforming selections without content
- ✅ Transforming selections with content
- ✅ Transforming non-rectangular selection should have a correct position
- ✅ Handles work as expected if the canvas is flipped
- ✅ Movement with arrow keys
- ✅ Only move selection when Alt is pressed `Input.is_action_pressed(&"transform_move_selection_only")`
- ✅ Draw tiles mode in rectangular tilemap layers
- ✅ Undo/redo
- ✅ Copy
- ✅ Paste
- ✅ Delete
- ✅ Create brushes
- ✅ Change position, size, rotation and skewing from the tool options
- ✅ Transform in multiple selected cels
- ✅ Project switching when a transformation is active
- ✅ Crop to selection
- ✅ Fill selection with bucket
- ✅ Modify selection from Selection menu
- ✅ Quick copy