### PR TITLE
Update all canvas layers when toggling layer effects

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -637,6 +637,7 @@ var display_layer_effects := true:
 		display_layer_effects = value
 		if is_instance_valid(top_menu_container):
 			top_menu_container.view_menu.set_item_checked(ViewMenu.DISPLAY_LAYER_EFFECTS, value)
+			canvas.update_all_layers = true
 			canvas.queue_redraw()
 ## If [code]true[/code], cursor snaps to the boundary of rectangular grid boxes.
 var snap_to_rectangular_grid_boundary := false


### PR DESCRIPTION
Fixes #1442 

The crux of the issue was that toggling "Display Layer Effects" in the menu bar
only invokes `queue_redraw` for the Canvas, without updating any state flags.
So what happens is `draw_layers` updates only the currently selected layer.
Meanwhile, clicking on some other layer or animation cell emits the
`cel_switched` signal which correctly sets `project_changed = true` before
calling `queue_redraw` for the Canvas.

I've found that these 4 methods all solve the issue:

```gdscript
# a) Set update_all_layers
Global.canvas.update_all_layers = true
Global.canvas.queue_redraw()

# b) Set project_changed
Global.canvas.project_changed = true
Global.canvas.queue_redraw()

# c) Call queue_redraw_all_layers (equivalent to b))
Global.canvas.queue_redraw_all_layers()

# d) Emit the signal like everywhere else
Global.cel_switched.emit()
```

I went with the first option here because it made the most sense given the
variable name.