### PR TITLE
boost speed of bucket in the pressence of selection by about 87%

### DIFF
--- a/src/Classes/SelectionMap.gd
+++ b/src/Classes/SelectionMap.gd
@@ -4,6 +4,9 @@ extends Image
 const INVERT_SHADER := preload("res://src/Shaders/Effects/Invert.gdshader")
 const OUTLINE_INLINE_SHADER := preload("res://src/Shaders/Effects/OutlineInline.gdshader")
 
+## An optimization technique
+var _selection_rect_cache := Rect2i()
+
 
 func is_pixel_selected(
 	pixel: Vector2i, calculate_offset := true, project := Global.current_project
@@ -100,7 +103,19 @@ func invert() -> void:
 	gen.generate_image(self, INVERT_SHADER, params, get_size())
 
 
+## An optimization. Stores existing selection rect as cache and forces [method get_selection_rect]
+## to use cache instead. use this to save time when the rect isn't meant to change between repeated
+## calls (e.g see Bucket tool)
+func lock_selection_rect(project: Project, locked := false):
+	if locked:
+		_selection_rect_cache = get_selection_rect(project)
+	else:
+		_selection_rect_cache = Rect2i()
+
+
 func get_selection_rect(project: Project) -> Rect2i:
+	if _selection_rect_cache != Rect2i():
+		return _selection_rect_cache
 	var rect := get_used_rect()
 	rect.position += project.selection_offset
 	return rect

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -278,6 +278,9 @@ func commit_undo() -> void:
 
 
 func draw_tool(pos: Vector2i) -> void:
+	var project := Global.current_project
+	if project.has_selection:
+		project.selection_map.lock_selection_rect(project, true)
 	if Global.mirror_view:
 		# Even brushes are not perfectly centered and are offsetted by 1 px, so we add it.
 		if int(_stroke_dimensions.x) % 2 == 0:
@@ -286,6 +289,8 @@ func draw_tool(pos: Vector2i) -> void:
 	var coords_to_draw := _draw_tool(pos)
 	for coord in coords_to_draw:
 		_set_pixel_no_cache(coord)
+	if project.has_selection:
+		project.selection_map.lock_selection_rect(project, false)
 
 
 func draw_end(pos: Vector2i) -> void:
@@ -377,6 +382,9 @@ func _draw_tool(pos: Vector2) -> PackedVector2Array:
 
 
 func draw_fill_gap(start: Vector2i, end: Vector2i) -> void:
+	var project := Global.current_project
+	if project.has_selection:
+		project.selection_map.lock_selection_rect(project, true)
 	if Global.mirror_view:
 		# Even brushes are not perfectly centred and are offsetted by 1 px so we add it
 		if int(_stroke_dimensions.x) % 2 == 0:
@@ -394,6 +402,8 @@ func draw_fill_gap(start: Vector2i, end: Vector2i) -> void:
 			coords_to_draw[coord] = 0
 	for c in coords_to_draw.keys():
 		_set_pixel_no_cache(c)
+	if project.has_selection:
+		project.selection_map.lock_selection_rect(project, true)
 
 
 ## Calls [method Geometry2D.bresenham_line] and takes [param thickness] into account.

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -377,6 +377,8 @@ func _flood_fill(pos: Vector2i) -> void:
 			tilemap_cel.bucket_fill(
 				cell_pos, TileSetPanel.selected_tile_index, draw_tile.bind(tilemap_cel)
 			)
+		if project.has_selection:
+			project.selection_map.lock_selection_rect(project, false)
 		return
 
 	var cels = _get_selected_draw_cels()
@@ -395,6 +397,8 @@ func _flood_fill(pos: Vector2i) -> void:
 			# end early if we are filling with an empty pattern
 			var pattern_size := _pattern.image.get_size()
 			if pattern_size.x == 0 or pattern_size.y == 0:
+				if project.has_selection:
+					project.selection_map.lock_selection_rect(project, false)
 				return
 		# init flood data structures
 		_allegro_flood_segments = []

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -35,8 +35,9 @@ class Segment:
 	var y := 0
 	var next := 0
 
-	func _init(_y: int) -> void:
+	func _init(_y: int, _next) -> void:
 		y = _y
+		next = _next
 
 
 func _ready() -> void:
@@ -450,7 +451,7 @@ func _compute_segments_for_image(
 
 ## Add a new segment to the array
 func _add_new_segment(y := 0) -> void:
-	_allegro_flood_segments.append(Segment.new(y))
+	_allegro_flood_segments.append(Segment.new(y, _area_start_idx))
 
 
 ## Fill an horizontal segment around the specified position, and adds it to the
@@ -493,11 +494,11 @@ func _flood_line_around_point(
 	# we may have already processed some segments on this y coordinate
 	if segment.flooding:
 		while segment.next > _area_start_idx:
-			c = segment.next  # index of next segment in this line of image
+			c = segment.next - _area_start_idx  # index of next segment in this line of image
 			segment = _allegro_flood_segments[c]
 		# found last current segment on this line
 		c = _allegro_flood_segments.size()
-		segment.next = c
+		segment.next = c + _area_start_idx
 		_add_new_segment(pos.y)
 		segment = _allegro_flood_segments[c]
 	# set the values for the current segment
@@ -536,8 +537,8 @@ func _check_flooded_segment(
 			if left >= segment.left_position and left <= segment.right_position:
 				left = segment.right_position + 2
 				break
-			c = segment.next
-			if c == _area_start_idx:  # couldn't find a valid segment, so we draw a new one
+			c = segment.next - _area_start_idx
+			if c == 0:  # couldn't find a valid segment, so we draw a new one
 				left = _flood_line_around_point(Vector2i(left, y), project, image, src_color)
 				ret = true
 				break

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -537,7 +537,7 @@ func _check_flooded_segment(
 				left = segment.right_position + 2
 				break
 			c = segment.next
-			if c == 0:  # couldn't find a valid segment, so we draw a new one
+			if c == _area_start_idx:  # couldn't find a valid segment, so we draw a new one
 				left = _flood_line_around_point(Vector2i(left, y), project, image, src_color)
 				ret = true
 				break

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -452,6 +452,7 @@ func _flood_line_around_point(
 	var west := pos
 	var east := pos
 	if project.has_selection:
+		project.selection_map.lock_selection_rect(project, true)
 		while (
 			project.can_pixel_get_drawn(west)
 			&& DrawingAlgos.similar_colors(image.get_pixelv(west), src_color, _tolerance)
@@ -462,6 +463,7 @@ func _flood_line_around_point(
 			&& DrawingAlgos.similar_colors(image.get_pixelv(east), src_color, _tolerance)
 		):
 			east += Vector2i.RIGHT
+		project.selection_map.lock_selection_rect(project, false)
 	else:
 		while (
 			west.x >= 0


### PR DESCRIPTION
This introduces two independent optimizations:
## 1.  `lock_selection_rect` optimization:
Stores existing selection rect as cache and forces `get_selection_rect` in `SelectionMap` to use cache instead. use this to save time when the rect isn't meant to change between repeated calls (e.g see it's use in Bucket tool `_flood_fill`). This causes roughly an 87% boost to the area fill algorithm

## 2.  area_fill compatible with selection size:
when segments were created in `_compute_segments_for_image`
```
for j in image.get_height():
	_add_new_segment(j)
```
When we have selection, this ends up adding segments not necessary for calculation. As an optimization, i change it to
```
var y_range = [0, image.get_height()]
	_area_end_idx = project.size.y - 1
	_area_start_idx = 0
	if project.has_selection:
		var selection_rect := project.selection_map.get_selection_rect(project)
		_area_start_idx = selection_rect.position.y
		_area_end_idx = selection_rect.end.y - 1
		y_range = [selection_rect.position.y, selection_rect.end.y]
	for j in range(y_range[0], y_range[1]):
		_add_new_segment(j)
```
This dramatically decreases the fill time even further.

### Benchmark of area_fill on a `30x30` selection in a `646x646` canvas
| Version | Area fill time (msec) |
| --- | --- |
| `master` | 3834 |
| `PR` | 32 |

### Related optimization that tagged along.
- The **lock_selection_rect** optimization is used by `draw_tool` and `draw_fill_gap` as well (this will be noticeable when drawing a line using **Pencil** on a 5000x5000 canvas in presence of selection).