### PR TITLE
Use float explicitly for perspective lines to avoid precision loss

### DIFF
--- a/src/UI/PerspectiveEditor/PerspectiveLine.gd
+++ b/src/UI/PerspectiveEditor/PerspectiveLine.gd
@@ -4,8 +4,8 @@ extends Line2D
 const LINE_WIDTH := 2
 const CIRCLE_RAD := 4
 
-var angle := 0
-var length := 19999
+var angle: float = 0.0
+var length: float = 19999.0
 
 var is_hidden := false
 var has_focus := false


### PR DESCRIPTION
I was working with the perspective editor and noticed the perspective line didn't follow the mouse very well, it jumped large increments when far from the vanishing point. After a bit of investigation, I noticed `rad_to_deg` was losing precision because `angle` was implicitly an integer. Explicitly typing it as a float fixes the issue