### PR TITLE
Added RGB color shifting & fixed HSV shifting

### DIFF
--- a/src/Shaders/Effects/BrightnessContrast.gdshader
+++ b/src/Shaders/Effects/BrightnessContrast.gdshader
@@ -5,16 +5,25 @@ render_mode unshaded;
 
 uniform float brightness : hint_range(-1, 1) = 0;
 uniform float contrast : hint_range(0, 3) = 1.0;
-uniform float saturation : hint_range(0, 3) = 1.0;
 
-uniform float red_value : hint_range(0, 1) = 1.0;
-uniform float green_value : hint_range(0, 1) = 1.0;
-uniform float blue_value : hint_range(0, 1) = 1.0;
+uniform float saturation : hint_range(0, 3) = 1.0;
+uniform float red_value : hint_range(0, 1) = 1.0;  // Red contribution in saturation.
+uniform float green_value : hint_range(0, 1) = 1.0;  // Green contribution in saturation.
+uniform float blue_value : hint_range(0, 1) = 1.0;  // Blue contribution in saturation.
+
+uniform float red_shift : hint_range(-1, 1) = 0.0;
+uniform float green_shift : hint_range(-1, 1) = 0.0;
+uniform float blue_shift : hint_range(-1, 1) = 0.0;
 
 uniform vec4 tint_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);
 uniform float tint_effect_factor : hint_range(0, 1) = 0.0;
 
+uniform bool wrap_overflowing = false;
 uniform sampler2D selection : filter_nearest;
+
+bool is_equal_approx(float a, float b) {
+	return abs(a - b) <= 0.0001;
+}
 
 mat4 contrastMatrix( float _contrast )
 {
@@ -40,7 +49,7 @@ mat4 saturationMatrix( float _saturation )
 	float oneMinusSat = 1.0 - _saturation;
 
 	vec3 red = vec3( luminance.x * oneMinusSat );
-	red+= vec3(_saturation, 0, 0) * red_value;
+	red += vec3(_saturation, 0, 0) * red_value;
 	vec3 green = vec3( luminance.y * oneMinusSat );
 	green += vec3(0, _saturation, 0) * green_value;
 	vec3 blue = vec3( luminance.z * oneMinusSat );
@@ -52,9 +61,30 @@ mat4 saturationMatrix( float _saturation )
 void fragment()
 {
 	vec4 original_color = texture(TEXTURE, UV);
+
+	vec4 c_shift = original_color;
+	if (!is_equal_approx(red_shift, 0.0)){
+		if (wrap_overflowing && (c_shift.r + red_shift > 1.0 || c_shift.r + red_shift < 0.0)){
+			c_shift.r = mod(c_shift.r + red_shift, 1.0);
+		}
+		else c_shift.r = clamp(c_shift.r + red_shift, 0.0, 1.0);
+	}
+	if (!is_equal_approx(green_shift, 0.0)){
+		if (wrap_overflowing && (c_shift.g + green_shift > 1.0 || c_shift.g + green_shift < 0.0)){
+			c_shift.g = mod(c_shift.g + green_shift, 1.0);
+		}
+		else c_shift.g = clamp(c_shift.g + green_shift, 0, 1.0);
+	}
+	if (!is_equal_approx(blue_shift, 0.0)){
+		if (wrap_overflowing && (c_shift.b + blue_shift > 1.0 || c_shift.b + blue_shift < 0.0)){
+			c_shift.b = mod(c_shift.b + blue_shift, 1.0);
+		}
+		else c_shift.b = clamp(c_shift.b + blue_shift, 0.0, 1.0);
+	}
+
 	vec4 selection_color = texture(selection, UV);
-	vec4 c2 = original_color * tint_color;
-	vec4 col = brightnessMatrix(brightness) * contrastMatrix(contrast) * saturationMatrix(saturation) * mix(original_color, c2, tint_effect_factor);
+	vec4 c2 = c_shift * tint_color;
+	vec4 col = brightnessMatrix(brightness) * contrastMatrix(contrast) * saturationMatrix(saturation) * mix(c_shift, c2, tint_effect_factor);
 	vec3 output = mix(original_color.rgb, col.rgb, selection_color.a);
 	COLOR = vec4(output.rgb, original_color.a);
 }

--- a/src/Shaders/Effects/HSV.gdshader
+++ b/src/Shaders/Effects/HSV.gdshader
@@ -45,13 +45,22 @@ void fragment() {
 	// If not greyscale
 	if(!is_equal_approx(col[0], col[1]) || !is_equal_approx(col[1], col[2])) {
 		// Shift the color by shift_amount, but rolling over the value goes over 1
-		hsb.x = mod(hsb.x + hue, 1.0);
+		if (hsb.x + hue > 1.0 || hsb.x + hue < 0.0){
+			hsb.x = mod(hsb.x + hue, 1.0);
+		}
+		else hsb.x += hue;
 	}
-	if(saturation > 0.0) {
-		hsb.y = mod(hsb.y + saturation, 1.0);
+	if (!is_equal_approx(saturation, 0)){
+		if (hsb.y + saturation > 1.0 || hsb.y + saturation < 0.0){
+			hsb.y = mod(hsb.y + saturation, 1.0);
+		}
+		else hsb.y += saturation;
 	}
-	if(value > 0.0) {
-		hsb.z = mod(hsb.z + value, 1.0);
+	if (!is_equal_approx(value, 0)){
+		if (hsb.z + value > 1.0 || hsb.z + value < 0.0){
+			hsb.z = mod(hsb.z + value, 1.0);
+		}
+		else hsb.z += value;
 	}
 	// Minimize uncertanities by scaling up to the standardized values, round and then scale down.
 	// I don't think removing this will will cause problems, but it's better to place it here.

--- a/src/Shaders/Effects/HSV.gdshader
+++ b/src/Shaders/Effects/HSV.gdshader
@@ -30,7 +30,6 @@ vec3 hsb2rgb(vec3 c){
 					6.0)-3.0)-1.0,
 					0.0,
 					1.0 );
-	rgb = rgb*rgb*(3.0-2.0*rgb);
 	return c.z * mix(vec3(1.0), rgb, c.y);
 }
 
@@ -41,24 +40,24 @@ void fragment() {
 
 	vec3 col = original_color.rgb;
 	vec3 hsb = rgb2hsb(col);
+
+	// Apply the shifting (this is incremental, not by percentage of original).
 	// If not greyscale
 	if(!is_equal_approx(col[0], col[1]) || !is_equal_approx(col[1], col[2])) {
 		// Shift the color by shift_amount, but rolling over the value goes over 1
 		hsb.x = mod(hsb.x + hue, 1.0);
 	}
 	if(saturation > 0.0) {
-		hsb.y =  mix(hsb.y, 1 , saturation);
+		hsb.y = mod(hsb.y + saturation, 1.0);
 	}
-	else if (saturation < 0.0) {
-		hsb.y =  mix(0, hsb.y , 1.0 - abs(saturation));
-	}
-
 	if(value > 0.0) {
-		hsb.z =  mix(hsb.z, 1 , value);
+		hsb.z = mod(hsb.z + value, 1.0);
 	}
-	else if (value < 0.0) {
-		hsb.z =  mix(0, hsb.z , 1.0 - abs(value));
-	}
+	// Minimize uncertanities by scaling up to the standardized values, round and then scale down.
+	// I don't think removing this will will cause problems, but it's better to place it here.
+	hsb.x = round(hsb.x * 360.0) / 360.0;
+	hsb.y = round(hsb.y * 100.0) / 100.0;
+	hsb.z = round(hsb.z * 100.0) / 100.0;
 
 	col = hsb2rgb(hsb);
 	vec3 output = mix(original_color.rgb, col, selection_color.a);

--- a/src/Shaders/Effects/HSV.gdshader
+++ b/src/Shaders/Effects/HSV.gdshader
@@ -26,6 +26,24 @@ vec3 rgb2hsb(vec3 c){
 				q.x);
 }
 
+// another algorithm based on https://stackoverflow.com/questions/51203917/math-behind-hsv-to-rgb-conversion-of-colors
+//vec3 hsb2rgb(vec3 c){
+    //float i = floor(c.x * 6.0);
+    //float f = c.x * 6.0 - i;
+    //float p = c.z * (1.0 - c.y);
+    //float q = c.z * (1.0 - f * c.y);
+    //float t = c.z * (1.0 - (1.0 - f) * c.y);
+//
+    //switch (int(i) % 6){
+        //case 0: return vec3(c.z, t, p);
+        //case 1: return vec3(q, c.z, p);
+        //case 2: return vec3(p, c.z, t);
+        //case 3: return vec3(p, q, c.z);
+        //case 4: return vec3(t, p, c.z);
+        //case 5: return vec3(c.z, p, q);
+    //}
+//}
+
 vec3 hsb2rgb(vec3 c){
 	vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),
 					6.0)-3.0)-1.0,
@@ -55,20 +73,19 @@ void fragment() {
 		if (wrap_overflowing && (hsb.y + saturation > 1.0 || hsb.y + saturation < 0.0)){
 			hsb.y = mod(hsb.y + saturation, 1.0);
 		}
-		else hsb.y = clamp(hsb.x + saturation, 0.0, 1.0);
+		else hsb.y = clamp(hsb.y + saturation, 0.0, 1.0);
 	}
 	if (!is_equal_approx(value, 0)){
 		if (wrap_overflowing && (hsb.z + value > 1.0 || hsb.z + value < 0.0)){
 			hsb.z = mod(hsb.z + value, 1.0);
 		}
-		else hsb.z = clamp(hsb.x + value, 0.0, 1.0);
+		else hsb.z = clamp(hsb.z + value, 0.0, 1.0);
 	}
 	// Minimize uncertanities by scaling up to the standardized values, round and then scale down.
 	// I don't think removing this will will cause problems, but it's better to place it here.
 	hsb.x = round(hsb.x * 360.0) / 360.0;
 	hsb.y = round(hsb.y * 100.0) / 100.0;
 	hsb.z = round(hsb.z * 100.0) / 100.0;
-
 	col = hsb2rgb(hsb);
 	vec3 output = mix(original_color.rgb, col, selection_color.a);
 	COLOR = vec4(output.rgb, original_color.a);

--- a/src/Shaders/Effects/HSV.gdshader
+++ b/src/Shaders/Effects/HSV.gdshader
@@ -4,6 +4,7 @@ render_mode unshaded;
 uniform float hue : hint_range(-1, 1);
 uniform float saturation : hint_range(-1, 1);
 uniform float value : hint_range(-1, 1);
+uniform bool wrap_overflowing = false;
 uniform sampler2D selection : filter_nearest;
 
 bool is_equal_approx(float a, float b) {
@@ -45,22 +46,22 @@ void fragment() {
 	// If not greyscale
 	if(!is_equal_approx(col[0], col[1]) || !is_equal_approx(col[1], col[2])) {
 		// Shift the color by shift_amount, but rolling over the value goes over 1
-		if (hsb.x + hue > 1.0 || hsb.x + hue < 0.0){
+		if (wrap_overflowing && (hsb.x + hue > 1.0 || hsb.x + hue < 0.0)){
 			hsb.x = mod(hsb.x + hue, 1.0);
 		}
-		else hsb.x += hue;
+		else hsb.x = clamp(hsb.x + hue, 0.0, 1.0);
 	}
 	if (!is_equal_approx(saturation, 0)){
-		if (hsb.y + saturation > 1.0 || hsb.y + saturation < 0.0){
+		if (wrap_overflowing && (hsb.y + saturation > 1.0 || hsb.y + saturation < 0.0)){
 			hsb.y = mod(hsb.y + saturation, 1.0);
 		}
-		else hsb.y += saturation;
+		else hsb.y = clamp(hsb.x + saturation, 0.0, 1.0);
 	}
 	if (!is_equal_approx(value, 0)){
-		if (hsb.z + value > 1.0 || hsb.z + value < 0.0){
+		if (wrap_overflowing && (hsb.z + value > 1.0 || hsb.z + value < 0.0)){
 			hsb.z = mod(hsb.z + value, 1.0);
 		}
-		else hsb.z += value;
+		else hsb.z = clamp(hsb.x + value, 0.0, 1.0);
 	}
 	// Minimize uncertanities by scaling up to the standardized values, round and then scale down.
 	// I don't think removing this will will cause problems, but it's better to place it here.

--- a/src/Shaders/Effects/HSV.gdshader
+++ b/src/Shaders/Effects/HSV.gdshader
@@ -1,9 +1,9 @@
 shader_type canvas_item;
 render_mode unshaded;
 
-uniform float hue : hint_range(-1, 1);
-uniform float saturation : hint_range(-1, 1);
-uniform float value : hint_range(-1, 1);
+uniform int hue : hint_range(-180, 180);
+uniform int saturation : hint_range(-100, 100);
+uniform int value : hint_range(-100, 100);
 uniform bool wrap_overflowing = false;
 uniform sampler2D selection : filter_nearest;
 
@@ -15,7 +15,8 @@ float fmod(float x, float y) {
     return x - y * trunc(x / y);
 }
 
-// Inspired from Color::get_h(), Color::get_s() and Color::get_v() in godot's color.cpp
+// Inspired from Color::get_h(), Color::get_s() and Color::get_v() in godot's color.cpp.
+// All color ranges are from set [0,1].
 vec3 rgb2hsv(vec3 rgb) {
 	float h, s, v;
 	float min_val = min(rgb.r, rgb.g);
@@ -48,7 +49,7 @@ vec3 rgb2hsv(vec3 rgb) {
 	return vec3(h, s, v);
 }
 
-// Inspired from Color::set_hsv in godot's color.cpp
+// Inspired from Color::set_hsv in godot's color.cpp. All color ranges are from set [0,1].
 vec3 hsv2rgb(vec3 hsv) {
 	int i;
 	float f, p, q, t;
@@ -88,32 +89,30 @@ void fragment() {
 	vec4 selection_color = texture(selection, UV);
 
 	vec3 col = original_color.rgb;
-	vec3 hsb = rgb2hsv(col);
+	ivec3 hsv_8 = ivec3(round(rgb2hsv(col) * vec3(360.0, 100.0, 100.0)));
 
 	// Apply the shifting (this is incremental, not by percentage of original).
 	// If not greyscale
 	if(!is_equal_approx(col[0], col[1]) || !is_equal_approx(col[1], col[2])) {
 		// Shift the color by shift_amount, but rolling over ih the value goes over 1
-		if (wrap_overflowing && (hsb.x + hue > 1.0 || hsb.x + hue < 0.0)){
-			hsb.x = mod(hsb.x + hue, 1.0);
+		if (wrap_overflowing && (hsv_8.x + hue > 360 || hsv_8.x + hue < 0)){
+			hsv_8.x = int(mod(float(hsv_8.x) + float(hue), 360));
 		}
-		else hsb.x = clamp(hsb.x + hue, 0.0, 1.0);
+		else hsv_8.x = clamp(hsv_8.x + hue, 0, 360);
 	}
-	if (!is_equal_approx(saturation, 0)){
-		if (wrap_overflowing && (hsb.y + saturation > 1.0 || hsb.y + saturation < 0.0)){
-			hsb.y = mod(hsb.y + saturation, 1.0);
+	if (saturation != 0){
+		if (wrap_overflowing && (hsv_8.y + saturation > 100 || hsv_8.y + saturation < 0)){
+			hsv_8.y = int(mod(float(hsv_8.y) + float(saturation), 100));
 		}
-		else hsb.y = clamp(hsb.y + saturation, 0.0, 1.0);
+		else hsv_8.y = clamp(hsv_8.y + saturation, 0, 100);
 	}
-	if (!is_equal_approx(value, 0)){
-		if (wrap_overflowing && (hsb.z + value > 1.0 || hsb.z + value < 0.0)){
-			hsb.z = mod(hsb.z + value, 1.0);
+	if (value != 0){
+		if (wrap_overflowing && (hsv_8.z + value > 100 || hsv_8.z + value < 0)){
+			hsv_8.z = int(mod(float(hsv_8.z) + float(value), 100));
 		}
-		else hsb.z = clamp(hsb.z + value, 0.0, 1.0);
+		else hsv_8.z = clamp(hsv_8.z + value, 0, 100);
 	}
-	col = vec3(hue, 0.1, value);
-	//col = hsb - rgb2hsv(original_color.rgb);
-	//col = hsv2rgb(hsb);
+	col = hsv2rgb(vec3(hsv_8) / vec3(360, 100, 100));
 	vec3 output = mix(original_color.rgb, col, selection_color.a);
 	COLOR = vec4(output.rgb, original_color.a);
 }

--- a/src/Shaders/Effects/HSV.gdshader
+++ b/src/Shaders/Effects/HSV.gdshader
@@ -11,45 +11,75 @@ bool is_equal_approx(float a, float b) {
 	return abs(a - b) <= 0.0001;
 }
 
-vec3 rgb2hsb(vec3 c){
-	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-	vec4 p = mix(vec4(c.bg, K.wz),
-				vec4(c.gb, K.xy),
-				step(c.b, c.g));
-	vec4 q = mix(vec4(p.xyw, c.r),
-				vec4(c.r, p.yzx),
-				step(p.x, c.r));
-	float d = q.x - min(q.w, q.y);
-	float e = 1.0e-10;
-	return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)),
-				d / (q.x + e),
-				q.x);
+float fmod(float x, float y) {
+    return x - y * trunc(x / y);
 }
 
-// another algorithm based on https://stackoverflow.com/questions/51203917/math-behind-hsv-to-rgb-conversion-of-colors
-//vec3 hsb2rgb(vec3 c){
-    //float i = floor(c.x * 6.0);
-    //float f = c.x * 6.0 - i;
-    //float p = c.z * (1.0 - c.y);
-    //float q = c.z * (1.0 - f * c.y);
-    //float t = c.z * (1.0 - (1.0 - f) * c.y);
-//
-    //switch (int(i) % 6){
-        //case 0: return vec3(c.z, t, p);
-        //case 1: return vec3(q, c.z, p);
-        //case 2: return vec3(p, c.z, t);
-        //case 3: return vec3(p, q, c.z);
-        //case 4: return vec3(t, p, c.z);
-        //case 5: return vec3(c.z, p, q);
-    //}
-//}
+// Inspired from Color::get_h(), Color::get_s() and Color::get_v() in godot's color.cpp
+vec3 rgb2hsv(vec3 rgb) {
+	float h, s, v;
+	float min_val = min(rgb.r, rgb.g);
+	min_val = min(min_val, rgb.b);
+	float max_val = max(rgb.r, rgb.g);
+	max_val = max(max_val, rgb.b);
 
-vec3 hsb2rgb(vec3 c){
-	vec3 rgb = clamp(abs(mod(c.x*6.0+vec3(0.0,4.0,2.0),
-					6.0)-3.0)-1.0,
-					0.0,
-					1.0 );
-	return c.z * mix(vec3(1.0), rgb, c.y);
+	float delta = max_val - min_val;
+
+	if (is_equal_approx(delta, 0.0)) {
+		h = 0.0;
+	}
+	else{
+		if (is_equal_approx(rgb.r, max_val)) {
+			h = (rgb.g - rgb.b) / delta; // between yellow & magenta
+		} else if (is_equal_approx(rgb.g, max_val)) {
+			h = 2.0 + (rgb.b - rgb.r) / delta; // between cyan & yellow
+		} else {
+			h = 4.0 + (rgb.r - rgb.g) / delta; // between magenta & cyan
+		}
+
+		h /= 6.0f;
+		if (h < 0.0f) {
+			h += 1.0f;
+		}
+	}
+
+	s = (!is_equal_approx(max_val, 0.0)) ? (delta / max_val) : 0.0;
+	v = max_val;
+	return vec3(h, s, v);
+}
+
+// Inspired from Color::set_hsv in godot's color.cpp
+vec3 hsv2rgb(vec3 hsv) {
+	int i;
+	float f, p, q, t;
+	if (is_equal_approx(hsv.y, 0.0)) {
+		// Achromatic (gray)
+		return vec3(hsv.z, hsv.z, hsv.z);
+	}
+
+	hsv.x *= 6.0f;
+	hsv.x = fmod(hsv.x, 6);
+	i = int(floor(hsv.x));
+
+	f = hsv.x - float(i);
+	p = hsv.z * (1.0 - hsv.y);
+	q = hsv.z * (1.0 - hsv.y * f);
+	t = hsv.z * (1.0 - hsv.y * (1.0f - f));
+
+	switch (i) {
+		case 0: // Red is the dominant color
+			return vec3(hsv.z, t, p);
+		case 1: // Green is the dominant color
+			return vec3(q, hsv.z, p);
+		case 2:
+			return vec3(p, hsv.z, t);
+		case 3: // Blue is the dominant color
+			return vec3(p, q, hsv.z);
+		case 4:
+			return vec3(t, p, hsv.z);
+		default: // (5) Red is the dominant color
+			return vec3(hsv.z, p, q);
+	}
 }
 
 void fragment() {
@@ -58,12 +88,12 @@ void fragment() {
 	vec4 selection_color = texture(selection, UV);
 
 	vec3 col = original_color.rgb;
-	vec3 hsb = rgb2hsb(col);
+	vec3 hsb = rgb2hsv(col);
 
 	// Apply the shifting (this is incremental, not by percentage of original).
 	// If not greyscale
 	if(!is_equal_approx(col[0], col[1]) || !is_equal_approx(col[1], col[2])) {
-		// Shift the color by shift_amount, but rolling over the value goes over 1
+		// Shift the color by shift_amount, but rolling over ih the value goes over 1
 		if (wrap_overflowing && (hsb.x + hue > 1.0 || hsb.x + hue < 0.0)){
 			hsb.x = mod(hsb.x + hue, 1.0);
 		}
@@ -81,12 +111,9 @@ void fragment() {
 		}
 		else hsb.z = clamp(hsb.z + value, 0.0, 1.0);
 	}
-	// Minimize uncertanities by scaling up to the standardized values, round and then scale down.
-	// I don't think removing this will will cause problems, but it's better to place it here.
-	hsb.x = round(hsb.x * 360.0) / 360.0;
-	hsb.y = round(hsb.y * 100.0) / 100.0;
-	hsb.z = round(hsb.z * 100.0) / 100.0;
-	col = hsb2rgb(hsb);
+	col = vec3(hue, 0.1, value);
+	//col = hsb - rgb2hsv(original_color.rgb);
+	//col = hsv2rgb(hsb);
 	vec3 output = mix(original_color.rgb, col, selection_color.a);
 	COLOR = vec4(output.rgb, original_color.a);
 }

--- a/src/UI/Dialogs/ImageEffects/BrightnessContrastDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/BrightnessContrastDialog.gd
@@ -1,8 +1,21 @@
 extends ImageEffect
 
-enum Animate { BRIGHTNESS, CONTRAST, SATURATION, RED, GREEN, BLUE, TINT_EFFECT_FACTOR }
+enum Animate {
+	RED_SHIFT,
+	GREEN_SHIFT,
+	BLUE_SHIFT,
+	BRIGHTNESS,
+	CONTRAST,
+	SATURATION,
+	RED,
+	GREEN,
+	BLUE,
+	TINT_EFFECT_FACTOR
+}
 
 var shader := preload("res://src/Shaders/Effects/BrightnessContrast.gdshader")
+
+@onready var overflow_check_box := $VBoxContainer/OverflowCheckBox as CheckBox
 
 
 func _ready() -> void:
@@ -10,16 +23,22 @@ func _ready() -> void:
 	var sm := ShaderMaterial.new()
 	sm.shader = shader
 	preview.set_material(sm)
+	animate_panel.add_float_property("Red shift", $VBoxContainer/RedShift)
+	animate_panel.add_float_property("Green shift", $VBoxContainer/GreenShift)
+	animate_panel.add_float_property("Blue shift", $VBoxContainer/BlueShift)
 	animate_panel.add_float_property("Brightness", $VBoxContainer/BrightnessSlider)
 	animate_panel.add_float_property("Contrast", $VBoxContainer/ContrastSlider)
 	animate_panel.add_float_property("Saturation", $VBoxContainer/SaturationSlider)
-	animate_panel.add_float_property("Red", $VBoxContainer/RedSlider)
-	animate_panel.add_float_property("Green", $VBoxContainer/GreenSlider)
-	animate_panel.add_float_property("Blue", $VBoxContainer/BlueSlider)
+	animate_panel.add_float_property("Red contribution", $VBoxContainer/RedSlider)
+	animate_panel.add_float_property("Green contribution", $VBoxContainer/GreenSlider)
+	animate_panel.add_float_property("Blue contribution", $VBoxContainer/BlueSlider)
 	animate_panel.add_float_property("Tint effect factor", $VBoxContainer/TintSlider)
 
 
 func commit_action(cel: Image, project := Global.current_project) -> void:
+	var red_shift := animate_panel.get_animated_value(commit_idx, Animate.RED_SHIFT) / 255.0
+	var green_shift := animate_panel.get_animated_value(commit_idx, Animate.GREEN_SHIFT) / 255.0
+	var blue_shift := animate_panel.get_animated_value(commit_idx, Animate.BLUE_SHIFT) / 255.0
 	var brightness := animate_panel.get_animated_value(commit_idx, Animate.BRIGHTNESS) / 100.0
 	var contrast := animate_panel.get_animated_value(commit_idx, Animate.CONTRAST) / 100.0
 	var saturation := animate_panel.get_animated_value(commit_idx, Animate.SATURATION) / 100.0
@@ -34,8 +53,10 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 	if selection_checkbox.button_pressed and project.has_selection:
 		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
-
 	var params := {
+		"red_shift": red_shift,
+		"green_shift": green_shift,
+		"blue_shift": blue_shift,
 		"brightness": brightness,
 		"contrast": contrast,
 		"saturation": saturation,
@@ -44,6 +65,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 		"green_value": green,
 		"tint_color": tint_color,
 		"tint_effect_factor": tint_effect_factor,
+		"wrap_overflowing": overflow_check_box.button_pressed,
 		"selection": selection_tex
 	}
 
@@ -53,6 +75,18 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 	else:
 		var gen := ShaderImageEffect.new()
 		gen.generate_image(cel, shader, params, project.size)
+
+
+func _on_red_shift_value_changed(_value: float) -> void:
+	update_preview()
+
+
+func _on_green_shift_value_changed(_value: float) -> void:
+	update_preview()
+
+
+func _on_blue_shift_value_changed(_value: float) -> void:
+	update_preview()
 
 
 func _on_brightness_slider_value_changed(_value: float) -> void:
@@ -84,4 +118,8 @@ func _on_tint_color_color_changed(_color: Color) -> void:
 
 
 func _on_tint_slider_value_changed(_value: float) -> void:
+	update_preview()
+
+
+func _on_overflow_check_box_toggled(_toggled_on: bool) -> void:
 	update_preview()

--- a/src/UI/Dialogs/ImageEffects/BrightnessContrastDialog.tscn
+++ b/src/UI/Dialogs/ImageEffects/BrightnessContrastDialog.tscn
@@ -13,7 +13,58 @@ script = ExtResource("2_msv0o")
 [node name="VBoxContainer" parent="." index="2" unique_id=1773123238]
 offset_bottom = 491.0
 
-[node name="BrightnessSlider" type="TextureProgressBar" parent="VBoxContainer" index="2" unique_id=738643021]
+[node name="RedShift" type="TextureProgressBar" parent="VBoxContainer" index="2" unique_id=2116233543]
+custom_minimum_size = Vector2(32, 24)
+layout_mode = 2
+focus_mode = 2
+mouse_default_cursor_shape = 2
+theme_type_variation = &"ValueSlider"
+min_value = -255.0
+max_value = 255.0
+allow_greater = true
+nine_patch_stretch = true
+stretch_margin_left = 3
+stretch_margin_top = 3
+stretch_margin_right = 3
+stretch_margin_bottom = 3
+script = ExtResource("3_2epr4")
+prefix = "Red shift:"
+
+[node name="GreenShift" type="TextureProgressBar" parent="VBoxContainer" index="3" unique_id=1436100762]
+custom_minimum_size = Vector2(32, 24)
+layout_mode = 2
+focus_mode = 2
+mouse_default_cursor_shape = 2
+theme_type_variation = &"ValueSlider"
+min_value = -255.0
+max_value = 255.0
+allow_greater = true
+nine_patch_stretch = true
+stretch_margin_left = 3
+stretch_margin_top = 3
+stretch_margin_right = 3
+stretch_margin_bottom = 3
+script = ExtResource("3_2epr4")
+prefix = "Green shift:"
+
+[node name="BlueShift" type="TextureProgressBar" parent="VBoxContainer" index="4" unique_id=2079536811]
+custom_minimum_size = Vector2(32, 24)
+layout_mode = 2
+focus_mode = 2
+mouse_default_cursor_shape = 2
+theme_type_variation = &"ValueSlider"
+min_value = -255.0
+max_value = 255.0
+allow_greater = true
+nine_patch_stretch = true
+stretch_margin_left = 3
+stretch_margin_top = 3
+stretch_margin_right = 3
+stretch_margin_bottom = 3
+script = ExtResource("3_2epr4")
+prefix = "Blue shift:"
+
+[node name="BrightnessSlider" type="TextureProgressBar" parent="VBoxContainer" index="5" unique_id=738643021]
 custom_minimum_size = Vector2(32, 24)
 layout_mode = 2
 focus_mode = 2
@@ -28,7 +79,7 @@ stretch_margin_bottom = 3
 script = ExtResource("3_2epr4")
 prefix = "Brightness:"
 
-[node name="ContrastSlider" type="TextureProgressBar" parent="VBoxContainer" index="3" unique_id=719668350]
+[node name="ContrastSlider" type="TextureProgressBar" parent="VBoxContainer" index="6" unique_id=719668350]
 custom_minimum_size = Vector2(32, 24)
 layout_mode = 2
 focus_mode = 2
@@ -44,7 +95,7 @@ stretch_margin_bottom = 3
 script = ExtResource("3_2epr4")
 prefix = "Contrast:"
 
-[node name="SaturationSlider" type="TextureProgressBar" parent="VBoxContainer" index="4" unique_id=450016837]
+[node name="SaturationSlider" type="TextureProgressBar" parent="VBoxContainer" index="7" unique_id=450016837]
 custom_minimum_size = Vector2(32, 24)
 layout_mode = 2
 focus_mode = 2
@@ -60,13 +111,14 @@ stretch_margin_bottom = 3
 script = ExtResource("3_2epr4")
 prefix = "Saturation:"
 
-[node name="RedSlider" type="TextureProgressBar" parent="VBoxContainer" index="5" unique_id=1115794383]
+[node name="RedSlider" type="TextureProgressBar" parent="VBoxContainer" index="8" unique_id=1115794383]
 custom_minimum_size = Vector2(32, 24)
 layout_mode = 2
 focus_mode = 2
 mouse_default_cursor_shape = 2
 theme_type_variation = &"ValueSlider"
 value = 100.0
+allow_greater = true
 nine_patch_stretch = true
 stretch_margin_left = 3
 stretch_margin_top = 3
@@ -74,14 +126,16 @@ stretch_margin_right = 3
 stretch_margin_bottom = 3
 script = ExtResource("3_2epr4")
 prefix = "Red value:"
+suffix = "%"
 
-[node name="GreenSlider" type="TextureProgressBar" parent="VBoxContainer" index="6" unique_id=1456343987]
+[node name="GreenSlider" type="TextureProgressBar" parent="VBoxContainer" index="9" unique_id=1456343987]
 custom_minimum_size = Vector2(32, 24)
 layout_mode = 2
 focus_mode = 2
 mouse_default_cursor_shape = 2
 theme_type_variation = &"ValueSlider"
 value = 100.0
+allow_greater = true
 nine_patch_stretch = true
 stretch_margin_left = 3
 stretch_margin_top = 3
@@ -89,14 +143,16 @@ stretch_margin_right = 3
 stretch_margin_bottom = 3
 script = ExtResource("3_2epr4")
 prefix = "Green value:"
+suffix = "%"
 
-[node name="BlueSlider" type="TextureProgressBar" parent="VBoxContainer" index="7" unique_id=2082911472]
+[node name="BlueSlider" type="TextureProgressBar" parent="VBoxContainer" index="10" unique_id=2082911472]
 custom_minimum_size = Vector2(32, 24)
 layout_mode = 2
 focus_mode = 2
 mouse_default_cursor_shape = 2
 theme_type_variation = &"ValueSlider"
 value = 100.0
+allow_greater = true
 nine_patch_stretch = true
 stretch_margin_left = 3
 stretch_margin_top = 3
@@ -104,8 +160,9 @@ stretch_margin_right = 3
 stretch_margin_bottom = 3
 script = ExtResource("3_2epr4")
 prefix = "Blue value:"
+suffix = "%"
 
-[node name="TintColorContainer" type="HBoxContainer" parent="VBoxContainer" index="8" unique_id=975945355]
+[node name="TintColorContainer" type="HBoxContainer" parent="VBoxContainer" index="11" unique_id=975945355]
 layout_mode = 2
 alignment = 1
 
@@ -119,7 +176,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 color = Color(1, 1, 1, 1)
 
-[node name="TintSlider" type="TextureProgressBar" parent="VBoxContainer" index="9" unique_id=1493212009]
+[node name="TintSlider" type="TextureProgressBar" parent="VBoxContainer" index="12" unique_id=1493212009]
 custom_minimum_size = Vector2(32, 24)
 layout_mode = 2
 focus_mode = 2
@@ -133,6 +190,13 @@ stretch_margin_bottom = 3
 script = ExtResource("3_2epr4")
 prefix = "Tint effect factor:"
 
+[node name="OverflowCheckBox" type="CheckBox" parent="VBoxContainer" index="13" unique_id=901992428]
+layout_mode = 2
+text = "Wrap overflowing values"
+
+[connection signal="value_changed" from="VBoxContainer/RedShift" to="." method="_on_red_shift_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/GreenShift" to="." method="_on_green_shift_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/BlueShift" to="." method="_on_blue_shift_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/BrightnessSlider" to="." method="_on_brightness_slider_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/ContrastSlider" to="." method="_on_contrast_slider_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/SaturationSlider" to="." method="_on_saturation_slider_value_changed"]
@@ -141,3 +205,4 @@ prefix = "Tint effect factor:"
 [connection signal="value_changed" from="VBoxContainer/BlueSlider" to="." method="_on_blue_slider_value_changed"]
 [connection signal="color_changed" from="VBoxContainer/TintColorContainer/TintColor" to="." method="_on_tint_color_color_changed"]
 [connection signal="value_changed" from="VBoxContainer/TintSlider" to="." method="_on_tint_slider_value_changed"]
+[connection signal="toggled" from="VBoxContainer/OverflowCheckBox" to="." method="_on_overflow_check_box_toggled"]

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.gd
@@ -6,6 +6,7 @@ var shader := preload("res://src/Shaders/Effects/HSV.gdshader")
 @onready var hue_slider := $VBoxContainer/HueSlider as ValueSlider
 @onready var sat_slider := $VBoxContainer/SaturationSlider as ValueSlider
 @onready var val_slider := $VBoxContainer/ValueSlider as ValueSlider
+@onready var overflow_check_box := $VBoxContainer/OverflowCheckBox as CheckBox
 
 
 func _ready() -> void:
@@ -33,7 +34,13 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
-	var params := {"hue": hue, "saturation": sat, "value": val, "selection": selection_tex}
+	var params := {
+		"hue": hue,
+		"saturation": sat,
+		"value": val,
+		"selection": selection_tex,
+		"wrap_overflowing": overflow_check_box.button_pressed
+	}
 	if !has_been_confirmed:
 		for param in params:
 			preview.material.set_shader_parameter(param, params[param])
@@ -58,4 +65,8 @@ func _on_SaturationSlider_value_changed(_value: float) -> void:
 
 
 func _on_ValueSlider_value_changed(_value: float) -> void:
+	update_preview()
+
+
+func _on_overflow_check_box_toggled(_toggled_on: bool) -> void:
 	update_preview()

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.gd
@@ -34,12 +34,9 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
-	hue = remap(hue, -180, 180, -1, 1)
-	sat = remap(sat, -100, 100, -1, 1)
-	val = remap(val, -100, 100, -1, 1)
 	var params := {
 		"hue": hue,
-		"saturation": 0.1,
+		"saturation": sat,
 		"value": val,
 		"selection": selection_tex,
 		"wrap_overflowing": overflow_check_box.button_pressed
@@ -49,16 +46,7 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 			preview.material.set_shader_parameter(param, params[param])
 	else:
 		var gen := ShaderImageEffect.new()
-		print("======================")# 0.09803921729326
-		var old_a = cel.get_pixel(1, 1).g
-		var old_b = cel.get_pixel(2, 1).g
-		var old_c = cel.get_pixel(3, 1).g
 		gen.generate_image(cel, shader, params, project.size)
-		var new_a = cel.get_pixel(1, 1).g
-		var new_b = cel.get_pixel(2, 1).g
-		var new_c = cel.get_pixel(3, 1).g
-		prints("New:", new_a, new_b, new_c)
-		#prints("Dif:", new_a - old_a, new_b - old_b, new_c - old_c)
 
 
 func _reset() -> void:

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.gd
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.gd
@@ -26,17 +26,20 @@ func _about_to_popup() -> void:
 
 
 func commit_action(cel: Image, project := Global.current_project) -> void:
-	var hue = animate_panel.get_animated_value(commit_idx, Animate.HUE) / 360
-	var sat = animate_panel.get_animated_value(commit_idx, Animate.SATURATION) / 100
-	var val = animate_panel.get_animated_value(commit_idx, Animate.VALUE) / 100
+	var hue = animate_panel.get_animated_value(commit_idx, Animate.HUE)
+	var sat = animate_panel.get_animated_value(commit_idx, Animate.SATURATION)
+	var val = animate_panel.get_animated_value(commit_idx, Animate.VALUE)
 	var selection_tex: ImageTexture
 	if selection_checkbox.button_pressed and project.has_selection:
 		var selection := project.selection_map.return_cropped_copy(project, project.size)
 		selection_tex = ImageTexture.create_from_image(selection)
 
+	hue = remap(hue, -180, 180, -1, 1)
+	sat = remap(sat, -100, 100, -1, 1)
+	val = remap(val, -100, 100, -1, 1)
 	var params := {
 		"hue": hue,
-		"saturation": sat,
+		"saturation": 0.1,
 		"value": val,
 		"selection": selection_tex,
 		"wrap_overflowing": overflow_check_box.button_pressed
@@ -46,7 +49,16 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 			preview.material.set_shader_parameter(param, params[param])
 	else:
 		var gen := ShaderImageEffect.new()
+		print("======================")# 0.09803921729326
+		var old_a = cel.get_pixel(1, 1).g
+		var old_b = cel.get_pixel(2, 1).g
+		var old_c = cel.get_pixel(3, 1).g
 		gen.generate_image(cel, shader, params, project.size)
+		var new_a = cel.get_pixel(1, 1).g
+		var new_b = cel.get_pixel(2, 1).g
+		var new_c = cel.get_pixel(3, 1).g
+		prints("New:", new_a, new_b, new_c)
+		#prints("Dif:", new_a - old_a, new_b - old_b, new_c - old_c)
 
 
 func _reset() -> void:

--- a/src/UI/Dialogs/ImageEffects/HSVDialog.tscn
+++ b/src/UI/Dialogs/ImageEffects/HSVDialog.tscn
@@ -5,11 +5,13 @@
 [ext_resource type="PackedScene" uid="uid://yjhp0ssng2mp" path="res://src/UI/Nodes/Sliders/ValueSlider.tscn" id="3"]
 
 [node name="HSVDialog" unique_id=1520656639 instance=ExtResource("2")]
+oversampling_override = 1.0
 title = "Adjust Hue/Saturation/Value"
+size = Vector2i(362, 435)
 script = ExtResource("1")
 
 [node name="VBoxContainer" parent="." index="2" unique_id=1773123238]
-offset_bottom = 344.0
+offset_bottom = 386.0
 
 [node name="HueSlider" parent="VBoxContainer" index="2" unique_id=161711944 instance=ExtResource("3")]
 layout_mode = 2
@@ -27,6 +29,11 @@ layout_mode = 2
 min_value = -100.0
 prefix = "Value:"
 
+[node name="OverflowCheckBox" type="CheckBox" parent="VBoxContainer" index="5" unique_id=1305313863]
+layout_mode = 2
+text = "Wrap overflowing values"
+
 [connection signal="value_changed" from="VBoxContainer/HueSlider" to="." method="_on_HueSlider_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/SaturationSlider" to="." method="_on_SaturationSlider_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/ValueSlider" to="." method="_on_ValueSlider_value_changed"]
+[connection signal="toggled" from="VBoxContainer/OverflowCheckBox" to="." method="_on_overflow_check_box_toggled"]

--- a/src/UI/Nodes/AnimatePanel.gd
+++ b/src/UI/Nodes/AnimatePanel.gd
@@ -112,6 +112,8 @@ func _refresh_properties(idx: int):
 	# Nodes setup
 	var property_node: Range = properties[idx]["range_node"]
 	if property_node is ValueSlider:
+		initial_value.suffix = property_node.suffix
+		final_value.suffix = property_node.suffix
 		final_value.snap_step = property_node.snap_step
 		initial_value.snap_step = property_node.snap_step
 	final_value.allow_greater = property_node.allow_greater


### PR DESCRIPTION
there were 2 issues:

- Replaced HSV <-> RGB algorithms by ones used by Godot (in it's source code) 

- Use integers in the shader. this makes it consistent between Layer FX and Image effect versions.

- The saturation and value were being incremented very awkwardly (i assume by percentages), so i changed them to how hue was being shifted.

## New Feature:
Added RGB shifting to brightness dialog