### PR TITLE
Persist export dialog settings per-project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Built using Godot 4.6.3
 - Fixed hardware related issue where layer opacity & blend mode did not update in certain mobile GPUs. [#1546](https://github.com/Orama-Interactive/Pixelorama/issues/1546)
 - Make UI elements in the audio layer properties stack properly.
 - Fixed extension exporters not working. [#1497](https://github.com/Orama-Interactive/Pixelorama/pull/1497)
+- Export dialog settings (spritesheet layout, frame range, resize, crop mode, etc.) are now saved per-project and restored when the project is reopened. [#1503](https://github.com/Orama-Interactive/Pixelorama/issues/1503)
 
 ### Removed
 - Removed tool & background color options from the Preferences in favor of the new theming system. If there is enough demand for them, we could add them again. [#1515](https://github.com/Orama-Interactive/Pixelorama/pull/1515)

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -45,34 +45,14 @@ var file_format_dictionary: Dictionary[FileFormat, Array] = {
 var custom_file_formats := {}
 var custom_exporter_generators := {}
 
-var current_tab := ExportTab.IMAGE
 ## All frames and their layers processed/blended into images
 var processed_images: Array[ProcessedImage] = []
 ## A dictionary that contains all of the blended frames.
 ## Changes when [method cache_blended_frames] is called.
 var blended_frames: Dictionary[Frame, Image] = {}
-var export_json := false
-var split_layers := false
-var sheet_layers_as_separate_files := false
-var crop_mode := CropMode.NONE
-var erase_unselected_area := false
-# Spritesheet options
-var orientation := Orientation.COLUMNS
-var lines_count := 1  ## How many rows/columns before new line is added
-
-# General options
-var frame_current_tag := 0  ## Export only current frame tag
-var export_layers := 0
+## The result of [method Project.frames] divided by the export settings' lines count.
+## Computed by [method process_spritesheet]/[method process_animation], not a persisted setting.
 var number_of_frames := 1
-var direction := AnimationDirection.FORWARD
-var repeat_count := 0
-var resize := 100
-var save_quality := 0.75  ## Used when saving jpg and webp images. Goes from 0 to 1.
-var interpolation := Image.INTERPOLATE_NEAREST
-var include_tag_in_filename := false
-var new_dir_for_each_frame_tag := false  ## We don't need to store this after export
-var number_of_digits := 4
-var separator_character := "_"
 var stop_export := false  ## Export coroutine signal
 
 var file_exists_alert := "The following files already exist. Do you wish to overwrite them?\n%s"
@@ -154,9 +134,9 @@ func external_export(project := Global.current_project) -> void:
 
 func process_data(project := Global.current_project) -> void:
 	var frames := _calculate_frames(project)
-	if frames.size() * (repeat_count + 1) > blended_frames.size():
+	if frames.size() * (project.export_repeat_count + 1) > blended_frames.size():
 		cache_blended_frames(project)
-	match current_tab:
+	match project.export_tab:
 		ExportTab.IMAGE:
 			process_animation(project)
 		ExportTab.SPRITESHEET:
@@ -178,9 +158,9 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var frames := _calculate_frames(project)
 	# Add additional repeated animation (Doing it here instead of _calculate_frames() to save
 	# compute power
-	if repeat_count > 0:
+	if project.export_repeat_count > 0:
 		var frames_copy := frames.duplicate()
-		for _r in repeat_count:
+		for _r in project.export_repeat_count:
 			frames.append_array(frames_copy)
 	# Then store the size of frames for other functions
 	number_of_frames = frames.size()
@@ -190,12 +170,12 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var spritesheet_columns := 1
 	var spritesheet_rows := 1
 	# If rows mode selected calculate columns count and vice versa
-	if orientation == Orientation.COLUMNS:
-		spritesheet_columns = frames_divided_by_spritesheet_lines()
-		spritesheet_rows = lines_count
-	elif orientation == Orientation.ROWS:
-		spritesheet_columns = lines_count
-		spritesheet_rows = frames_divided_by_spritesheet_lines()
+	if project.export_orientation == Orientation.COLUMNS:
+		spritesheet_columns = frames_divided_by_spritesheet_lines(project)
+		spritesheet_rows = project.export_lines_count
+	elif project.export_orientation == Orientation.ROWS:
+		spritesheet_columns = project.export_lines_count
+		spritesheet_rows = frames_divided_by_spritesheet_lines(project)
 	else:
 		spritesheet_rows = project.animation_tags.size() + 1
 		if spritesheet_rows == 1:
@@ -213,7 +193,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 		if frames_without_tag == 0:
 			# If all frames have a tag, remove the first row
 			spritesheet_rows -= 1
-		if orientation == Orientation.TAGS_BY_COLUMN:
+		if project.export_orientation == Orientation.TAGS_BY_COLUMN:
 			# Switch rows and columns
 			var temp := spritesheet_rows
 			spritesheet_rows = spritesheet_columns
@@ -221,9 +201,9 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var width := project.size.x * spritesheet_columns
 	var height := project.size.y * spritesheet_rows
 	var splitter_array: Array[BaseLayer] = []
-	if split_layers:
+	if project.export_split_layers:
 		splitter_array = _calculate_layers_to_export(project)
-	var only_selected_cels := _export_only_selected_cels()
+	var only_selected_cels := _export_only_selected_cels(project)
 	var sprite_sheets: Array[Image]  # Array of all apritesheets
 	var sprite_sheet_layer_indices: Array[int] = []
 	# This is an imitation of a do-while loop. The loop ends early if split_layers is empty
@@ -235,7 +215,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 		var sheet_image := Image.create_empty(width, height, false, project.get_image_format())
 		var sheet_is_valid := false
 		for frame in frames:
-			if orientation == Orientation.ROWS:
+			if project.export_orientation == Orientation.ROWS:
 				if vv < spritesheet_columns:
 					origin.x = project.size.x * vv
 					vv += 1
@@ -244,7 +224,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.x = 0
 					vv = 1
 					origin.y = project.size.y * hh
-			elif orientation == Orientation.COLUMNS:
+			elif project.export_orientation == Orientation.COLUMNS:
 				if hh < spritesheet_rows:
 					origin.y = project.size.y * hh
 					hh += 1
@@ -253,7 +233,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.y = 0
 					hh = 1
 					origin.x = project.size.x * vv
-			elif orientation == Orientation.TAGS_BY_ROW:
+			elif project.export_orientation == Orientation.TAGS_BY_ROW:
 				var frame_index := project.frames.find(frame)
 				var frame_has_tag := false
 				for i in project.animation_tags.size():
@@ -272,7 +252,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.x = project.size.x * layer_tag_origins[0]
 					origin.y = 0
 					layer_tag_origins[0] += 1
-			elif orientation == Orientation.TAGS_BY_COLUMN:
+			elif project.export_orientation == Orientation.TAGS_BY_COLUMN:
 				var frame_index := project.frames.find(frame)
 				var frame_has_tag := false
 				for i in project.animation_tags.size():
@@ -291,7 +271,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.y = project.size.y * layer_tag_origins[0]
 					origin.x = 0
 					layer_tag_origins[0] += 1
-			if not split_layers:
+			if not project.export_split_layers:
 				sheet_image.blend_rect(
 					blended_frames[frame], Rect2i(Vector2i.ZERO, project.size), origin
 				)
@@ -307,13 +287,13 @@ func process_spritesheet(project := Global.current_project) -> void:
 					sheet_is_valid = true
 		if sheet_is_valid:
 			sprite_sheets.append(sheet_image)
-			if split_layers and split_l < splitter_array.size():
+			if project.export_split_layers and split_l < splitter_array.size():
 				sprite_sheet_layer_indices.append(splitter_array[split_l].index)
 			else:
 				sprite_sheet_layer_indices.append(-1)
 		if splitter_array.is_empty():
 			break
-	if not sheet_layers_as_separate_files and sprite_sheets.size() > 1:
+	if not project.export_sheet_layers_as_separate_files and sprite_sheets.size() > 1:
 		var big_image := Image.create(
 			width, height * sprite_sheets.size(), false, project.get_image_format()
 		)
@@ -335,9 +315,9 @@ func process_spritesheet(project := Global.current_project) -> void:
 func process_animation(project := Global.current_project) -> void:
 	processed_images.clear()
 	var frames := _calculate_frames(project)
-	var only_selected_cels := _export_only_selected_cels()
+	var only_selected_cels := _export_only_selected_cels(project)
 	for frame in frames:
-		if split_layers:
+		if project.export_split_layers:
 			for layer in _calculate_layers_to_export(project):
 				if only_selected_cels and not _is_cel_selected(project, frame, layer.index):
 					continue
@@ -351,7 +331,7 @@ func process_animation(project := Global.current_project) -> void:
 		else:
 			var image := project.new_empty_image()
 			image.copy_from(blended_frames[frame])
-			if erase_unselected_area and project.has_selection:
+			if project.export_erase_unselected_area and project.has_selection:
 				var crop := project.new_empty_image()
 				var selection_image := project.selection_map.return_cropped_copy(
 					project, project.size
@@ -360,7 +340,7 @@ func process_animation(project := Global.current_project) -> void:
 					image, selection_image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO
 				)
 				image.copy_from(crop)
-			match crop_mode:
+			match project.export_crop_mode:
 				CropMode.CONTENT:
 					if image.get_used_rect().has_area():
 						image = image.get_region(image.get_used_rect())
@@ -377,7 +357,7 @@ func process_animation(project := Global.current_project) -> void:
 	# Add additional repeated animation (Doing it here instead of _calculate_frames() to save
 	# compute power
 	var un_repeated_size: int = processed_images.size()
-	for _r in repeat_count:
+	for _r in project.export_repeat_count:
 		for i in un_repeated_size:
 			processed_images.append(
 				ProcessedImage.new(
@@ -390,15 +370,15 @@ func process_animation(project := Global.current_project) -> void:
 
 
 func _calculate_frames(project := Global.current_project) -> Array[Frame]:
-	var tag_index := frame_current_tag - ExportFrames.size()
+	var tag_index := project.export_frame_current_tag - ExportFrames.size()
 	if tag_index >= project.animation_tags.size():
-		frame_current_tag = ExportFrames.ALL_FRAMES
+		project.export_frame_current_tag = ExportFrames.ALL_FRAMES
 	var frames: Array[Frame] = []
-	if frame_current_tag >= ExportFrames.size():  # Export a specific tag
+	if project.export_frame_current_tag >= ExportFrames.size():  # Export a specific tag
 		var frame_start: int = project.animation_tags[tag_index].from
 		var frame_end: int = project.animation_tags[tag_index].to
 		frames = project.frames.slice(frame_start - 1, frame_end, 1, true)
-	elif frame_current_tag == ExportFrames.SELECTED_FRAMES:
+	elif project.export_frame_current_tag == ExportFrames.SELECTED_FRAMES:
 		for cel in project.selected_cels:
 			var frame := project.frames[cel[0]]
 			if not frames.has(frame):
@@ -406,9 +386,9 @@ func _calculate_frames(project := Global.current_project) -> Array[Frame]:
 	else:  # All frames
 		frames = project.frames.duplicate()
 
-	if direction == AnimationDirection.BACKWARDS:
+	if project.export_direction == AnimationDirection.BACKWARDS:
 		frames.reverse()
-	elif direction == AnimationDirection.PING_PONG:
+	elif project.export_direction == AnimationDirection.PING_PONG:
 		var inverted_frames := frames.duplicate()
 		inverted_frames.reverse()
 		inverted_frames.remove_at(0)
@@ -425,13 +405,13 @@ func _calculate_layers_to_export(project := Global.current_project) -> Array[Bas
 		if layer is GroupLayer or layer is AudioLayer:
 			continue
 		var include := false
-		match export_layers:
+		match project.export_layers:
 			VISIBLE_LAYERS:
 				include = layer.is_visible_in_hierarchy()
 			SELECTED_LAYERS:
 				include = layer.is_visible_in_hierarchy() and _is_layer_selected(project, i)
 			_:  # A specific layer was chosen from the dropdown
-				include = i == export_layers - 2
+				include = i == project.export_layers - 2
 		if include:
 			layers_to_export.append(layer)
 	return layers_to_export
@@ -446,8 +426,11 @@ func _is_layer_selected(project: Project, layer_index: int) -> bool:
 
 ## True when both "Selected frames" and "Selected layers" are chosen, in which case only the exact
 ## cels the user selected are exported, instead of every selected layer at every selected frame.
-func _export_only_selected_cels() -> bool:
-	return frame_current_tag == ExportFrames.SELECTED_FRAMES and export_layers == SELECTED_LAYERS
+func _export_only_selected_cels(project := Global.current_project) -> bool:
+	return (
+		project.export_frame_current_tag == ExportFrames.SELECTED_FRAMES
+		and project.export_layers == SELECTED_LAYERS
+	)
 
 
 func _is_cel_selected(project: Project, frame: Frame, layer_index: int) -> bool:
@@ -487,9 +470,9 @@ func export_processed_images(
 		var frame_index := i + 1
 		var layer_index := -1
 		var actual_frame_index := processed_images[i].frame_index
-		if split_layers:
+		if project.export_split_layers:
 			layer_index = processed_images[i].layer_index
-			if current_tab == ExportTab.IMAGE:
+			if project.export_tab == ExportTab.IMAGE:
 				if actual_frame_index != previous_split_frame:
 					split_frame_counter += 1
 					previous_split_frame = actual_frame_index
@@ -501,8 +484,8 @@ func export_processed_images(
 		# if directories exist, and create them if not
 		if (
 			multiple_files
-			and new_dir_for_each_frame_tag
-			and not current_tab == ExportTab.SPRITESHEET
+			and project.export_new_dir_for_each_frame_tag
+			and not project.export_tab == ExportTab.SPRITESHEET
 		):
 			var frame_tag_directory := DirAccess.open(export_path.get_base_dir())
 			if not DirAccess.dir_exists_absolute(export_path.get_base_dir()):
@@ -527,8 +510,8 @@ func export_processed_images(
 		if stop_export:  # User decided to stop export
 			return false
 
-	_scale_processed_images()
-	if export_json:
+	_scale_processed_images(project)
+	if project.export_json:
 		var json := JSON.stringify(project.serialize())
 		var json_file_name := project.name + ".json"
 		if OS.has_feature("web"):
@@ -599,7 +582,7 @@ func export_processed_images(
 					)
 				elif project.file_format == FileFormat.JPEG:
 					JavaScriptBridge.download_buffer(
-						processed_images[i].image.save_jpg_to_buffer(save_quality),
+						processed_images[i].image.save_jpg_to_buffer(project.export_save_quality),
 						export_paths[i].get_file(),
 						"image/jpeg"
 					)
@@ -617,7 +600,7 @@ func export_processed_images(
 				elif project.file_format == FileFormat.WEBP:
 					err = processed_images[i].image.save_webp(export_paths[i])
 				elif project.file_format == FileFormat.JPEG:
-					err = processed_images[i].image.save_jpg(export_paths[i], save_quality)
+					err = processed_images[i].image.save_jpg(export_paths[i], project.export_save_quality)
 				elif project.file_format == FileFormat.EXR:
 					err = processed_images[i].image.save_exr(export_paths[i])
 				if err != OK:
@@ -651,7 +634,7 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var input_file_path := temp_path.path_join("input.txt")
 	var input_file := FileAccess.open(input_file_path, FileAccess.WRITE)
 	for i in range(processed_images.size()):
-		var temp_file_name := str(i + 1).pad_zeros(number_of_digits) + ".png"
+		var temp_file_name := str(i + 1).pad_zeros(project.export_number_of_digits) + ".png"
 		var temp_file_path := temp_path.path_join(temp_file_name)
 		processed_images[i].image.save_png(temp_file_path)
 		input_file.store_line("file '" + temp_file_name + "'")
@@ -689,7 +672,7 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var adelay_string := ""
 	for layer in project.get_all_audio_layers():
 		if layer.audio is AudioStreamMP3 or layer.audio is AudioStreamWAV:
-			var temp_file_name := str(audio_layer_count + 1).pad_zeros(number_of_digits)
+			var temp_file_name := str(audio_layer_count + 1).pad_zeros(project.export_number_of_digits)
 			if layer.audio is AudioStreamMP3:
 				temp_file_name += ".mp3"
 			elif layer.audio is AudioStreamWAV:
@@ -800,13 +783,15 @@ func _increase_export_progress(export_dialog: Node) -> void:
 	export_dialog.set_export_progress_bar(export_progress)
 
 
-func _scale_processed_images() -> void:
-	var resize_f := resize / 100.0
+func _scale_processed_images(project := Global.current_project) -> void:
+	var resize_f := project.export_resize / 100.0
 	for processed_image in processed_images:
-		if is_equal_approx(resize, 1.0):
+		if is_equal_approx(project.export_resize, 1.0):
 			continue
 		var image := processed_image.image
-		image.resize(image.get_size().x * resize_f, image.get_size().y * resize_f, interpolation)
+		image.resize(
+			image.get_size().x * resize_f, image.get_size().y * resize_f, project.export_interpolation
+		)
 
 
 ## Returns the format string (.png, .jpg etc...). For formats added through extensions, a unique id
@@ -882,11 +867,11 @@ func _create_export_path(
 			var layer_name := project.layers[layer].name
 			path_extras += "(%s) " % layer_name
 		var counter: String = (
-			str(layer).pad_zeros(number_of_digits)
-			if current_tab == ExportTab.SPRITESHEET
-			else str(str(frame).pad_zeros(number_of_digits))
+			str(layer).pad_zeros(project.export_number_of_digits)
+			if project.export_tab == ExportTab.SPRITESHEET
+			else str(str(frame).pad_zeros(project.export_number_of_digits))
 		)
-		path_extras += separator_character + counter
+		path_extras += project.export_separator_character + counter
 	var frame_tag_and_start_id := _get_processed_image_tag_name_and_start_id(
 		project, actual_frame_index
 	)
@@ -898,15 +883,18 @@ func _create_export_path(
 		var regex := RegEx.new()
 		regex.compile("[^a-zA-Z0-9_]+")
 		var frame_tag_dir := regex.sub(frame_tag, "", true)
-		if include_tag_in_filename:
+		if project.export_include_tag_in_filename:
 			# (actual_frame_index - start_id + 2) makes frames id to start from 1
 			var tag_frame_number := str(actual_frame_index - start_id + 2).pad_zeros(
-				number_of_digits
+				project.export_number_of_digits
 			)
 			path_extras = (
-				separator_character + frame_tag_dir + separator_character + tag_frame_number
+				project.export_separator_character
+				+ frame_tag_dir
+				+ project.export_separator_character
+				+ tag_frame_number
 			)
-		if new_dir_for_each_frame_tag:
+		if project.export_new_dir_for_each_frame_tag:
 			path += path_extras
 			return project.export_directory_path.path_join(frame_tag_dir).path_join(
 				path + file_format_string(project.file_format, true)
@@ -940,9 +928,9 @@ func _get_processed_image_tag_name_and_start_id(project: Project, processed_imag
 func _blend_layers(
 	image: Image, frame: Frame, origin := Vector2i.ZERO, project := Global.current_project
 ) -> void:
-	if export_layers - 2 >= project.layers.size():
-		export_layers = VISIBLE_LAYERS
-	if export_layers == VISIBLE_LAYERS:
+	if project.export_layers - 2 >= project.layers.size():
+		project.export_layers = VISIBLE_LAYERS
+	if project.export_layers == VISIBLE_LAYERS:
 		var load_result_from_pxo := not project.save_path.is_empty() and not project.has_changed
 		if load_result_from_pxo:
 			# Attempt to read the image data directly from the pxo file, without having to blend
@@ -972,17 +960,17 @@ func _blend_layers(
 				load_result_from_pxo = false
 		if not load_result_from_pxo:
 			DrawingAlgos.blend_layers(image, frame, origin, project)
-	elif export_layers == SELECTED_LAYERS:
+	elif project.export_layers == SELECTED_LAYERS:
 		DrawingAlgos.blend_layers(image, frame, origin, project, false, true)
 	else:
-		var layer := project.layers[export_layers - 2]
+		var layer := project.layers[project.export_layers - 2]
 		var layer_image := Image.new()
 		if layer is GroupLayer:
 			layer_image.copy_from(layer.blend_children(frame, Vector2i.ZERO))
 		else:
-			layer_image.copy_from(layer.display_effects(frame.cels[export_layers - 2]))
+			layer_image.copy_from(layer.display_effects(frame.cels[project.export_layers - 2]))
 		image.blend_rect(layer_image, Rect2i(Vector2i.ZERO, project.size), origin)
 
 
-func frames_divided_by_spritesheet_lines() -> int:
-	return ceili(number_of_frames / float(lines_count))
+func frames_divided_by_spritesheet_lines(project := Global.current_project) -> int:
+	return ceili(number_of_frames / float(project.export_lines_count))

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -600,7 +600,9 @@ func export_processed_images(
 				elif project.file_format == FileFormat.WEBP:
 					err = processed_images[i].image.save_webp(export_paths[i])
 				elif project.file_format == FileFormat.JPEG:
-					err = processed_images[i].image.save_jpg(export_paths[i], project.export_save_quality)
+					err = processed_images[i].image.save_jpg(
+						export_paths[i], project.export_save_quality
+					)
 				elif project.file_format == FileFormat.EXR:
 					err = processed_images[i].image.save_exr(export_paths[i])
 				if err != OK:
@@ -672,7 +674,9 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var adelay_string := ""
 	for layer in project.get_all_audio_layers():
 		if layer.audio is AudioStreamMP3 or layer.audio is AudioStreamWAV:
-			var temp_file_name := str(audio_layer_count + 1).pad_zeros(project.export_number_of_digits)
+			var temp_file_name := str(audio_layer_count + 1).pad_zeros(
+				project.export_number_of_digits
+			)
 			if layer.audio is AudioStreamMP3:
 				temp_file_name += ".mp3"
 			elif layer.audio is AudioStreamWAV:
@@ -790,7 +794,9 @@ func _scale_processed_images(project := Global.current_project) -> void:
 			continue
 		var image := processed_image.image
 		image.resize(
-			image.get_size().x * resize_f, image.get_size().y * resize_f, project.export_interpolation
+			image.get_size().x * resize_f,
+			image.get_size().y * resize_f,
+			project.export_interpolation
 		)
 
 

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -123,6 +123,29 @@ var was_exported := false
 var export_overwrite := false
 var backup_path := ""
 
+# Export dialog settings, kept per-project so that they are saved/loaded along with the file.
+var export_tab := Export.ExportTab.IMAGE
+var export_json := false
+var export_split_layers := false
+var export_sheet_layers_as_separate_files := false
+var export_crop_mode := Export.CropMode.NONE
+var export_erase_unselected_area := false
+# Spritesheet options
+var export_orientation := Export.Orientation.COLUMNS
+var export_lines_count := 1  ## How many rows/columns before new line is added
+# General options
+var export_frame_current_tag := 0  ## Export only current frame tag
+var export_layers := 0
+var export_direction := Export.AnimationDirection.FORWARD
+var export_repeat_count := 0
+var export_resize := 100
+var export_save_quality := 0.75  ## Used when saving jpg and webp images. Goes from 0 to 1.
+var export_interpolation := Image.INTERPOLATE_NEAREST
+var export_include_tag_in_filename := false
+var export_new_dir_for_each_frame_tag := false
+var export_number_of_digits := 4
+var export_separator_character := "_"
+
 
 func _init(_frames: Array[Frame] = [], _name := tr("untitled"), _size := Vector2i(64, 64)) -> void:
 	frames = _frames
@@ -341,6 +364,25 @@ func serialize() -> Dictionary:
 		"export_directory_path": export_directory_path,
 		"export_file_name": file_name,
 		"export_file_format": file_format,
+		"export_tab": export_tab,
+		"export_json": export_json,
+		"export_split_layers": export_split_layers,
+		"export_sheet_layers_as_separate_files": export_sheet_layers_as_separate_files,
+		"export_crop_mode": export_crop_mode,
+		"export_erase_unselected_area": export_erase_unselected_area,
+		"export_orientation": export_orientation,
+		"export_lines_count": export_lines_count,
+		"export_frame_current_tag": export_frame_current_tag,
+		"export_layers_option": export_layers,
+		"export_direction": export_direction,
+		"export_repeat_count": export_repeat_count,
+		"export_resize": export_resize,
+		"export_save_quality": export_save_quality,
+		"export_interpolation": export_interpolation,
+		"export_include_tag_in_filename": export_include_tag_in_filename,
+		"export_new_dir_for_each_frame_tag": export_new_dir_for_each_frame_tag,
+		"export_number_of_digits": export_number_of_digits,
+		"export_separator_character": export_separator_character,
 		"fps": fps,
 		"license": license,
 		"user_data": user_data,
@@ -561,6 +603,33 @@ func deserialize(dict: Dictionary, zip_reader: ZIPReader = null, file: FileAcces
 	if file_name.is_empty() or file_name == "untitled":
 		file_name = name
 	file_format = dict.get("export_file_format", file_format)
+	export_tab = dict.get("export_tab", export_tab)
+	export_json = dict.get("export_json", export_json)
+	export_split_layers = dict.get("export_split_layers", export_split_layers)
+	export_sheet_layers_as_separate_files = dict.get(
+		"export_sheet_layers_as_separate_files", export_sheet_layers_as_separate_files
+	)
+	export_crop_mode = dict.get("export_crop_mode", export_crop_mode)
+	export_erase_unselected_area = dict.get(
+		"export_erase_unselected_area", export_erase_unselected_area
+	)
+	export_orientation = dict.get("export_orientation", export_orientation)
+	export_lines_count = dict.get("export_lines_count", export_lines_count)
+	export_frame_current_tag = dict.get("export_frame_current_tag", export_frame_current_tag)
+	export_layers = dict.get("export_layers_option", export_layers)
+	export_direction = dict.get("export_direction", export_direction)
+	export_repeat_count = dict.get("export_repeat_count", export_repeat_count)
+	export_resize = dict.get("export_resize", export_resize)
+	export_save_quality = dict.get("export_save_quality", export_save_quality)
+	export_interpolation = dict.get("export_interpolation", export_interpolation)
+	export_include_tag_in_filename = dict.get(
+		"export_include_tag_in_filename", export_include_tag_in_filename
+	)
+	export_new_dir_for_each_frame_tag = dict.get(
+		"export_new_dir_for_each_frame_tag", export_new_dir_for_each_frame_tag
+	)
+	export_number_of_digits = dict.get("export_number_of_digits", export_number_of_digits)
+	export_separator_character = dict.get("export_separator_character", export_separator_character)
 	fps = dict.get("fps", fps)
 	license = dict.get("license", license)
 	author_display_name = dict.get("author_display_name", "")

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -121,8 +121,8 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 	static func enable_export(_project: Project, _next_arg: String):
 		return true
 
-	static func enable_spritesheet(_project: Project, _next_arg: String):
-		Export.current_tab = Export.ExportTab.SPRITESHEET
+	static func enable_spritesheet(project: Project, _next_arg: String):
+		project.export_tab = Export.ExportTab.SPRITESHEET
 		return true
 
 	static func set_output(project: Project, next_arg: String) -> void:
@@ -134,10 +134,10 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 			var extension := next_arg.get_extension()
 			project.file_format = Export.get_file_format_from_extension(extension)
 
-	static func set_export_scale(_project: Project, next_arg: String) -> void:
+	static func set_export_scale(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
 			if next_arg.is_valid_float():
-				Export.resize = next_arg.to_float() * 100
+				project.export_resize = next_arg.to_float() * 100
 
 	static func set_frames(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
@@ -156,36 +156,36 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 					for frame in range(frame_number_1, frame_number_2 + 1):
 						project.selected_cels.append([frame, project.current_layer])
 						project.change_cel(frame)
-						Export.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
+						project.export_frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
 			elif next_arg.is_valid_int():
 				var frame_number := next_arg.to_int() - 1
 				frame_number = clampi(frame_number, 0, project.frames.size() - 1)
 				project.selected_cels = [[frame_number, project.current_layer]]
 				project.change_cel(frame_number)
-				Export.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
+				project.export_frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
 
-	static func set_direction(_project: Project, next_arg: String) -> void:
+	static func set_direction(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
 			next_arg = next_arg.to_lower()
 			if next_arg == "0" or next_arg.contains("forward"):
-				Export.direction = Export.AnimationDirection.FORWARD
+				project.export_direction = Export.AnimationDirection.FORWARD
 			elif next_arg == "1" or next_arg.contains("backward"):
-				Export.direction = Export.AnimationDirection.BACKWARDS
+				project.export_direction = Export.AnimationDirection.BACKWARDS
 			elif next_arg == "2" or next_arg.contains("ping"):
-				Export.direction = Export.AnimationDirection.PING_PONG
+				project.export_direction = Export.AnimationDirection.PING_PONG
 			else:
-				print(Export.AnimationDirection.keys()[Export.direction])
+				print(Export.AnimationDirection.keys()[project.export_direction])
 		else:
-			print(Export.AnimationDirection.keys()[Export.direction])
+			print(Export.AnimationDirection.keys()[project.export_direction])
 
-	static func set_json(_project: Project, _next_arg: String) -> void:
-		Export.export_json = true
+	static func set_json(project: Project, _next_arg: String) -> void:
+		project.export_json = true
 
-	static func set_split_layers(_project: Project, _next_arg: String) -> void:
-		Export.split_layers = true
+	static func set_split_layers(project: Project, _next_arg: String) -> void:
+		project.export_split_layers = true
 
-	static func set_sheet_layers_as_separate_files(_project: Project, _next_arg: String) -> void:
-		Export.sheet_layers_as_separate_files = true
+	static func set_sheet_layers_as_separate_files(project: Project, _next_arg: String) -> void:
+		project.export_sheet_layers_as_separate_files = true
 
 	static func dummy(_project: Project, _next_arg: String) -> void:
 		pass

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -38,8 +38,12 @@ var _preview_images: Array[Export.ProcessedImage]
 
 @onready var frames_option_button: OptionButton = $"%Frames"
 @onready var layers_option_button: OptionButton = $"%Layers"
+@onready var split_layers_checkbox: CheckBox = %SplitLayers
+@onready var direction_option_button: OptionButton = %Direction
+@onready var repeat_count_spinbox: SpinBox = %RepeatCount
 @onready var options_resize: ValueSlider = $"%Resize"
 @onready var dimension_label: Label = $"%DimensionLabel"
+@onready var options_quality: ValueSlider = %Quality
 @onready var crop_image_option: OptionButton = %CropImages
 @onready var erase_outside_selection: CheckBox = %EraseOutsideSelection
 
@@ -47,6 +51,10 @@ var _preview_images: Array[Export.ProcessedImage]
 @onready var path_line_edit: LineEdit = $"%PathLineEdit"
 @onready var file_format_options: OptionButton = $"%FileFormat"
 @onready var options_interpolation: OptionButton = $"%Interpolation"
+@onready var separator_character_edit: LineEdit = %SeparatorCharacter
+@onready var export_json_checkbox: CheckBox = %ExportJSON
+@onready var include_tags_in_filename_checkbox: CheckBox = %IncludeTagsInFilename
+@onready var multiple_animations_directories_checkbox: CheckBox = %MultipleAnimationsDirectories
 
 @onready var file_exists_alert_popup: AcceptDialog = $FileExistsAlert
 @onready var path_validation_alert_popup: AcceptDialog = $PathValidationAlert
@@ -80,14 +88,15 @@ func _ready() -> void:
 
 
 func show_tab() -> void:
+	var project := Global.current_project
 	get_tree().call_group("ExportImageOptions", "hide")
 	get_tree().call_group("ExportSpritesheetOptions", "hide")
 	set_file_format_selector()
 	create_frame_tag_list()
-	frames_option_button.select(Export.frame_current_tag)
+	frames_option_button.select(project.export_frame_current_tag)
 	create_layer_list()
-	layers_option_button.select(Export.export_layers)
-	match Export.current_tab:
+	layers_option_button.select(project.export_layers)
+	match project.export_tab:
 		Export.ExportTab.IMAGE:
 			Export.process_animation()
 			get_tree().call_group("ExportImageOptions", "show")
@@ -100,15 +109,15 @@ func show_tab() -> void:
 		Export.ExportTab.SPRITESHEET:
 			frame_timer.stop()
 			Export.process_spritesheet()
-			spritesheet_orientation.selected = Export.orientation
+			spritesheet_orientation.selected = project.export_orientation
 			spritesheet_lines_count.max_value = Export.number_of_frames
-			spritesheet_lines_count.value = Export.lines_count
-			spritesheet_layers_as_separate_files.disabled = !Export.split_layers
+			spritesheet_lines_count.value = project.export_lines_count
+			spritesheet_layers_as_separate_files.disabled = !project.export_split_layers
 			get_tree().call_group("ExportSpritesheetOptions", "show")
 			_handle_orientation_ui()
 	set_preview()
 	update_dimensions_label()
-	tabs.current_tab = Export.current_tab
+	tabs.current_tab = project.export_tab
 	if OS.get_name() == "Web":
 		get_tree().call_group("NotHTML5", "hide")
 	elif OS.get_name() == "Android":
@@ -121,7 +130,7 @@ func set_preview() -> void:
 		return
 	var preview_data := {
 		"exporter_id": Global.current_project.file_format,
-		"export_tab": Export.current_tab,
+		"export_tab": Global.current_project.export_tab,
 		"preview_images": _preview_images,
 	}
 	about_to_preview.emit(preview_data)
@@ -198,7 +207,7 @@ func remove_previews() -> void:
 
 
 func set_file_format_selector() -> void:
-	match Export.current_tab:
+	match Global.current_project.export_tab:
 		Export.ExportTab.IMAGE:
 			_set_file_format_selector_suitable_file_formats(image_exports)
 		Export.ExportTab.SPRITESHEET:
@@ -271,7 +280,8 @@ func create_layer_list() -> void:
 
 func update_dimensions_label() -> void:
 	if _preview_images.size() > 0:
-		var new_size: Vector2i = _preview_images[0].image.get_size() * (Export.resize / 100.0)
+		var resize_factor := Global.current_project.export_resize / 100.0
+		var new_size: Vector2i = _preview_images[0].image.get_size() * resize_factor
 		dimension_label.text = str(new_size.x, "×", new_size.y)
 
 
@@ -318,9 +328,23 @@ func _on_about_to_popup() -> void:
 			"data", "current_dir", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP)
 		)
 
-	# If export already occurred - sets GUI to show previous settings
-	options_resize.value = Export.resize
-	options_interpolation.selected = Export.interpolation
+	# If export already occurred (or the project was loaded with export settings saved in it)
+	# sets the GUI to show the project's export settings
+	options_resize.value = project.export_resize
+	options_interpolation.selected = project.export_interpolation
+	options_quality.value = project.export_save_quality * 100.0
+	direction_option_button.selected = project.export_direction
+	repeat_count_spinbox.value = project.export_repeat_count
+	split_layers_checkbox.button_pressed = project.export_split_layers
+	crop_image_option.selected = project.export_crop_mode
+	erase_outside_selection.disabled = project.export_crop_mode == Export.CropMode.SELECTION
+	erase_outside_selection.button_pressed = project.export_erase_unselected_area
+	separator_character_edit.text = project.export_separator_character
+	export_json_checkbox.button_pressed = project.export_json
+	include_tags_in_filename_checkbox.button_pressed = project.export_include_tag_in_filename
+	multiple_animations_directories_checkbox.button_pressed = (
+		project.export_new_dir_for_each_frame_tag
+	)
 	directory_path_label.text = project.export_directory_path
 	var file_ext := Export.file_format_string(project.file_format)
 	if OS.get_name() == "Web" or OS.get_name() == "Android":
@@ -336,25 +360,27 @@ func _on_about_to_popup() -> void:
 
 
 func _on_tab_bar_tab_changed(tab: Export.ExportTab) -> void:
-	Export.current_tab = tab
+	Global.current_project.export_tab = tab
 	show_tab()
 
 
 func _on_orientation_item_selected(id: Export.Orientation) -> void:
-	Export.orientation = id
+	var project := Global.current_project
+	project.export_orientation = id
 	_handle_orientation_ui()
-	spritesheet_lines_count.value = Export.frames_divided_by_spritesheet_lines()
+	spritesheet_lines_count.value = Export.frames_divided_by_spritesheet_lines(project)
 	Export.process_spritesheet()
 	update_dimensions_label()
 	set_preview()
 
 
 func _handle_orientation_ui() -> void:
-	if Export.orientation == Export.Orientation.ROWS:
+	var orientation := Global.current_project.export_orientation
+	if orientation == Export.Orientation.ROWS:
 		spritesheet_lines_count_label.visible = true
 		spritesheet_lines_count.visible = true
 		spritesheet_lines_count_label.text = "Columns:"
-	elif Export.orientation == Export.Orientation.COLUMNS:
+	elif orientation == Export.Orientation.COLUMNS:
 		spritesheet_lines_count_label.visible = true
 		spritesheet_lines_count.visible = true
 		spritesheet_lines_count_label.text = "Rows:"
@@ -364,14 +390,14 @@ func _handle_orientation_ui() -> void:
 
 
 func _on_lines_count_value_changed(value: float) -> void:
-	Export.lines_count = value
+	Global.current_project.export_lines_count = value
 	Export.process_spritesheet()
 	update_dimensions_label()
 	set_preview()
 
 
 func _on_direction_item_selected(id: Export.AnimationDirection) -> void:
-	Export.direction = id
+	Global.current_project.export_direction = id
 	preview_current_frame = 0
 	Export.process_data()
 	set_preview()
@@ -380,7 +406,7 @@ func _on_direction_item_selected(id: Export.AnimationDirection) -> void:
 
 
 func _on_repeat_count_changed(value: int) -> void:
-	Export.repeat_count = value
+	Global.current_project.export_repeat_count = value
 	preview_current_frame = 0
 	Export.process_data()
 	set_preview()
@@ -389,16 +415,16 @@ func _on_repeat_count_changed(value: int) -> void:
 
 
 func _on_resize_value_changed(value: float) -> void:
-	Export.resize = value
+	Global.current_project.export_resize = value
 	update_dimensions_label()
 
 
 func _on_quality_value_changed(value: float) -> void:
-	Export.save_quality = value / 100.0
+	Global.current_project.export_save_quality = value / 100.0
 
 
 func _on_interpolation_item_selected(id: Image.Interpolation) -> void:
-	Export.interpolation = id
+	Global.current_project.export_interpolation = id
 
 
 func _on_confirmed() -> void:
@@ -511,57 +537,59 @@ func _on_ExportDialog_visibility_changed() -> void:
 
 
 func _on_export_json_toggled(toggled_on: bool) -> void:
-	Export.export_json = toggled_on
+	Global.current_project.export_json = toggled_on
 
 
 func _on_split_layers_toggled(toggled_on: bool) -> void:
-	Export.split_layers = toggled_on
-	spritesheet_layers_as_separate_files.disabled = !Export.split_layers
+	var project := Global.current_project
+	project.export_split_layers = toggled_on
+	spritesheet_layers_as_separate_files.disabled = !project.export_split_layers
 	Export.process_data()
 	set_preview()
 
 
 func _on_layers_as_separate_files_toggled(toggled_on: bool) -> void:
-	Export.sheet_layers_as_separate_files = toggled_on
+	Global.current_project.export_sheet_layers_as_separate_files = toggled_on
 	Export.process_data()
 	set_preview()
 
 
 func _on_include_tags_in_filename_toggled(button_pressed: bool) -> void:
-	Export.include_tag_in_filename = button_pressed
+	Global.current_project.export_include_tag_in_filename = button_pressed
 
 
 func _on_multiple_animations_directories_toggled(button_pressed: bool) -> void:
-	Export.new_dir_for_each_frame_tag = button_pressed
+	Global.current_project.export_new_dir_for_each_frame_tag = button_pressed
 
 
 func _on_crop_image_option_selected(index: int) -> void:
-	Export.crop_mode = index as Export.CropMode
+	Global.current_project.export_crop_mode = index as Export.CropMode
 	erase_outside_selection.disabled = index == Export.CropMode.SELECTION
 	Export.process_data()
 	set_preview()
 
 
 func _on_clip_images_selection_toggled(toggled_on: bool) -> void:
-	Export.erase_unselected_area = toggled_on
+	Global.current_project.export_erase_unselected_area = toggled_on
 	Export.process_data()
 	set_preview()
 
 
 func _on_frames_item_selected(id: int) -> void:
-	Export.frame_current_tag = id
+	var project := Global.current_project
+	project.export_frame_current_tag = id
 	Export.process_data()
 	set_preview()
 	spritesheet_lines_count.max_value = Export.number_of_frames
-	spritesheet_lines_count.value = Export.lines_count
+	spritesheet_lines_count.value = project.export_lines_count
 
 
 func _on_layers_item_selected(id: int) -> void:
-	Export.export_layers = id
+	Global.current_project.export_layers = id
 	Export.cache_blended_frames()
 	Export.process_data()
 	set_preview()
 
 
 func _on_separator_character_text_changed(new_text: String) -> void:
-	Export.separator_character = new_text
+	Global.current_project.export_separator_character = new_text

--- a/src/UI/Dialogs/ExportDialog.tscn
+++ b/src/UI/Dialogs/ExportDialog.tscn
@@ -149,6 +149,7 @@ popup/item_1/text = "Selected layers"
 popup/item_1/id = 1
 
 [node name="SplitLayers" type="CheckBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer/LayersContainer" unique_id=287230239 groups=["ExportImageOptions", "ExportSpritesheetOptions", "NotAndroid"]]
+unique_name_in_owner = true
 layout_mode = 2
 mouse_default_cursor_shape = 2
 text = "Split layers"
@@ -158,6 +159,7 @@ layout_mode = 2
 text = "Direction:"
 
 [node name="Direction" type="OptionButton" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer" unique_id=72482042]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -176,6 +178,7 @@ layout_mode = 2
 text = "Repeat times:"
 
 [node name="RepeatCount" type="SpinBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer" unique_id=1383852018]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "The number of times the animation is repeated in addition to the original animation."
@@ -320,11 +323,13 @@ size_flags_horizontal = 3
 text = "Separator character(s):"
 
 [node name="SeparatorCharacter" type="LineEdit" parent="VBoxContainer/VSplitContainer/VBoxContainer/AdvancedOptions/GridContainer" unique_id=863531641 groups=["ExportImageOptions", "ExportMultipleFilesEditableOptions", "ExportSpritesheetOptions"]]
+unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "The character(s) that separate the file name and the frame number"
 text = "_"
 
 [node name="ExportJSON" type="CheckBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/AdvancedOptions/GridContainer" unique_id=459971663 groups=["NotAndroid"]]
+unique_name_in_owner = true
 layout_mode = 2
 mouse_default_cursor_shape = 2
 text = "Export JSON data"
@@ -336,11 +341,13 @@ mouse_default_cursor_shape = 2
 text = "Layers as separate files"
 
 [node name="IncludeTagsInFilename" type="CheckBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/AdvancedOptions/GridContainer" unique_id=64815569 groups=["ExportImageOptions", "ExportMultipleFilesOptions", "NotAndroid"]]
+unique_name_in_owner = true
 layout_mode = 2
 mouse_default_cursor_shape = 2
 text = "Include frame tags in the file name"
 
 [node name="MultipleAnimationsDirectories" type="CheckBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/AdvancedOptions/GridContainer" unique_id=2068197934 groups=["ExportImageOptions", "ExportMultipleFilesOptions", "NotAndroid", "NotHTML5"]]
+unique_name_in_owner = true
 visible = false
 layout_mode = 2
 tooltip_text = "Creates multiple files but every file is stored in different folder that corresponds to its frame tag"


### PR DESCRIPTION
Export dialog settings (spritesheet orientation, lines count, frame range, resize, crop mode, split layers, etc.) used to live only in the Export autoload's global state, so they were shared across all open projects and lost whenever Pixelorama was closed and reopened.

Move these settings onto Project itself, serialize/deserialize them with the rest of the project data (like export_directory_path and file_format already were), and fully sync the export dialog's UI from the current project's settings when it is opened.

Fixes #1503

Assisted by Claude Sonnet 5