### PR TITLE
Removed the `Project.undos` variable 

### DIFF
--- a/src/Autoload/DrawingAlgos.gd
+++ b/src/Autoload/DrawingAlgos.gd
@@ -812,7 +812,6 @@ func center(indices: Array) -> void:
 	Global.canvas.selection.transform_content_confirm()
 	var redo_data := {}
 	var undo_data := {}
-	project.undos += 1
 	project.undo_redo.create_action("Center Frames")
 	for frame in indices:
 		# Find used rect of the current frame (across all of the layers)
@@ -1015,7 +1014,6 @@ func general_do_and_undo_scale(
 	new_y_symmetry_axis_points[0].x /= x_ratio
 	new_y_symmetry_axis_points[1].x /= x_ratio
 
-	project.undos += 1
 	project.undo_redo.create_action("Scale")
 	project.undo_redo.add_do_property(project, "size", size)
 	project.undo_redo.add_do_property(project, "x_symmetry_point", new_x_symmetry_point)

--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -1002,15 +1002,12 @@ func notification_label(text: String) -> void:
 
 ## Performs the general, bare minimum stuff needed after an undo is done.
 func general_undo(project := current_project) -> void:
-	project.undos -= 1
 	var action_name := project.undo_redo.get_current_action_name()
 	notification_label("Undo: %s" % action_name)
 
 
 ## Performs the general, bare minimum stuff needed after a redo is done.
 func general_redo(project := current_project) -> void:
-	if project.undos < project.undo_redo.get_version():  # If we did undo and then redo
-		project.undos = project.undo_redo.get_version()
 	if control.redone:
 		var action_name := project.undo_redo.get_current_action_name()
 		notification_label("Redo: %s" % action_name)

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -638,7 +638,6 @@ func open_image_as_spritesheet_layer_smart(
 		DrawingAlgos.resize_canvas(project_width, project_height, 0, 0)
 
 	# Initialize undo mechanism
-	project.undos += 1
 	project.undo_redo.create_action("Add Spritesheet Layer")
 
 	# Create new frames (if needed)
@@ -719,7 +718,6 @@ func open_image_as_spritesheet_layer(
 		DrawingAlgos.resize_canvas(project_width, project_height, 0, 0)
 
 	# Initialize undo mechanism
-	project.undos += 1
 	project.undo_redo.create_action("Add Spritesheet Layer")
 
 	# Create new frames (if needed)
@@ -794,7 +792,6 @@ func open_image_at_cel(image: Image, layer_index := 0, frame_index := 0) -> void
 	var project_height := maxi(image.get_height(), project.size.y)
 	if project.size < Vector2i(project_width, project_height):
 		DrawingAlgos.resize_canvas(project_width, project_height, 0, 0)
-	project.undos += 1
 	project.undo_redo.create_action("Replaced Cel")
 
 	var cel := project.frames[frame_index].cels[layer_index]
@@ -849,7 +846,6 @@ func open_image_as_new_frame(
 	if not undo:
 		project.frames.append(frame)
 		return
-	project.undos += 1
 	project.undo_redo.create_action("Add Frame")
 	project.undo_redo.add_do_method(Global.undo_or_redo.bind(false))
 	project.undo_redo.add_do_method(project.add_frames.bind([frame], [project.frames.size()]))
@@ -872,7 +868,6 @@ func open_image_as_new_layer(image: Image, file_name: String, frame_index := 0) 
 	var layer := PixelLayer.new(project, file_name)
 	var cels := []
 
-	Global.current_project.undos += 1
 	Global.current_project.undo_redo.create_action("Add Layer")
 	for i in project.frames.size():
 		if i == frame_index:

--- a/src/Classes/AnimationTag.gd
+++ b/src/Classes/AnimationTag.gd
@@ -25,7 +25,6 @@ extends RefCounted
 ##    new_animation_tags.append(AnimationTag.new(tag_name, color, from, to))
 ##
 ##    # Handle Undo/Redo
-##    Global.current_project.undos += 1
 ##    Global.current_project.undo_redo.create_action("Adding a Tag")
 ##    Global.current_project.undo_redo.add_do_method(Global.general_redo)
 ##    Global.current_project.undo_redo.add_undo_method(Global.general_undo)

--- a/src/Classes/ImageEffect.gd
+++ b/src/Classes/ImageEffect.gd
@@ -180,7 +180,6 @@ func _commit_undo(action: String, undo_data: Dictionary, project: Project) -> vo
 		tile_editing_mode = TileSetPanel.TileEditingMode.AUTO
 	project.update_tilemaps(undo_data, tile_editing_mode)
 	var redo_data := _get_undo_data(project)
-	project.undos += 1
 	project.undo_redo.create_action(action)
 	project.deserialize_cel_undo_data(redo_data, undo_data)
 	project.undo_redo.add_do_method(Global.undo_or_redo.bind(false, -1, -1, project))

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -22,7 +22,6 @@ var size: Vector2i:
 	set = _size_changed
 var undo_redo := UndoRedo.new()
 var tiles: Tiles
-var undos := 0  ## The number of times we added undo properties
 var can_undo := true
 var color_mode: int = Image.FORMAT_RGBA8:
 	set(value):

--- a/src/Tools/BaseDraw.gd
+++ b/src/Tools/BaseDraw.gd
@@ -269,7 +269,6 @@ func commit_undo() -> void:
 		frame = project.current_frame
 		layer = project.current_layer
 
-	project.undos += 1
 	project.deserialize_cel_undo_data(redo_data, _undo_data)
 	project.undo_redo.add_do_method(Global.undo_or_redo.bind(false, frame, layer))
 	project.undo_redo.add_undo_method(Global.undo_or_redo.bind(true, frame, layer))

--- a/src/Tools/DesignTools/Bucket.gd
+++ b/src/Tools/DesignTools/Bucket.gd
@@ -592,7 +592,6 @@ func commit_undo() -> void:
 		frame = project.current_frame
 		layer = project.current_layer
 
-	project.undos += 1
 	project.undo_redo.create_action("Draw")
 	project.deserialize_cel_undo_data(redo_data, _undo_data)
 	project.undo_redo.add_do_method(Global.undo_or_redo.bind(false, frame, layer))

--- a/src/Tools/UtilityTools/Move.gd
+++ b/src/Tools/UtilityTools/Move.gd
@@ -157,7 +157,6 @@ func _commit_undo(action: String) -> void:
 		if project.get_current_cel() is not GroupCel:
 			layer = project.current_layer
 
-	project.undos += 1
 	project.undo_redo.create_action(action)
 	project.deserialize_cel_undo_data(redo_data, _undo_data)
 	if Tools.is_placing_tiles():

--- a/src/Tools/UtilityTools/Text.gd
+++ b/src/Tools/UtilityTools/Text.gd
@@ -171,7 +171,6 @@ func commit_undo(action: String, undo_data: Dictionary) -> void:
 		frame = project.current_frame
 		layer = project.current_layer
 
-	project.undos += 1
 	project.undo_redo.create_action(action)
 	project.deserialize_cel_undo_data(redo_data, undo_data)
 	project.undo_redo.add_do_method(Global.undo_or_redo.bind(false, frame, layer))

--- a/src/UI/Buttons/BrushesPopup.gd
+++ b/src/UI/Buttons/BrushesPopup.gd
@@ -131,7 +131,6 @@ func remove_brush(brush_button: Node) -> void:
 		container.visible = false
 		Global.brushes_popup.get_node("Background/Brushes/Categories/ProjectLabel").visible = false
 
-	project.undos += 1
 	project.undo_redo.create_action("Delete Custom Brush")
 	project.undo_redo.add_do_property(project, "brushes", project.brushes)
 	project.undo_redo.add_undo_property(project, "brushes", undo_brushes)

--- a/src/UI/Canvas/ReferenceImages.gd
+++ b/src/UI/Canvas/ReferenceImages.gd
@@ -298,7 +298,6 @@ func commit_undo(action: String, undo_data_tmp: Dictionary) -> void:
 	var redo_data: Dictionary = get_undo_data()
 	var project := Global.current_project
 
-	project.undos += 1
 	project.undo_redo.create_action(action)
 
 	for key in undo_data_tmp.keys():

--- a/src/UI/Canvas/Selection.gd
+++ b/src/UI/Canvas/Selection.gd
@@ -177,7 +177,6 @@ func commit_undo(action: String, undo_data_tmp: Dictionary) -> void:
 	else:
 		project.update_tilemaps(undo_data_tmp, TileSetPanel.TileEditingMode.AUTO)
 	var redo_data := get_undo_data(undo_data_tmp["undo_image"])
-	project.undos += 1
 	project.undo_redo.create_action(action)
 	project.deserialize_cel_undo_data(redo_data, undo_data_tmp)
 	project.undo_redo.add_do_property(project, "selection_offset", redo_data["outline_offset"])

--- a/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/FlipImageDialog.gd
@@ -54,7 +54,6 @@ func _commit_undo(action: String, undo_data: Dictionary, project: Project) -> vo
 		tile_editing_mode = TileSetPanel.TileEditingMode.AUTO
 	project.update_tilemaps(undo_data, tile_editing_mode)
 	var redo_data := _get_undo_data(project)
-	project.undos += 1
 	project.undo_redo.create_action(action)
 	project.deserialize_cel_undo_data(redo_data, undo_data)
 	if redo_data.has("outline_offset"):

--- a/src/UI/Dialogs/ImportTagDialog.gd
+++ b/src/UI/Dialogs/ImportTagDialog.gd
@@ -101,7 +101,6 @@ func add_animation(indices: Array, destination: int, from_tag: AnimationTag = nu
 	var copied_indices: PackedInt32Array = range(
 		destination + 1, (destination + 1) + indices.size()
 	)
-	project.undos += 1
 	project.undo_redo.create_action("Import Tag")
 	# Step 1: calculate layers to generate
 	var layer_to_names := PackedStringArray()  # names of currently existing layers

--- a/src/UI/Dialogs/ProjectProperties.gd
+++ b/src/UI/Dialogs/ProjectProperties.gd
@@ -75,7 +75,6 @@ func _on_tilesets_list_button_clicked(item: TreeItem, column: int, id: int, _mbi
 			var new_image := Image.new()
 			new_image.copy_from(tile.image)
 			new_tileset.add_tile(new_image, null)
-		project.undos += 1
 		project.undo_redo.create_action("Duplicate tileset")
 		project.undo_redo.add_do_method(func(): project.tilesets.append(new_tileset))
 		project.undo_redo.add_do_method(Global.undo_or_redo.bind(false))
@@ -86,7 +85,6 @@ func _on_tilesets_list_button_clicked(item: TreeItem, column: int, id: int, _mbi
 	if id == 1:  # Delete
 		if tileset.find_using_layers(project).size() > 0:
 			return
-		project.undos += 1
 		project.undo_redo.create_action("Delete tileset")
 		project.undo_redo.add_do_method(func(): project.tilesets.erase(tileset))
 		project.undo_redo.add_do_method(Global.undo_or_redo.bind(false))

--- a/src/UI/PerspectiveEditor/PerspectiveEditor.gd
+++ b/src/UI/PerspectiveEditor/PerspectiveEditor.gd
@@ -18,7 +18,6 @@ func _ready() -> void:
 func _on_AddPoint_pressed() -> void:
 	do_pool.clear()  # Reset (clears Redo history of vanishing points)
 	var project := Global.current_project
-	project.undos += 1
 	project.undo_redo.create_action("Add Vanishing Point")
 	project.undo_redo.add_do_method(add_vanishing_point.bind(true))
 	project.undo_redo.add_undo_method(undo_add_vanishing_point)
@@ -49,7 +48,6 @@ func undo_add_vanishing_point() -> void:
 
 func delete_point(idx: int) -> void:
 	var project := Global.current_project
-	project.undos += 1
 	project.undo_redo.create_action("Delete Vanishing Point")
 	project.undo_redo.add_do_method(do_delete_point.bind(idx))
 	project.undo_redo.add_undo_method(undo_delete_point.bind(idx))

--- a/src/UI/Timeline/AnimationTagUI.gd
+++ b/src/UI/Timeline/AnimationTagUI.gd
@@ -49,7 +49,6 @@ func _resize_tag(resize: Drag, value: int) -> void:
 		new_animation_tags[tag_id].to = value
 
 	# Handle Undo/Redo
-	Global.current_project.undos += 1
 	Global.current_project.undo_redo.create_action("Resize Frame Tag")
 	Global.current_project.undo_redo.add_do_method(Global.general_redo)
 	Global.current_project.undo_redo.add_undo_method(Global.general_undo)

--- a/src/UI/Timeline/AnimationTimeline.gd
+++ b/src/UI/Timeline/AnimationTimeline.gd
@@ -339,7 +339,6 @@ func add_frame() -> void:
 	var project := Global.current_project
 	var frame_add_index := project.current_frame + 1
 	var frame := project.new_empty_frame()
-	project.undos += 1
 	project.undo_redo.create_action("Add Frame")
 	for l in range(project.layers.size()):
 		if project.layers[l].new_cels_linked:  # If the link button is pressed
@@ -430,7 +429,6 @@ func delete_frames(indices: PackedInt32Array = []) -> void:
 				tag.to -= 1
 		frame_correction += 1  # Compensation for the next batch
 
-	project.undos += 1
 	project.undo_redo.create_action("Remove Frame")
 	project.undo_redo.add_do_method(project.remove_frames.bind(indices))
 	project.undo_redo.add_undo_method(project.add_frames.bind(frames, indices))
@@ -483,7 +481,6 @@ func copy_frames(
 	# as project.animation_tags's classes. Needed for undo/redo to work properly.
 	for i in new_animation_tags.size():
 		new_animation_tags[i] = new_animation_tags[i].duplicate()
-	project.undos += 1
 	project.undo_redo.create_action("Add Frame")
 	var last_focus_cels := []
 	for f in indices:
@@ -970,7 +967,6 @@ func add_layer(layer: BaseLayer, project: Project) -> void:
 		# Set the parent of layer to be the same as the layer below it.
 		layer.parent = project.layers[project.current_layer].parent
 
-	project.undos += 1
 	project.undo_redo.create_action("Add Layer")
 	project.undo_redo.add_do_method(project.add_layers.bind([layer], [new_layer_idx], [cels]))
 	project.undo_redo.add_undo_method(project.remove_layers.bind([new_layer_idx]))
@@ -1060,7 +1056,6 @@ func _on_CloneLayer_pressed() -> void:
 		project.current_layer + 1, project.current_layer + clones.size() + 1
 	)
 
-	project.undos += 1
 	project.undo_redo.create_action("Add Layer")
 	project.undo_redo.add_do_method(project.add_layers.bind(clones, indices, cels))
 	project.undo_redo.add_undo_method(project.remove_layers.bind(indices))
@@ -1098,7 +1093,6 @@ func _on_RemoveLayer_pressed() -> void:
 		for frame in project.frames:
 			cels[-1].append(frame.cels[index])
 
-	project.undos += 1
 	project.undo_redo.create_action("Remove Layer")
 	project.undo_redo.add_do_method(project.remove_layers.bind(indices))
 	project.undo_redo.add_undo_method(project.add_layers.bind(layers, indices, cels))
@@ -1174,7 +1168,6 @@ func _on_MergeDownLayer_pressed() -> void:
 		return
 	var top_cels := []
 
-	project.undos += 1
 	project.undo_redo.create_action("Merge Layer")
 	for frame in project.frames:
 		var top_cel := frame.cels[top_layer.index]
@@ -1328,7 +1321,6 @@ func flatten_layers(indices: PackedInt32Array, only_visible := false) -> void:
 			new_layer.parent = bottom_layer.parent
 			break
 		bottom_layer = bottom_layer.parent
-	project.undos += 1
 	project.undo_redo.create_action("Flatten layers")
 	project.undo_redo.add_do_method(project.remove_layers.bind(indices))
 	project.undo_redo.add_do_method(

--- a/src/UI/Timeline/CelButton.gd
+++ b/src/UI/Timeline/CelButton.gd
@@ -237,7 +237,6 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 func _delete_cel_content() -> void:
 	var indices := _get_cel_indices()
 	var project := Global.current_project
-	project.undos += 1
 	project.undo_redo.create_action("Draw")
 	for cel_index in indices:
 		var frame_index: int = cel_index[0]

--- a/src/UI/Timeline/FrameProperties.gd
+++ b/src/UI/Timeline/FrameProperties.gd
@@ -28,7 +28,6 @@ func _on_FrameProperties_confirmed() -> void:
 	var project := Global.current_project
 	var new_duration: float = frame_dur.get_value()
 	var new_user_data := user_data_text_edit.text
-	project.undos += 1
 	project.undo_redo.create_action("Change frame duration")
 	for frame_idx in frame_indices:
 		var frame := project.frames[frame_idx]

--- a/src/UI/Timeline/LayerEffects/LayerEffectButton.gd
+++ b/src/UI/Timeline/LayerEffects/LayerEffectButton.gd
@@ -41,7 +41,6 @@ func _drop_data(_pos: Vector2, data) -> void:
 		to_index = panel.get_index() + 1
 	if drop_index < panel.get_index():
 		to_index -= 1
-	Global.current_project.undos += 1
 	Global.current_project.undo_redo.create_action("Re-arrange layer effect")
 	Global.current_project.undo_redo.add_do_method(
 		layer_effects_settings.move_effect.bind(layer, drop_index, to_index)

--- a/src/UI/Timeline/LayerEffects/LayerEffectsSettings.gd
+++ b/src/UI/Timeline/LayerEffects/LayerEffectsSettings.gd
@@ -122,7 +122,6 @@ func _on_effect_list_pressed(menu_item_index: int, menu: PopupMenu) -> void:
 	var index: int = menu.get_item_metadata(menu_item_index)
 	var layer := Global.current_project.layers[Global.current_project.current_layer]
 	var effect := effects[index].duplicate()
-	Global.current_project.undos += 1
 	Global.current_project.undo_redo.create_action("Add layer effect")
 	Global.current_project.undo_redo.add_do_method(func(): layer.effects.append(effect))
 	Global.current_project.undo_redo.add_do_method(layer.emit_effects_added_removed)
@@ -199,7 +198,6 @@ func move_effect(layer: BaseLayer, from_index: int, to_index: int) -> void:
 func _delete_effect(effect: LayerEffect) -> void:
 	var layer := Global.current_project.layers[Global.current_project.current_layer]
 	var index := layer.effects.find(effect)
-	Global.current_project.undos += 1
 	Global.current_project.undo_redo.create_action("Delete layer effect")
 	Global.current_project.undo_redo.add_do_method(func(): layer.effects.erase(effect))
 	Global.current_project.undo_redo.add_do_method(layer.emit_effects_added_removed)
@@ -249,7 +247,6 @@ func _apply_effect(layer: BaseLayer, effect: LayerEffect) -> void:
 		if cel_image is ImageExtended:
 			redo_data[cel_image.indices_image] = cel_image.indices_image.data
 		redo_data[cel_image] = cel_image.data
-	project.undos += 1
 	project.undo_redo.create_action("Apply layer effect")
 	project.deserialize_cel_undo_data(redo_data, undo_data)
 	project.undo_redo.add_do_method(func(): layer.effects.erase(effect))

--- a/src/UI/Timeline/LayerProperties.gd
+++ b/src/UI/Timeline/LayerProperties.gd
@@ -129,7 +129,6 @@ func _on_blend_mode_option_button_item_selected(index: BaseLayer.BlendModes) -> 
 	Global.canvas.update_all_layers = true
 	var project := Global.current_project
 	var current_mode := blend_modes_button.get_item_id(index)
-	project.undos += 1
 	project.undo_redo.create_action("Set Blend Mode")
 	for layer_index in layer_indices:
 		var layer := project.layers[layer_index]
@@ -174,7 +173,6 @@ func _emit_layer_property_signal() -> void:
 func _on_tileset_option_button_item_selected(index: int) -> void:
 	var project := Global.current_project
 	var new_tileset := project.tilesets[index]
-	project.undos += 1
 	project.undo_redo.create_action("Set Tileset")
 	for layer_index in layer_indices:
 		var layer := project.layers[layer_index]
@@ -237,7 +235,6 @@ func _on_place_only_mode_check_button_toggled(toggled_on: bool) -> void:
 
 func _on_place_only_confirmation_dialog_confirmed() -> void:
 	var project := Global.current_project
-	project.undos += 1
 	project.undo_redo.create_action("Set place-only mode")
 	for layer_index in layer_indices:
 		var layer := project.layers[layer_index]
@@ -263,7 +260,6 @@ func _on_place_only_confirmation_dialog_confirmed() -> void:
 
 func _on_tile_size_slider_value_changed(value: Vector2) -> void:
 	var project := Global.current_project
-	project.undos += 1
 	project.undo_redo.create_action("Change tilemap settings")
 	for layer_index in layer_indices:
 		var layer := project.layers[layer_index]
@@ -290,7 +286,6 @@ func _on_tile_size_slider_value_changed(value: Vector2) -> void:
 func _on_tile_shape_option_button_item_selected(index: TileSet.TileShape) -> void:
 	var selected_id := tile_shape_option_button.get_item_id(index)
 	var project := Global.current_project
-	project.undos += 1
 	project.undo_redo.create_action("Change tilemap settings")
 	for layer_index in layer_indices:
 		var layer := project.layers[layer_index]
@@ -315,7 +310,6 @@ func _on_tile_shape_option_button_item_selected(index: TileSet.TileShape) -> voi
 
 func _on_tile_layout_option_button_item_selected(index: TileSet.TileLayout) -> void:
 	var project := Global.current_project
-	project.undos += 1
 	project.undo_redo.create_action("Change tilemap settings")
 	for layer_index in layer_indices:
 		var layer := project.layers[layer_index]
@@ -341,7 +335,6 @@ func _on_tile_layout_option_button_item_selected(index: TileSet.TileLayout) -> v
 func _on_tile_offset_axis_button_item_selected(index: TileSet.TileOffsetAxis) -> void:
 	var selected_id := tile_offset_axis_button.get_item_id(index)
 	var project := Global.current_project
-	project.undos += 1
 	project.undo_redo.create_action("Change tilemap settings")
 	for layer_index in layer_indices:
 		var layer := project.layers[layer_index]

--- a/src/UI/Timeline/TagProperties.gd
+++ b/src/UI/Timeline/TagProperties.gd
@@ -62,7 +62,6 @@ func _on_confirmed() -> void:
 		new_animation_tags[current_tag_id].user_data = user_data
 
 	# Handle Undo/Redo
-	Global.current_project.undos += 1
 	Global.current_project.undo_redo.create_action("Modify Frame Tag")
 	Global.current_project.undo_redo.add_do_method(Global.general_redo)
 	Global.current_project.undo_redo.add_undo_method(Global.general_undo)
@@ -81,7 +80,6 @@ func _on_custom_action(action: StringName) -> void:
 	var new_animation_tags := Global.current_project.animation_tags.duplicate()
 	new_animation_tags.remove_at(current_tag_id)
 	# Handle Undo/Redo
-	Global.current_project.undos += 1
 	Global.current_project.undo_redo.create_action("Delete Frame Tag")
 	Global.current_project.undo_redo.add_do_method(Global.general_redo)
 	Global.current_project.undo_redo.add_undo_method(Global.general_undo)

--- a/src/UI/TopMenuContainer/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer/TopMenuContainer.gd
@@ -821,7 +821,6 @@ func _color_mode_submenu_id_pressed(id: ColorModes) -> void:
 	project.update_tilemaps(undo_data, TileSetPanel.TileEditingMode.AUTO)
 	project.serialize_cel_undo_data(pixel_cels, redo_data)
 	project.undo_redo.create_action("Change color mode")
-	project.undos += 1
 	var palette_in_focus = Palettes.current_palette
 	if not palette_in_focus.is_project_palette and project.color_mode == Project.INDEXED_MODE:
 		palette_in_focus = palette_in_focus.duplicate()


### PR DESCRIPTION
An old commit for 0.4: https://github.com/Orama-Interactive/Pixelorama/commit/8fadacdf123f89ba8430b8e02312e148df0019bc introduced the`undos` variable at 3 important places in Canvas.gd

These were later removed/replaced by better alternatives (see below)
This PR removes all the other remaining traces of `undos` variable.

(The 3 important places and the commits that remove them)

---
```
# If we're already pressing a mouse button and we haven't handled undo yet,...
    #. .. it means that the cursor was outside the canvas. Then, ...
    # simulate "just pressed" logic the moment the cursor gets inside the canvas

    # Or, if we're making a line. This is used for handling undo/redo for lines...
    # ...that go outside the canvas
    if Input.is_action_pressed("left_mouse") || Input.is_action_pressed("right_mouse"):
        if (mouse_in_canvas && Global.undos < Global.undo_redo.get_version()) || is_making_line:
            mouse_pressed = true
```
The need for this section was removed by https://github.com/Orama-Interactive/Pixelorama/pull/253/commits/bda9e6267dbde2c9c3413bbaf7391c4639a84cb2#diff-fda2b27bbbd524f0edab9f12f5a93963e7eb070bebc1672ad9d3dbc144d2560e

---

```
func handle_redo(
    _action: String, project: Project = Global.current_project, layer_index := -2, frame_index := -2
) -> void:
    can_undo = true
    if project.undos < project.undo_redo.get_version():
        return
```
The need for this segment was removed by https://github.com/Orama-Interactive/Pixelorama/commit/f7ef4a4283d1f8ac479b3e095512eff1dd76ab33

---

```
        if can_handle || current_project.undos == current_project.undo_redo.get_version():
            if previous_action != -1 && previous_action != Global.Tools.RECTSELECT && current_action != Global.Tools.COLORPICKER && current_action != Global.Tools.ZOOM:
                handle_redo("Draw")

    handle_tools(current_mouse_button, current_action, mouse_pos, can_handle)
```
The need for this segment was removed by https://github.com/Orama-Interactive/Pixelorama/pull/281 (sub-commit `789b2b0bf181f324655cbd9b6313477109af596a`)