### PR TITLE
Fix project.export_directory_path set wrongly when frame 1 is part of a tag

### DIFF
--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -638,8 +638,8 @@ func export_processed_images(
 		Global.top_menu_container.file_menu.set_item_text(
 			Global.FileMenu.EXPORT, tr("Export") + " %s" % file_name_with_ext
 		)
-	if OS.get_name() != "Android":
-		project.export_directory_path = export_paths[0].get_base_dir()
+	# NOTE: project.export_directory_path is already updated through ExportDialog.gd
+	# we only need to update the current_dir here after the export
 	Global.config_cache.set_value("data", "current_dir", project.export_directory_path)
 	return true
 


### PR DESCRIPTION
Currently when exporting to a path (e.g `path/to/image.png`) with the option to make different directories for each tag, if frame 1 was part of a tag (e.g `some_tag`), then after export, the `project.export_directory_path` gets changed to: `path/to/some_tag`

This is undesirable because further exports (through Ctrl + E) would now be using `path/to/some_tag/image.png` as file path (instead of `path/to/image.png`), and further changing the directory link to `path/to/some_tag/some_tag`

After investigating, i saw that the code:
```
if OS.get_name() != "Android":
		project.export_directory_path = export_paths[0].get_base_dir()
```
is not required at all as it is already done in [ExportDialog.gd](https://github.com/Orama-Interactive/Pixelorama/blob/fb3f7a9cc1cd431fbe38c3e91403323e43fe3377/src/UI/Dialogs/ExportDialog.gd#L420), removing this line fixes the issue