### PR TITLE
Palette QOL changes

### DIFF
--- a/src/Autoload/Palettes.gd
+++ b/src/Autoload/Palettes.gd
@@ -17,6 +17,7 @@ var palettes_write_path := Global.home_data_directory.path_join("Palettes")
 var palettes: Dictionary[String, Palette] = {}
 ## Currently displayed palette
 var current_palette: Palette = null
+var auto_add_colors := false
 
 # Indexes of colors that are selected in palette
 # by left and right mouse button

--- a/src/Palette/PaletteGrid.gd
+++ b/src/Palette/PaletteGrid.gd
@@ -82,7 +82,7 @@ func scroll_palette(origin: Vector2i) -> void:
 
 
 ## Called when the color changes, either the left or the right, determined by [param mouse_button].
-## If current palette has [param target_color] as a [Color], then select it.
+## If current palette has [param color_info], then select the first slot that has it.
 ## This is helpful when we select color indirectly (e.g through colorpicker)
 func find_and_select_color(color_info: Dictionary, mouse_button: int) -> void:
 	var target_color: Color = color_info.get("color", Color(0, 0, 0, 0))

--- a/src/Palette/PalettePanel.gd
+++ b/src/Palette/PalettePanel.gd
@@ -143,13 +143,11 @@ func toggle_add_delete_buttons() -> void:
 	else:
 		add_color_button.mouse_default_cursor_shape = CURSOR_POINTING_HAND
 	delete_color_button.disabled = Palettes.current_palette.is_empty()
-	sort_button.disabled = Palettes.current_palette.is_empty()
+	sort_button_popup.set_item_disabled(1, Palettes.current_palette.is_empty())
 	if delete_color_button.disabled:
 		delete_color_button.mouse_default_cursor_shape = CURSOR_FORBIDDEN
-		sort_button.mouse_default_cursor_shape = CURSOR_FORBIDDEN
 	else:
 		delete_color_button.mouse_default_cursor_shape = CURSOR_POINTING_HAND
-		sort_button.mouse_default_cursor_shape = CURSOR_POINTING_HAND
 
 
 func _on_AddPalette_pressed() -> void:

--- a/src/Palette/PalettePanel.gd
+++ b/src/Palette/PalettePanel.gd
@@ -78,7 +78,7 @@ func _ready() -> void:
 	hidden_color_picker.get_picker().presets_visible = false
 
 
-func _input(event: InputEvent) -> void:
+func _input(_event: InputEvent) -> void:
 	if Palettes.auto_add_colors and Tools.active_button != -1:
 		var new_color := Tools.get_assigned_color(Tools.active_button)
 		if not Palettes.current_palette.has_theme_color(new_color):

--- a/src/Palette/PalettePanel.gd
+++ b/src/Palette/PalettePanel.gd
@@ -234,6 +234,16 @@ func _on_PaletteGrid_swatch_dropped(source_index: int, target_index: int) -> voi
 
 func _on_PaletteGrid_swatch_pressed(mouse_button: int, index: int) -> void:
 	# Gets previously selected color index
+	var is_empty_swatch = Palettes.current_palette.get_color(index) == null
+	if is_empty_swatch:
+		# Gets the grid index that corresponds to the top left of current grid window
+		# Color will be added at the start of the currently scrolled part of palette
+		# - not the absolute beginning of palette
+		var start_index := palette_grid.convert_grid_index_to_palette_index(index)
+		Palettes.current_palette_add_color(mouse_button, start_index)
+		redraw_current_palette()
+		toggle_add_delete_buttons()
+	# Gets previously selected color index
 	var old_index := Palettes.current_palette_get_selected_color_index(mouse_button)
 	Palettes.current_palette_select_color(mouse_button, index)
 	palette_grid.select_swatch(mouse_button, index, old_index)

--- a/src/Palette/PalettePanel.gd
+++ b/src/Palette/PalettePanel.gd
@@ -60,7 +60,6 @@ func _ready() -> void:
 	sort_button_popup.add_child(sort_submenu)
 	sort_button_popup.add_submenu_node_item("Palette Sort", sort_submenu)
 
-
 	Palettes.palette_selected.connect(select_palette)
 	Palettes.new_palette_created.connect(_new_palette_created)
 	Palettes.new_palette_imported.connect(setup_palettes_selector)

--- a/src/Palette/PalettePanel.tscn
+++ b/src/Palette/PalettePanel.tscn
@@ -34,6 +34,7 @@ layout_mode = 2
 
 [node name="AddColor" type="Button" parent="PaletteVBoxContainer/PaletteButtons" groups=["UIButtons"]]
 unique_name_in_owner = true
+visible = false
 custom_minimum_size = Vector2(24, 24)
 layout_mode = 2
 tooltip_text = "Add a new color"

--- a/src/Palette/PalettePanel.tscn
+++ b/src/Palette/PalettePanel.tscn
@@ -34,7 +34,6 @@ layout_mode = 2
 
 [node name="AddColor" type="Button" parent="PaletteVBoxContainer/PaletteButtons" groups=["UIButtons"]]
 unique_name_in_owner = true
-visible = false
 custom_minimum_size = Vector2(24, 24)
 layout_mode = 2
 tooltip_text = "Add a new color"

--- a/src/Palette/PaletteSwatch.gd
+++ b/src/Palette/PaletteSwatch.gd
@@ -99,8 +99,8 @@ func _drop_data(_position: Vector2, data) -> void:
 
 
 func _on_PaletteSlot_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.is_pressed() and not empty:
-		if event.double_click:
+	if event is InputEventMouseButton and event.is_pressed():
+		if event.double_click and not empty:
 			double_clicked.emit(event.button_index, get_global_rect().position)
 		else:
 			pressed.emit(event.button_index)

--- a/src/Palette/PaletteSwatch.gd
+++ b/src/Palette/PaletteSwatch.gd
@@ -102,5 +102,5 @@ func _on_PaletteSlot_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.is_pressed():
 		if event.double_click and not empty:
 			double_clicked.emit(event.button_index, get_global_rect().position)
-		else:
+		elif event.button_index == MOUSE_BUTTON_LEFT or event.button_index == MOUSE_BUTTON_RIGHT:
 			pressed.emit(event.button_index)


### PR DESCRIPTION
I noticed some aspects of the palette panel were in need of improvement so this PR addresses these
- Clicking a swatch with Left/Right color now directly add the color to the desired swatch. This saves the trouble of re-arranging the swatch (if required) to the desired place each time a new color is added
- Previously when deleting a color from palette, you'd have to select color and then press delete button. This is fine for removing one or two colors but when removing a chunk of colors, this task becomes cumbersome. **You can now remove colors by `Ctrl + click` on the desired swatch.**

## Before
https://github.com/user-attachments/assets/f6effdac-e3ea-4797-8666-b5357cd8c554

## After
https://github.com/user-attachments/assets/e8da0fa1-c616-4db2-8afc-f4ae305124c0

- A new `Auto add colors` option has been made available. When enabled, **NEW** colors drawn on canvas will automatically get added to the palette if space is available. (This does not remove colors) 

