### PR TITLE
Fix crash when opening Pixelorama with a project which had a group layer saved as current layer

### DIFF
--- a/src/Autoload/Tools.gd
+++ b/src/Autoload/Tools.gd
@@ -883,10 +883,7 @@ func _cel_switched() -> void:
 	var layer: BaseLayer = Global.current_project.layers[Global.current_project.current_layer]
 	var layer_type := layer.get_layer_type()
 	# Do not make any changes when its the same type of layer, or an audio layer
-	if (
-		layer_type == _curr_layer_type
-		or layer_type in [Global.LayerTypes.AUDIO]
-	):
+	if layer_type == _curr_layer_type or layer_type in [Global.LayerTypes.AUDIO]:
 		return
 	_show_relevant_tools(layer_type)
 


### PR DESCRIPTION
The issue is that those layer types (Group, Audio, etc...) didn't have a key for `_left_tools_per_layer_type`.

Also as the move tool also works with Group layers, i added it's type in the tool dictionary. And made it eligible for updating tool list