### PR TITLE
Cleaned the AnimatableObject class, removed shadow variables in BaseLayer

### DIFF
--- a/src/Classes/AnimatableObject.gd
+++ b/src/Classes/AnimatableObject.gd
@@ -5,7 +5,17 @@ signal keyframe_set
 
 const TRANS_CONSTANT := -1
 
+## These are the default values for the animation calculator to fall back on when a keyframe is
+## not found.
+## Example:
+## [codeblock]
+##{
+##	"offset": Vector2(0, 0),
+##	"wrap_around": false,
+##}
+## [/codeblock]
 var params: Dictionary[String, Variant] = {}
+
 ## A Dictionary containing another Dictionary that
 ## maps the frame indices (int) to another Dictionary of value, trans, ease,
 ## and a layer-scope unique ID.
@@ -44,46 +54,62 @@ var animated_params: Dictionary[String, Dictionary] = {}
 var param_properties: Dictionary[String, Dictionary]
 
 
+## Returns the interpolated valued of all the properties present in [member animated_params] for the
+## frame at [param frame_index].
 func get_params(frame_index: int) -> Dictionary:
-	var to_return := params.duplicate()
+	var to_return := params.duplicate()  # Start with default values
 	for param in animated_params:
 		if param.begins_with("PXO_"):
 			continue
-		var animated_properties := animated_params[param]  # Dictionary[int, Dictionary]
-		to_return = get_animated_property(frame_index, param, animated_properties, to_return)
+		to_return[param] = get_animated_property(frame_index, param)
 	return to_return
 
 
-static func get_animated_property(
-	frame_index: int, param: String, properties: Dictionary, to_return: Dictionary
-) -> Dictionary:
+## Compact form of [method get_params]. Returns the interpolated value of the [param param] for the
+## [param frame_index] or [code]null[/code] if [param param] is not valid, i-e not registered
+## in the [member params] dictionary.
+func get_animated_property(frame_index: int, param: String) -> Variant:
+	# Check if the param is valid.
+	if not params.has(param):
+		return  # null return
+	# Check if the property is animatable, return default value if not animatable
+	if (
+		param.begins_with("PXO_")
+		or not animated_params.has(param)
+		or not is_animatable_type(params[param])
+	):
+		return params[param]
+
+	# Get the keyframe info for our param.
+	var properties := animated_params[param]  # Dictionary[int, Dictionary]
+	if properties.size() == 0:
+		return params[param]  # No Keyframes present, return default value
+
 	if properties.has(frame_index):
-		# If the frame index exists in the properties, get that.
-		to_return[param] = properties[frame_index].get("value", to_return[param])
+		# If the currect frame is a keyframe then there is no reason to
+		# interpolate. Get value directly from properties
+		return properties[frame_index].get("value", params[param])
 	else:
-		if properties.size() == 0:
-			return to_return
 		# If it doesn't exist, interpolate.
 		var frame_edges := find_frame_edges(frame_index, properties)
 		var min_params: Dictionary = properties[frame_edges[0]]
 		var max_params: Dictionary = properties[frame_edges[1]]
-		var min_value = min_params.get("value", to_return[param])
-		var max_value = max_params.get("value", to_return[param])
+		var min_value = min_params.get("value", params[param])
+		var max_value = max_params.get("value", params[param])
 		if not is_interpolatable_type(min_value):
-			to_return[param] = max_value
-			return to_return
+			# NOTE: Examples that trigger this are the Desaturation effect and Kernel of
+			# Convolution matrix effect. Here, we just take the interpolation as TRANS_CONSTANT.
+			return min_value
 		var elapsed := frame_index - frame_edges[0]
 		var delta = max_value - min_value
 		var duration := frame_edges[1] - frame_edges[0]
 		var trans_type: int = min_params.get("trans", Tween.TRANS_LINEAR)
 		if trans_type == TRANS_CONSTANT:
-			to_return[param] = min_value
-			return to_return
+			return min_value
 		var ease_type: Tween.EaseType = min_params.get("ease", Tween.EASE_IN)
-		to_return[param] = Tween.interpolate_value(
+		return Tween.interpolate_value(
 			min_value, delta, elapsed, duration, trans_type, ease_type
 		)
-	return to_return
 
 
 func set_keyframe(
@@ -101,6 +127,14 @@ func set_keyframe(
 	}
 	KeyframeTimeline.next_keyframe_id += 1
 	keyframe_set.emit()
+
+
+func unset_keyframe(
+	param_name: String,
+	frame_index: int
+) -> void:
+	if animated_params.has(param_name):
+		animated_params[param_name].erase(frame_index)
 
 
 static func is_interpolatable_type(value: Variant) -> bool:

--- a/src/Classes/AnimatableObject.gd
+++ b/src/Classes/AnimatableObject.gd
@@ -107,9 +107,7 @@ func get_animated_property(frame_index: int, param: String) -> Variant:
 		if trans_type == TRANS_CONSTANT:
 			return min_value
 		var ease_type: Tween.EaseType = min_params.get("ease", Tween.EASE_IN)
-		return Tween.interpolate_value(
-			min_value, delta, elapsed, duration, trans_type, ease_type
-		)
+		return Tween.interpolate_value(min_value, delta, elapsed, duration, trans_type, ease_type)
 
 
 func set_keyframe(
@@ -129,10 +127,7 @@ func set_keyframe(
 	keyframe_set.emit()
 
 
-func unset_keyframe(
-	param_name: String,
-	frame_index: int
-) -> void:
+func unset_keyframe(param_name: String, frame_index: int) -> void:
 	if animated_params.has(param_name):
 		animated_params[param_name].erase(frame_index)
 

--- a/src/Classes/AnimatableObject.gd
+++ b/src/Classes/AnimatableObject.gd
@@ -86,7 +86,7 @@ func get_animated_property(frame_index: int, param: String) -> Variant:
 		return params[param]  # No Keyframes present, return default value
 
 	if properties.has(frame_index):
-		# If the currect frame is a keyframe then there is no reason to
+		# If the current frame is a keyframe then there is no reason to
 		# interpolate. Get value directly from properties
 		return properties[frame_index].get("value", params[param])
 	else:

--- a/src/Classes/Layers/BaseLayer.gd
+++ b/src/Classes/Layers/BaseLayer.gd
@@ -252,9 +252,7 @@ func link_cel(cel: BaseCel, link_set = null) -> void:
 func get_opacity(frame_index := -1) -> float:
 	if frame_index == -1:
 		return opacity
-	var dict := {"opacity": opacity}
-	dict = get_animated_property(frame_index, "opacity", animated_params["opacity"], dict)
-	return dict["opacity"]
+	return get_animated_property(frame_index, "opacity")
 
 
 ## Returns a copy of the [param cel]'s [Image] with all of the effects applied to it.
@@ -279,12 +277,12 @@ func display_effects(cel: BaseCel, image_override: Image = null) -> Image:
 	for effect in effects:
 		if not effect.enabled or not is_instance_valid(effect.shader):
 			continue
-		var params := effect.get_params(frame_index)
-		params["PXO_time"] = frame.position_in_seconds(project)
-		params["PXO_frame_index"] = frame_index
-		params["PXO_layer_index"] = index
+		var interpol_params := effect.get_params(frame_index)
+		interpol_params["PXO_time"] = frame.position_in_seconds(project)
+		interpol_params["PXO_frame_index"] = frame_index
+		interpol_params["PXO_layer_index"] = index
 		var shader_image_effect := ShaderImageEffect.new()
-		shader_image_effect.generate_image(image, effect.shader, params, image_size)
+		shader_image_effect.generate_image(image, effect.shader, interpol_params, image_size)
 	# Inherit effects from the parents, if their blend mode is set to pass through
 	for ancestor in get_ancestors():
 		if ancestor.blend_mode != BlendModes.PASS_THROUGH:
@@ -294,12 +292,12 @@ func display_effects(cel: BaseCel, image_override: Image = null) -> Image:
 		for effect in ancestor.effects:
 			if not effect.enabled:
 				continue
-			var params := effect.get_params(frame_index)
-			params["PXO_time"] = frame.position_in_seconds(project)
-			params["PXO_frame_index"] = frame_index
-			params["PXO_layer_index"] = index
+			var interpol_params := effect.get_params(frame_index)
+			interpol_params["PXO_time"] = frame.position_in_seconds(project)
+			interpol_params["PXO_frame_index"] = frame_index
+			interpol_params["PXO_layer_index"] = index
 			var shader_image_effect := ShaderImageEffect.new()
-			shader_image_effect.generate_image(image, effect.shader, params, image_size)
+			shader_image_effect.generate_image(image, effect.shader, interpol_params, image_size)
 	return image
 
 

--- a/src/UI/Timeline/KeyframeTimeline/KeyframeTimeline.gd
+++ b/src/UI/Timeline/KeyframeTimeline/KeyframeTimeline.gd
@@ -435,7 +435,7 @@ func add_effect_keyframe(effect: AnimatableObject, frame_index: int, param_name:
 	var undo_redo := Global.current_project.undo_redo
 	undo_redo.create_action("Add keyframe")
 	undo_redo.add_do_method(effect.set_keyframe.bind(param_name, frame_index))
-	undo_redo.add_undo_method(func(): effect.animated_params[param_name].erase(frame_index))
+	undo_redo.add_undo_method(effect.unset_keyframe.bind(param_name, frame_index))
 	undo_redo.add_undo_method(unselect_keyframe.bind(next_keyframe_id))
 	undo_redo.add_do_method(recreate_timeline)
 	undo_redo.add_undo_method(recreate_timeline)


### PR DESCRIPTION
Follow up of 7b0d8b8b127c6dc386a84574958f2e279610ae65

- Added documentation comments to `params`, `get_params()` and `get_animated_property()`
- Added an `unset_keyframe()` method to `AnimatableObject`. This cleans up the `add_effect_keyframe()` method in `KeyframeTimeline.gd` and give more flexibility in case we want to use it for other types (e.g adding a bone keyframe etc.)
- Renamed `params` in BaseLayer's `display_effects()` as they were being marked as shadow variables.
- Removed `static` from `get_animated_property()`. I don't think it's used anywhere (as `AnimatableObject.get_animated_property()`) and i doubt we will ever use it like that, as this class is meant to be inherited by other classes so they can already use `get_animated_property()` without having the need for it to be static (and needing unnecessary parameters)
- In `get_animated_property`, changed:
```
if not is_interpolatable_type(min_value):
			to_return[param] = max_value
			return to_return
```
- To:
```
if not is_interpolatable_type(min_value):
			return min_value
```
- I thought returning `max_value` was a typo as in this situation we should have treated it like the `TRANS_CONSTANT` case