### PR TITLE
Boost performance of groups with blend_mode != PassThrough

### DIFF
--- a/src/Classes/Layers/GroupLayer.gd
+++ b/src/Classes/Layers/GroupLayer.gd
@@ -64,14 +64,16 @@ func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true
 			"origin_x_positive": origin.x > 0,
 			"origin_y_positive": origin.y > 0,
 		}
-		var c_key := [
-			_cache_texture_data, metadata_image.get_data(), origin.x > 0, origin.y > 0
-		]
+		var c_key := [_cache_texture_data, metadata_image.get_data(), origin.x > 0, origin.y > 0]
 		_group_cache.has(c_key)
 		if _group_cache.has(c_key):
 			# Don't waste time re-generating for groups that have remained unchanged
 			var cache_image = Image.create_from_data(
-			project.size.x, project.size.y, false, project.get_image_format(), _group_cache[c_key]
+				project.size.x,
+				project.size.y,
+				false,
+				project.get_image_format(),
+				_group_cache[c_key]
 			)
 			image.blit_rect(
 				cache_image, Rect2i(Vector2i.ZERO, cache_image.get_size()), Vector2i.ZERO

--- a/src/Classes/Layers/GroupLayer.gd
+++ b/src/Classes/Layers/GroupLayer.gd
@@ -113,6 +113,11 @@ func _blend_child_group(
 	var cel := frame.cels[layer.index]
 	if layer.blend_mode == BlendModes.PASS_THROUGH:
 		var children := layer.get_children(false)
+		if children.size() == 0:
+			# This is done to re-calibrate current_child_index += 1 in blend_children()
+			# without this visual bugs appear for example see:
+			# https://github.com/Orama-Interactive/Pixelorama/issues/1256
+			return new_i - 1
 		for j in children.size():
 			var child := children[j]
 			if child is GroupLayer:

--- a/src/Classes/Layers/GroupLayer.gd
+++ b/src/Classes/Layers/GroupLayer.gd
@@ -81,9 +81,6 @@ func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true
 			_blend_generator.generate_image(
 				image, DrawingAlgos.blend_layers_shader, params, project.size, true, false
 			)
-			_blend_generator.generate_image(
-				image, DrawingAlgos.blend_layers_shader, params, project.size, true, true
-			)
 			_group_cache[c_key] = image.get_data()
 		if apply_effects:
 			image = display_effects(frame.cels[index], image)

--- a/src/Classes/Layers/GroupLayer.gd
+++ b/src/Classes/Layers/GroupLayer.gd
@@ -26,7 +26,6 @@ func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true
 	for i in children.size():
 		var layer := children[i]
 		if layer is GroupLayer:
-			# incrementation of current_metadata_index is done internally in _blend_child_group()
 			current_metadata_index = _blend_child_group(
 				image,
 				layer,
@@ -37,6 +36,8 @@ func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true
 				origin,
 				apply_effects
 			)
+			# NOTE: incrementation of current_metadata_index is done internally in
+			# _blend_child_group(), so we don't have to use current_metadata_index += 1 here
 		else:
 			_include_child_in_blending(
 				image,
@@ -50,8 +51,6 @@ func blend_children(frame: Frame, origin := Vector2i.ZERO, apply_effects := true
 			)
 			current_metadata_index += 1
 
-	for i in textures.size():
-		textures[i].save_png("out/"+str(i, ".png"))
 	if DisplayServer.get_name() != "headless" and textures.size() > 0:
 		var texture_array := Texture2DArray.new()
 		texture_array.create_from_images(textures)
@@ -136,6 +135,7 @@ func _blend_child_group(
 		else:
 			textures.append(blended_children)
 			DrawingAlgos.set_layer_metadata_image(layer, cel, metadata_image, i)
+		new_i += 1
 	return new_i
 
 

--- a/src/Classes/ShaderImageEffect.gd
+++ b/src/Classes/ShaderImageEffect.gd
@@ -83,3 +83,9 @@ func generate_image(
 	if img is ImageExtended and respect_indexed:
 		img.convert_rgb_to_indexed()
 	done.emit()
+
+
+func _notification(what: int) -> void:
+	# Frees material or the reference is no longer tracked by anyone e.g undo/redo or project.
+	if what == NOTIFICATION_PREDELETE and cache_mat_rid.is_valid():
+		RenderingServer.free_rid(cache_mat_rid)

--- a/src/Classes/ShaderImageEffect.gd
+++ b/src/Classes/ShaderImageEffect.gd
@@ -6,6 +6,7 @@ signal done
 var cache_mat_rid: RID  # reference to the cache material
 var cache_shader: Shader  # it's just used to keep track of shader when dest_mat_after_gen is false
 
+
 func generate_image(
 	img: Image,
 	shader: Shader,


### PR DESCRIPTION
NOTE: This is a performance PR so this would need a little testing, also it should be merged *after* Pixelorama 1.1.2 gets released (just a preference, not a requirement)

Attempt at solving https://github.com/Orama-Interactive/Pixelorama/issues/1250. Boosts the performance of GroupLayers to roughly twice (47% to be precise) it's current state by introducing cache.
- In consecutive generations, when the shader is same, calling `RenderingServer.material_set_shader` again and again (in `generate_image()`) takes up unnecessary computation time (Which makes up most of the 47% time i talked about -- per generation). There is now a way to reuse the material in last generation for the next one.

- when a GroupLayer gets blended, if it has another GroupLayer as child, even if the contents of child GroupLayer didn't change, it ends up being re-blended regardless. To fix this there is now a cache which save time if the contents of a GroupLayer didn't change.

As it uses cache this takes up a little more memory but it's not noticeable.