### PR TITLE
Use the Command key for timeline selection on macOS

### DIFF
--- a/src/Autoload/Global.gd
+++ b/src/Autoload/Global.gd
@@ -872,6 +872,15 @@ func is_linux_or_bsd() -> bool:
 	return OS.get_name() in ["Linux", "FreeBSD", "NetBSD", "OpenBSD", "BSD"]
 
 
+## Returns [code]true[/code] if the platform's selection modifier is held down.
+## On macOS this is the Command key, because Control+left-click is interpreted by the
+## operating system as a right-click; on every other platform it is the Control key.
+func is_ctrl_or_cmd_pressed() -> bool:
+	if OS.get_name() == "macOS":
+		return Input.is_key_pressed(KEY_META)
+	return Input.is_action_pressed(&"ctrl")
+
+
 ## Print this when Pixelorama launches so it can be stored in the log files.
 ## This info may help us better debug issues certain users may have.
 func get_system_info() -> String:

--- a/src/UI/Timeline/CelButton.gd
+++ b/src/UI/Timeline/CelButton.gd
@@ -133,7 +133,7 @@ func _on_CelButton_pressed() -> void:
 					var frame_layer := [i, j]
 					if !project.selected_cels.has(frame_layer):
 						project.selected_cels.append(frame_layer)
-		elif Input.is_action_pressed("ctrl"):
+		elif Global.is_ctrl_or_cmd_pressed():
 			var frame_layer := [frame, layer]
 			if project.selected_cels.has(frame_layer):
 				if project.selected_cels.size() > 1:
@@ -409,7 +409,7 @@ func _can_drop_data(pos: Vector2, data) -> bool:
 	for l in drop_layers:
 		if l != layer:
 			different_layers = true
-	var is_swapping := Input.is_action_pressed("ctrl") or different_layers
+	var is_swapping := Global.is_ctrl_or_cmd_pressed() or different_layers
 
 	if is_swapping:
 		for cel_idx in drop_cels:
@@ -486,7 +486,7 @@ func _drop_data(_pos: Vector2, data) -> void:
 		offset.y = layer - Array(drop_layers).max()
 	var project := Global.current_project
 	project.undo_redo.create_action("Move Cels")
-	if Input.is_action_pressed("ctrl") or different_layers:  # Swap cels
+	if Global.is_ctrl_or_cmd_pressed() or different_layers:  # Swap cels
 		var swap_cel_positions := []
 		for cel_idx in drop_cels:
 			var drop_point_frame: int = cel_idx[0] + offset.x

--- a/src/UI/Timeline/FrameButton.gd
+++ b/src/UI/Timeline/FrameButton.gd
@@ -45,7 +45,7 @@ func _button_pressed() -> void:
 					var frame_layer := [i, j]
 					if !Global.current_project.selected_cels.has(frame_layer):
 						Global.current_project.selected_cels.append(frame_layer)
-		elif Input.is_action_pressed("ctrl"):
+		elif Global.is_ctrl_or_cmd_pressed():
 			for j in range(0, Global.current_project.layers.size()):
 				var frame_layer := [frame, j]
 				if !Global.current_project.selected_cels.has(frame_layer):
@@ -140,7 +140,7 @@ func _can_drop_data(pos: Vector2, data) -> bool:
 			frame_container.get_child(get_index() - 1)
 		)
 
-	var is_swapping := Input.is_action_pressed("ctrl")
+	var is_swapping := Global.is_ctrl_or_cmd_pressed()
 	var drop_frames: PackedInt32Array = data[1]
 	# Get offset
 	var offset: int = 0
@@ -173,7 +173,7 @@ func _drop_data(_pos: Vector2, data) -> void:
 	var drop_frames: PackedInt32Array = data[1]
 	var project := Global.current_project
 	project.undo_redo.create_action("Change Frame Order")
-	if Input.is_action_pressed("ctrl"):  # Swap frames
+	if Global.is_ctrl_or_cmd_pressed():  # Swap frames
 		var swap_frame_positions := []
 		# Get offset
 		var offset: int = 0

--- a/src/UI/Timeline/LayerButton.gd
+++ b/src/UI/Timeline/LayerButton.gd
@@ -239,7 +239,7 @@ func _on_layer_main_button_pressed() -> void:
 				if !project.selected_cels.has(frame_layer):
 					project.selected_cels.append(frame_layer)
 		project.change_cel(-1, layer_index)
-	elif Input.is_action_pressed(&"ctrl"):
+	elif Global.is_ctrl_or_cmd_pressed():
 		for i in range(0, project.frames.size()):
 			var frame_layer := [i, layer_index]
 			if !project.selected_cels.has(frame_layer):

--- a/src/UI/Timeline/LayerMainButton.gd
+++ b/src/UI/Timeline/LayerMainButton.gd
@@ -66,7 +66,7 @@ func _can_drop_data(pos: Vector2, data) -> bool:
 	var region: Rect2
 	var depth := curr_layer.get_hierarchy_depth()
 	var last_layer := Global.current_project.layers[drop_layers[-1]]
-	if Input.is_action_pressed(&"ctrl") and drop_layers.size() == 1:  # Swap layers
+	if Global.is_ctrl_or_cmd_pressed() and drop_layers.size() == 1:  # Swap layers
 		if last_layer.is_ancestor_of(curr_layer) or curr_layer.is_ancestor_of(last_layer):
 			Global.animation_timeline.drag_highlight.visible = false
 			return false
@@ -129,7 +129,7 @@ func _drop_data(pos: Vector2, data) -> void:
 		drop_from_parents.append(layers[drop_from_indices[i]].parent)
 
 	project.undo_redo.create_action("Change Layer Order")
-	if Input.is_action_pressed("ctrl") and initial_drop_layers.size() == 1:  # Swap layers
+	if Global.is_ctrl_or_cmd_pressed() and initial_drop_layers.size() == 1:  # Swap layers
 		# a and b both need "from", "to", and "to_parents"
 		# a is this layer (and children), b is the dropped layers
 		var a := {"from": range(layer_index - curr_layer.get_child_count(true), layer_index + 1)}


### PR DESCRIPTION
Closes #1313

## Issue
On macOS it is impossible to multi-select cels, frames or layers in the timeline. Holding **Control** and left-clicking is interpreted by macOS as a right-click, so instead of adding the item to the selection, the context menu opens. The same applies to **Control + drag** for swapping cels/frames/layers.

## Cause
All of these interactions polled the `ctrl` input action:
```gdscript
elif Input.is_action_pressed("ctrl"):
```
Because the OS converts Control + left-click into a right-click, this branch is never reached on macOS.

## Fix
Following Apple's interface guidelines, macOS should use the **Command** key for individual selection. Command + click stays a normal left-click, so it reaches the selection logic correctly.

Added a small helper to `Global`:
```gdscript
func is_ctrl_or_cmd_pressed() -> bool:
	if OS.get_name() == "macOS":
		return Input.is_key_pressed(KEY_META)
	return Input.is_action_pressed(&"ctrl")
```
and routed the timeline buttons (`CelButton`, `FrameButton`, `LayerButton`, `LayerMainButton`) through it, for both multi-selection and swap-on-drag. Behaviour on Windows and Linux is unchanged.

## Testing
- `gdformat --check` and `gdlint` pass on the changed files.
- The project compiles with no new errors introduced by these changes.
- Manual runtime testing on macOS is in progress; I will confirm here once Command + click multi-selection and Command + drag swapping are validated in a running build. Feedback from other macOS users is welcome.

If maintainers prefer using `is_command_or_control_pressed()` via `gui_input` instead of the `Global` helper, I am happy to adjust.