### PR TITLE
Fixed darkening of edges in the gaussian blur effect

### DIFF
--- a/src/Shaders/Effects/GaussianBlur.gdshader
+++ b/src/Shaders/Effects/GaussianBlur.gdshader
@@ -1,6 +1,7 @@
 // https://godotshaders.com/shader/gaussian-blur-functions-for-gles2/
 // Licensed under MIT.
 shader_type canvas_item;
+render_mode unshaded;
 
 uniform int blur_type : hint_enum("Xor's Gaussian Blur", "Monk's Multi-Pass Gaussian Blur", "NoDev's Single-Pass Gaussian Blur", "NoDev's Multi-Pass Gaussian Blur") = 0;
 uniform int blur_amount : hint_range(0, 100, 1) = 16;
@@ -8,107 +9,148 @@ uniform float blur_radius : hint_range(0.0, 100.0, 1.0) = 1.0;
 uniform vec2 blur_direction = vec2(1, 1);
 uniform sampler2D selection : filter_nearest;
 
-// Xor's gaussian blur function
-// Link: https://xorshaders.weebly.com/tutorials/blur-shaders-5-part-2
+// Xor's gaussian blur function from https://xorshaders.weebly.com/tutorials/blur-shaders-5-part-2
 // Defaults from: https://www.shadertoy.com/view/Xltfzj
-//
 // BLUR BLURRINESS (Default 8.0)
 // BLUR ITERATIONS (Default 16.0 - More is better but slower)
 // BLUR QUALITY (Default 4.0 - More is better but slower)
 //
-// Desc.: Don't have the best performance but will run on almost
-// anything, although, if developing for mobile, is better to use
-// 'texture_nodevgaussian(...) instead'.
+// improved with wide Gaussian bell curve and alpha-weighted averaging for correct color
+// on transparent backgrounds.
 vec4 texture_xorgaussian(sampler2D tex, vec2 uv, vec2 pixel_size, float blurriness, int iterations, int quality) {
 	vec2 radius = blurriness / (1.0 / pixel_size).xy;
-	vec4 blurred_tex = texture(tex, uv);
+	float total_weight = 1.0;
 
+	// Center pixel
+	vec4 center = texture(tex, uv);
+	vec3 blur_color_sum = center.rgb * center.a;
+	float blur_alpha_sum = center.a;
+
+	// Add up the colors of pixels arround the center pixel according to their gaussian weights.
 	for(float d = 0.0; d < TAU; d += TAU / float(iterations)) {
 		for(float i = 1.0 / float(quality); i <= 1.0; i += 1.0 / float(quality)) {
 			vec2 directions = uv + vec2(cos(d), sin(d)) * radius * i;
-			blurred_tex += texture(tex, directions);
+			// Read color located at the direction (r, theta) = (radius * i, d) relative to center.
+			vec4 sample_col = texture(tex, directions);
+			// Wide Gaussian: exp(-i^2 * 0.5) - gentle falloff for wider gradient spread
+			float w = exp(-i * i * 0.5);
+			blur_color_sum += sample_col.rgb * sample_col.a * w;
+			blur_alpha_sum += sample_col.a * w;
+			total_weight += w;
 		}
 	}
-	blurred_tex /= float(quality) * float(iterations) + 1.0;
+
+	// Average up the colors summed above to get the blurred color
+	vec4 blurred_tex = vec4(0.0);
+	if (blur_alpha_sum > 0.0) {
+		// Unpremultiply RGB: compute alpha-weighted average color
+		blurred_tex.rgb = blur_color_sum / blur_alpha_sum;
+	}
+	blurred_tex.a = blur_alpha_sum / total_weight;
 
 	return blurred_tex;
 }
 
-// Experience-Monks' fast gaussian blur function
-// Link: https://github.com/Experience-Monks/glsl-fast-gaussian-blur/
-//
-// BLUR ITERATIONS (Default 16.0 - More is better but slower)
-// BLUR DIRECTION (Direction in which the blur is applied, use vec2(1, 0) for first pass and vec2(0, 1) for second pass)
-//
-// Desc.: ACTUALLY PRETTY SLOW but still pretty good for custom cinematic
-// bloom effects, since this needs render 2 passes
+// Monk's multi-pass gaussian blur — improved with per-iteration Gaussian decay
+// and alpha-weighted averaging for correct color on transparent backgrounds.
 vec4 texture_monksgaussian_multipass(sampler2D tex, vec2 uv, vec2 pixel_size, int iterations, vec2 direction) {
-	vec4 blurred_tex = vec4(0.0);
+	vec3 blur_color_sum = vec3(0.0);
+	float blur_alpha_sum = 0.0;
+	float total_weight = 0.0;
 	vec2 resolution = 1.0 / pixel_size;
 
 	for (int i = 0; i < iterations; i++ ) {
 		float size = float(iterations - i);
+		float scale_weight = exp(-float(i * i) / max(1.0, float(iterations) * 0.8));
 
 		vec2 off1 = vec2(1.3846153846) * (direction * size);
 		vec2 off2 = vec2(3.2307692308) * (direction * size);
 
-		blurred_tex += texture(tex, uv) * 0.2270270270;
-		blurred_tex += texture(tex, uv + (off1 / resolution)) * 0.3162162162;
-		blurred_tex += texture(tex, uv - (off1 / resolution)) * 0.3162162162;
-		blurred_tex += texture(tex, uv + (off2 / resolution)) * 0.0702702703;
-		blurred_tex += texture(tex, uv - (off2 / resolution)) * 0.0702702703;
+		vec4 s0 = texture(tex, uv);
+		vec4 s1 = texture(tex, uv + (off1 / resolution));
+		vec4 s2 = texture(tex, uv - (off1 / resolution));
+		vec4 s3 = texture(tex, uv + (off2 / resolution));
+		vec4 s4 = texture(tex, uv - (off2 / resolution));
+
+		float w0 = 0.2270270270 * scale_weight;
+		float w1 = 0.3162162162 * scale_weight;
+		float w2 = 0.3162162162 * scale_weight;
+		float w3 = 0.0702702703 * scale_weight;
+		float w4 = 0.0702702703 * scale_weight;
+
+		blur_color_sum += s0.rgb * s0.a * w0;
+		blur_color_sum += s1.rgb * s1.a * w1;
+		blur_color_sum += s2.rgb * s2.a * w2;
+		blur_color_sum += s3.rgb * s3.a * w3;
+		blur_color_sum += s4.rgb * s4.a * w4;
+
+		blur_alpha_sum += s0.a * w0;
+		blur_alpha_sum += s1.a * w1;
+		blur_alpha_sum += s2.a * w2;
+		blur_alpha_sum += s3.a * w3;
+		blur_alpha_sum += s4.a * w4;
+
+		total_weight += (w0 + w1 + w2 + w3 + w4);
 	}
 
-	blurred_tex /= float(iterations) + 1.0;
+	vec4 blurred_tex = vec4(0.0);
+	if (blur_alpha_sum > 0.0) {
+		blurred_tex.rgb = blur_color_sum / blur_alpha_sum;
+	}
+	blurred_tex.a = blur_alpha_sum / total_weight;
 
 	return blurred_tex;
 }
 
-// u/_NoDev_'s gaussian blur function
-// Discussion Link: https://www.reddit.com/r/godot/comments/klgfo9/help_with_shaders_in_gles2/
-// Code Link: https://postimg.cc/7JDJw80d
-//
-// BLUR BLURRINESS (Default 8.0 - More is better but slower)
-// BLUR RADIUS (Default 1.5)
-// BLUR DIRECTION (Direction in which the blur is applied, use vec2(1, 0) for first pass and vec2(0, 1) for second pass)
-//
-// Desc.: Really fast and GOOD FOR MOST CASES, but might NOT RUN IN THE WEB!
-// use 'texture_xorgaussian' instead if you found any issues.
+// NoDev's gaussian blur functions — improved with wide Gaussian bell curve
+// and alpha-weighted averaging for correct color on transparent backgrounds.
 vec4 texture_nodevgaussian_singlepass(sampler2D tex, vec2 uv, vec2 pixel_size, float blurriness, float radius) {
-	float n = 0.0015;
-	vec4 blurred_tex = vec4(0);
-	float weight;
+	float sigma = max(1.0, blurriness * 0.7);
+	vec3 blur_color_sum = vec3(0);
+	float blur_alpha_sum = 0.0;
+	float total_weight = 0.0;
 
 	for (float i = -blurriness; i <= blurriness; i++) {
 		float d = i / PI;
 		vec2 anchor = vec2(cos(d), sin(d)) * radius * i;
 		vec2 directions = uv + pixel_size * anchor;
-		blurred_tex += texture(tex, directions) * n;
-		if (i <= 0.0) {n += 0.0015; }
-		if (i > 0.0) {n -= 0.0015; }
-		weight += n;
+		vec4 sample_col = texture(tex, directions);
+		float w = exp(-(i * i) / (2.0 * sigma * sigma));
+		blur_color_sum += sample_col.rgb * sample_col.a * w;
+		blur_alpha_sum += sample_col.a * w;
+		total_weight += w;
 	}
 
-	float norm = 1.0 / weight;
-	blurred_tex *= norm;
+	vec4 blurred_tex = vec4(0);
+	if (blur_alpha_sum > 0.0) {
+		blurred_tex.rgb = blur_color_sum / blur_alpha_sum;
+	}
+	blurred_tex.a = blur_alpha_sum / total_weight;
+
 	return blurred_tex;
 }
 
 vec4 texture_nodevgaussian_multipass(sampler2D tex, vec2 uv, vec2 pixel_size, float blurriness, vec2 direction) {
-	float n = 0.0015;
-	vec4 blurred_tex = vec4(0);
-	float weight;
+	float sigma = max(1.0, blurriness * 0.7);
+	vec3 blur_color_sum = vec3(0);
+	float blur_alpha_sum = 0.0;
+	float total_weight = 0.0;
 
 	for (float i = -blurriness; i <= blurriness; i++) {
 		vec2 directions = uv + pixel_size * (direction * i);
-		blurred_tex += texture(tex, directions) * n;
-		if (i <= 0.0) {n += 0.0015; }
-		if (i > 0.0) {n -= 0.0015; }
-		weight += n;
+		vec4 sample_col = texture(tex, directions);
+		float w = exp(-(i * i) / (2.0 * sigma * sigma));
+		blur_color_sum += sample_col.rgb * sample_col.a * w;
+		blur_alpha_sum += sample_col.a * w;
+		total_weight += w;
 	}
 
-	float norm = 1.0 / weight;
-	blurred_tex *= norm;
+	vec4 blurred_tex = vec4(0);
+	if (blur_alpha_sum > 0.0) {
+		blurred_tex.rgb = blur_color_sum / blur_alpha_sum;
+	}
+	blurred_tex.a = blur_alpha_sum / total_weight;
+
 	return blurred_tex;
 }
 
@@ -117,7 +159,7 @@ void fragment() {
 	vec4 selection_color = texture(selection, UV);
 	vec4 col = original_color;
 	if (blur_type == 0) {
-		vec4 xorgaussian = texture_xorgaussian(TEXTURE, UV, TEXTURE_PIXEL_SIZE, float(blur_amount), 16, 4);
+		vec4 xorgaussian = texture_xorgaussian(TEXTURE, UV, TEXTURE_PIXEL_SIZE, float(blur_amount), 32, 8);
 		col = xorgaussian;
 	}
 	else if (blur_type == 1) {

--- a/src/Shaders/Effects/GaussianBlur.gdshader
+++ b/src/Shaders/Effects/GaussianBlur.gdshader
@@ -26,7 +26,7 @@ vec4 texture_xorgaussian(sampler2D tex, vec2 uv, vec2 pixel_size, float blurrine
 	vec3 blur_color_sum = center.rgb * center.a;
 	float blur_alpha_sum = center.a;
 
-	// Add up the colors of pixels arround the center pixel according to their gaussian weights.
+	// Add up the colors of pixels around the center pixel according to their gaussian weights.
 	for(float d = 0.0; d < TAU; d += TAU / float(iterations)) {
 		for(float i = 1.0 / float(quality); i <= 1.0; i += 1.0 / float(quality)) {
 			vec2 directions = uv + vec2(cos(d), sin(d)) * radius * i;

--- a/src/UI/Dialogs/ImageEffects/GaussianBlur.gd
+++ b/src/UI/Dialogs/ImageEffects/GaussianBlur.gd
@@ -6,6 +6,17 @@ var blur_radius := 1.0
 var blur_direction := Vector2.ONE
 var shader := preload("res://src/Shaders/Effects/GaussianBlur.gdshader")
 
+# Supersample factor for smoother blur gradients on the commit path.
+# The blur is rendered at (SUPERSAMPLE × original) resolution, then
+# downscaled back with LANCZOS interpolation, producing much smoother
+# gradient transitions than rendering at native pixel-art resolution.
+const SUPERSAMPLE := 16
+
+# Number of iterative blur passes at supersampled resolution.
+# Each pass progressively smooths the gradient further.
+# More passes = smoother result, but slower.
+const BLUR_PASSES := 3
+
 
 func _ready() -> void:
 	super._ready()
@@ -31,8 +42,46 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 		for param in params:
 			preview.material.set_shader_parameter(param, params[param])
 	else:
-		var gen := ShaderImageEffect.new()
-		gen.generate_image(cel, shader, params, project.size)
+		# --- Supersampled + iterative rendering for smooth blur ---
+		var super_size := project.size * SUPERSAMPLE
+
+		# 1. Upscale the cel image to SUPERSAMPLE×resolution with bilinear
+		#    interpolation so the blur shader sees smooth intermediate values.
+		var super_image := Image.create(super_size.x, super_size.y, false, Image.FORMAT_RGBA8)
+		super_image.copy_from(cel)
+		super_image.resize(super_size.x, super_size.y, Image.INTERPOLATE_BILINEAR)
+
+		# 2. Upscale the selection texture to match supersampled size
+		var super_selection_tex: ImageTexture
+		if selection_tex:
+			var selected_img_supersampled := selection_tex.get_image()
+			selected_img_supersampled.resize(super_size.x, super_size.y, Image.INTERPOLATE_NEAREST)
+			super_selection_tex = ImageTexture.create_from_image(selected_img_supersampled)
+
+		# 3. Apply iterative blur passes at supersampled resolution.
+		#    Each pass smooths the previous result further.
+		#    Pass blur_amount = total / sqrt(passes) so the cumulative
+		#    Gaussian width is approximately the same as a single pass.
+		var pass_blur_amount: float = max(1.0, float(blur_amount) * float(SUPERSAMPLE) / sqrt(float(BLUR_PASSES)))
+		var pass_blur_radius: float = blur_radius * float(SUPERSAMPLE) / sqrt(float(BLUR_PASSES))
+
+		for _pass in range(BLUR_PASSES):
+			var super_params := {
+				"blur_type": blur_type,
+				"blur_amount": int(pass_blur_amount),
+				"blur_radius": pass_blur_radius,
+				"blur_direction": blur_direction,
+				"selection": super_selection_tex
+			}
+			var gen := ShaderImageEffect.new()
+			gen.generate_image(super_image, shader, super_params, super_size)
+
+		# 4. Downscale back to original size with high-quality LANCZOS
+		super_image.resize(project.size.x, project.size.y, Image.INTERPOLATE_LANCZOS)
+
+		# 5. Copy result back into the cel (preserving original format)
+		super_image.convert(cel.get_format())
+		cel.copy_from(super_image)
 
 
 func _on_blur_type_item_selected(index: int) -> void:

--- a/src/UI/Dialogs/ImageEffects/GaussianBlur.gd
+++ b/src/UI/Dialogs/ImageEffects/GaussianBlur.gd
@@ -6,17 +6,6 @@ var blur_radius := 1.0
 var blur_direction := Vector2.ONE
 var shader := preload("res://src/Shaders/Effects/GaussianBlur.gdshader")
 
-# Supersample factor for smoother blur gradients on the commit path.
-# The blur is rendered at (SUPERSAMPLE × original) resolution, then
-# downscaled back with LANCZOS interpolation, producing much smoother
-# gradient transitions than rendering at native pixel-art resolution.
-const SUPERSAMPLE := 16
-
-# Number of iterative blur passes at supersampled resolution.
-# Each pass progressively smooths the gradient further.
-# More passes = smoother result, but slower.
-const BLUR_PASSES := 3
-
 
 func _ready() -> void:
 	super._ready()
@@ -42,46 +31,8 @@ func commit_action(cel: Image, project := Global.current_project) -> void:
 		for param in params:
 			preview.material.set_shader_parameter(param, params[param])
 	else:
-		# --- Supersampled + iterative rendering for smooth blur ---
-		var super_size := project.size * SUPERSAMPLE
-
-		# 1. Upscale the cel image to SUPERSAMPLE×resolution with bilinear
-		#    interpolation so the blur shader sees smooth intermediate values.
-		var super_image := Image.create(super_size.x, super_size.y, false, Image.FORMAT_RGBA8)
-		super_image.copy_from(cel)
-		super_image.resize(super_size.x, super_size.y, Image.INTERPOLATE_BILINEAR)
-
-		# 2. Upscale the selection texture to match supersampled size
-		var super_selection_tex: ImageTexture
-		if selection_tex:
-			var selected_img_supersampled := selection_tex.get_image()
-			selected_img_supersampled.resize(super_size.x, super_size.y, Image.INTERPOLATE_NEAREST)
-			super_selection_tex = ImageTexture.create_from_image(selected_img_supersampled)
-
-		# 3. Apply iterative blur passes at supersampled resolution.
-		#    Each pass smooths the previous result further.
-		#    Pass blur_amount = total / sqrt(passes) so the cumulative
-		#    Gaussian width is approximately the same as a single pass.
-		var pass_blur_amount: float = max(1.0, float(blur_amount) * float(SUPERSAMPLE) / sqrt(float(BLUR_PASSES)))
-		var pass_blur_radius: float = blur_radius * float(SUPERSAMPLE) / sqrt(float(BLUR_PASSES))
-
-		for _pass in range(BLUR_PASSES):
-			var super_params := {
-				"blur_type": blur_type,
-				"blur_amount": int(pass_blur_amount),
-				"blur_radius": pass_blur_radius,
-				"blur_direction": blur_direction,
-				"selection": super_selection_tex
-			}
-			var gen := ShaderImageEffect.new()
-			gen.generate_image(super_image, shader, super_params, super_size)
-
-		# 4. Downscale back to original size with high-quality LANCZOS
-		super_image.resize(project.size.x, project.size.y, Image.INTERPOLATE_LANCZOS)
-
-		# 5. Copy result back into the cel (preserving original format)
-		super_image.convert(cel.get_format())
-		cel.copy_from(super_image)
+		var gen := ShaderImageEffect.new()
+		gen.generate_image(cel, shader, params, project.size)
 
 
 func _on_blur_type_item_selected(index: int) -> void:


### PR DESCRIPTION
Suggested by a user on discord (SOS1), the credit should go to them.

I have went through the code, my analysis is:
- The fix is basically the usage of `unshaded` render mode and then pre-multiplying alpha (e.g `blur_color_sum += sample_col.rgb * sample_col.a`) and then taking alpha-weighted average of the rgb color at the end.
- The weights (e.g `float w = exp(-i * i * 0.5);`) are just added for smoothing and don't contribute to the fix.