### PR TITLE
Fix apply all toggle taking too long

### DIFF
--- a/src/UI/Dialogs/ImportPreviewDialog.gd
+++ b/src/UI/Dialogs/ImportPreviewDialog.gd
@@ -253,9 +253,10 @@ func _on_ApplyAll_toggled(pressed: bool) -> void:
 			child.hiding = pressed
 			if pressed:
 				child.hide()
-				synchronize()
 			else:
 				child.popup_centered_clamped()
+	if pressed:
+		synchronize()
 	popup(old_rect)  # needed for correct popup_order
 
 


### PR DESCRIPTION
synchronize() only needs to be called "Once", by the main dialog (the one where the checkbox is pressed)

Currently it was unnecessarily called many times (still by the main dialog but called multiple times).
Not sure how version 0.11.x remained fast despite this but in versions 1.x this got very slow, and got noticed :grin: