### PR TITLE
further optimize area fill

### DIFF
--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -398,10 +398,18 @@ func _flood_fill(pos: Vector2i) -> void:
 				if project.has_selection:
 					var s_rect = project.selection_map.get_selection_rect(project)
 					if image.get_region(s_rect).get_used_rect().size == Vector2i.ZERO:
-						image.fill_rect(s_rect, tool_slot.color)
+						var filler := project.new_empty_image()
+						filler.fill(tool_slot.color)
+						var selection_map_copy := project.selection_map.return_cropped_copy(
+							project, project.size
+						)
+						var rect := selection_map_copy.get_used_rect()
+						image.blit_rect_mask(filler, selection_map_copy, rect, rect.position)
+						image.convert_rgb_to_indexed()
 						continue
 				else:
 					image.fill(tool_slot.color)
+					image.convert_rgb_to_indexed()
 					continue
 		else:
 			# end early if we are filling with an empty pattern
@@ -568,9 +576,13 @@ func _color_segments(image: ImageExtended) -> void:
 		# short circuit for flat colors
 		for c in _allegro_image_segments.size():
 			var p := _allegro_image_segments[c]
-			for px in range(p.left_position, p.right_position + 1):
-				# We don't have to check again whether the point being processed is within the bounds
-				image.set_pixel_custom(px, p.y, color)
+			# We don't have to check again whether the point being processed is within the bounds
+			var rect = Rect2(
+				Vector2i(p.left_position, p.y),
+				Vector2i(p.right_position - p.left_position + 1, 1)
+			)
+			image.fill_rect(rect, color)
+		image.convert_rgb_to_indexed()
 	else:
 		# shortcircuit tests for patternfills
 		var pattern_size := _pattern.image.get_size()

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -393,6 +393,16 @@ func _flood_fill(pos: Vector2i) -> void:
 			# end early if we are filling with the same color
 			if tool_slot.color.is_equal_approx(color):
 				continue
+			# Fill all area if it's completely empty and _fill_merged_area = false
+			if image.get_used_rect().size == Vector2i.ZERO and not _fill_merged_area:
+				if project.has_selection:
+					var s_rect = project.selection_map.get_selection_rect(project)
+					if image.get_region(s_rect).get_used_rect().size == Vector2i.ZERO:
+						image.fill_rect(s_rect, tool_slot.color)
+						continue
+				else:
+					image.fill(tool_slot.color)
+					continue
 		else:
 			# end early if we are filling with an empty pattern
 			var pattern_size := _pattern.image.get_size()


### PR DESCRIPTION
- in `_color_segments()` i used `fill_rect()` instead of filling pixel by pixel (and then use `image.convert_rgb_to_indexed()` at the end). This reduces fill time by about half

- Empty images and selections skip the unnecessary calculations and immediately start filling themselves.

I don't think this breaks something but testing for index mode is required nonetheless :grin: 