### PR TITLE
Fixed visual bug with clipping mask

### DIFF
--- a/src/Shaders/BlendLayers.gdshader
+++ b/src/Shaders/BlendLayers.gdshader
@@ -195,7 +195,8 @@ void fragment() {
 			current_origin.y = -current_origin.y;
 		}
 		// get origin of previous layer (used for clipping masks to work correctly)
-		float clipping_mask_index = float(find_previous_opaque_layer(i, metadata_size_float));
+		int clipping_i = find_previous_opaque_layer(i, metadata_size_float);
+		float clipping_mask_index = float(clipping_i) / metadata_size_float.x;
 		vec2 prev_origin = texture(metadata, vec2(clipping_mask_index, 2.0 / metadata_size_float.y)).rg;
 		if (!origin_x_positive) {
 			prev_origin.x = -prev_origin.x;
@@ -206,7 +207,7 @@ void fragment() {
 		float current_opacity = texture(metadata, vec2(layer_index, 1.0 / metadata_size_float.y)).r;
 		vec2 uv = UV - current_origin;
 		vec4 layer_color = texture(layers, vec3(uv, float(i)));
-		vec4 prev_layer_color = texture(layers, vec3(UV - prev_origin, clipping_mask_index));
+		vec4 prev_layer_color = texture(layers, vec3(UV - prev_origin, float(clipping_i)));
 		float clipping_mask = texture(metadata, vec2(layer_index, 3.0 / metadata_size_float.y)).r;
 		layer_color.a *= prev_layer_color.a * step(0.5, clipping_mask) + 1.0 * step(clipping_mask, 0.5);
 		layer_color.a = border_trim(layer_color, uv);


### PR DESCRIPTION
## Summary:
in shaders, we have to normalize the layer index to be compatible with UV convention (0 --- 1)
for example:
```
# normalization
float layer_index = float(i) / metadata_size_float.x;
# obtaining value
float blend_mode_float = texture(metadata, vec2(layer_index, 0.0)).r;
# (and later) here, we SHOULD use the non-normalized index as layers is a sampler2DArray, not a 2d texture
vec4 layer_color = texture(layers, vec3(uv, float(i)));
```
In comparison, in the original [PR](https://github.com/Orama-Interactive/Pixelorama/commit/1d82bd95e5f2259ab5fd9b0f2b1dc999e6556616) and then [in a later commit](https://github.com/Orama-Interactive/Pixelorama/commit/077c57c53a6a228dd50cfe937f2c67e95acbd66d#diff-6d9ced3699b6f20d40aa54b48b9d04c96604ff1e382292b0223828234d8a74e0R190), i wasn't normalizing to UV convention when i fetched the clipping mask layer index which in certain combinations resulted in (mainly 2) undesired visual bugs.
```
# when getting index
float clipping_mask_index = float(find_previous_opaque_layer(i, metadata_size_float));
```
### Visual bug 1 (when the "Top most" layer is moved in the presence of layer mask, the clipping mask moves as well)
https://github.com/user-attachments/assets/e72d754c-2ae3-4a63-adbe-2e6bd69ed38b

### Visual bug 2 (when the layer just below the clipping mask is moved, the clipping mask does not update until the move action is released)
https://github.com/user-attachments/assets/9470cf97-fa43-4259-816c-35751eee8531

