### PR TITLE
Fix GUI no longer de selecting when mouse enters canvas after renaming layer

### DIFF
--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -220,16 +220,7 @@ func _input(event: InputEvent) -> void:
 		and layer_index == Global.current_project.current_layer
 		and line_edit.visible == false
 	):
-		_old_camera_auto_release_gui_focus = Global.camera.auto_release_gui_focus
-		Global.camera.auto_release_gui_focus = false
-		_old_is_writing_text = get_tree().current_scene.is_writing_text
-		get_tree().current_scene.is_writing_text = true
-		label.visible = false
-		line_edit.visible = true
-		line_edit.editable = true
-		line_edit.grab_focus()
-		line_edit.select_all()
-		line_edit.caret_column = line_edit.text.length()
+		_show_rename_edit()
 	elif (
 		(event.is_action_released(&"ui_accept") or event.is_action_released(&"ui_cancel"))
 		and line_edit.visible
@@ -267,12 +258,7 @@ func _on_main_button_gui_input(event: InputEvent) -> void:
 		return
 	if event.button_index == MOUSE_BUTTON_LEFT:
 		if event.double_click:
-			label.visible = false
-			line_edit.visible = true
-			line_edit.editable = true
-			line_edit.grab_focus()
-			line_edit.select_all()
-			line_edit.caret_column = line_edit.text.length()
+			_show_rename_edit()
 
 	elif event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
 		popup_menu.popup_on_parent(Rect2(get_global_mouse_position(), Vector2.ONE))
@@ -280,6 +266,20 @@ func _on_main_button_gui_input(event: InputEvent) -> void:
 
 func _on_layer_name_line_edit_focus_exited() -> void:
 	_save_layer_name(line_edit.text)
+
+
+func _show_rename_edit():
+	# temporarily disable gui focus release mechanism when renaming layer
+	_old_camera_auto_release_gui_focus = Global.camera.auto_release_gui_focus
+	Global.camera.auto_release_gui_focus = false
+	_old_is_writing_text = get_tree().current_scene.is_writing_text
+	get_tree().current_scene.is_writing_text = true
+	label.visible = false
+	line_edit.visible = true
+	line_edit.editable = true
+	line_edit.grab_focus()
+	line_edit.select_all()
+	line_edit.caret_column = line_edit.text.length()
 
 
 func _save_layer_name(new_name: String) -> void:


### PR DESCRIPTION
Special thanks to PandaAoi for providing the replication steps for this bug :heart:

The issue was that in
```
func _save_layer_name(new_name: String) -> void:
	Global.camera.auto_release_gui_focus = _old_camera_auto_release_gui_focus
```
when using the rename shortcut, the `_old_camera_auto_release_gui_focus` works as it should but in case of double click, it didn't have a value set to it at when LineEdit is made visible and was always false by default. This was because both places had their own versions of making the LineEdit visible:

## Shortcut version (the correct implementation)
```
_old_camera_auto_release_gui_focus = Global.camera.auto_release_gui_focus
Global.camera.auto_release_gui_focus = false
_old_is_writing_text = get_tree().current_scene.is_writing_text
get_tree().current_scene.is_writing_text = true
label.visible = false
line_edit.visible = true
line_edit.editable = true
line_edit.grab_focus()
line_edit.select_all()
line_edit.caret_column = line_edit.text.length()
```
## Double click version (outdated implementation)
```
label.visible = false
line_edit.visible = true
line_edit.editable = true
line_edit.grab_focus()
line_edit.select_all()
line_edit.caret_column = line_edit.text.length()
```

This PR makes both places use a single function