### PR TITLE
Fix Color Picker not respecting the assigned mouse button

### DIFF
--- a/src/Tools/UtilityTools/ColorPicker.gd
+++ b/src/Tools/UtilityTools/ColorPicker.gd
@@ -7,6 +7,11 @@ var _color_slot := 0
 var _mode := 0
 
 
+func _ready() -> void:
+	_color_slot = 0 if tool_slot.button == MOUSE_BUTTON_LEFT else 1
+	super._ready()
+
+
 func _input(event: InputEvent) -> void:
 	var options: OptionButton = $ColorPicker/Options
 


### PR DESCRIPTION
## Summary
- The Color Picker tool always defaulted to writing extracted colors into the left tool color, regardless of which mouse button it was assigned to.
- Fixed by defaulting the tool's color slot to match its assigned mouse button (left/right) instead of always defaulting to left.

Fixes #1566

## Test plan
- [x] Assign Color Picker to the right mouse button via the toolbar, right-click on canvas, confirm the right tool color changes.
- [x] Hold Alt to quick-switch to Color Picker, right-click on canvas, confirm the right tool color changes.
- [x] Confirm left mouse button behavior is unchanged.
- [x] gdformat / gdlint pass on the changed file.