### PR TITLE
Fix CLI --quit and headless export not finishing before quitting

### DIFF
--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -149,7 +149,7 @@ func remove_custom_file_format(id: int) -> void:
 func external_export(project := Global.current_project) -> void:
 	cache_blended_frames(project)
 	process_data(project)
-	export_processed_images(true, Global.export_dialog, project)
+	await export_processed_images(true, Global.export_dialog, project)
 
 
 func process_data(project := Global.current_project) -> void:

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -41,9 +41,6 @@ var _last_session_last_project := ""
 
 
 class CLI:
-	## Set when [code]--quit[/code] is passed, so Pixelorama closes once the CLI
-	## command (e.g. an export) has actually finished, instead of quitting immediately.
-	static var quit_when_done := false
 	static var args_list := {
 		["rel-dir="]:
 		[dummy, "(Default='PWD') The directory using which relative paths are resolved."],
@@ -52,7 +49,6 @@ class CLI:
 		["--size"]: [CLI.print_project_size, "Prints size of the given project"],
 		["--framecount"]: [CLI.print_frame_count, "Prints total frames in the current project"],
 		["--export", "-e"]: [CLI.enable_export, "Indicates given project should be exported"],
-		["--quit"]: [CLI.enable_quit, "Close pixelorama after the current command finishes"],
 		["--spritesheet", "-s"]:
 		[CLI.enable_spritesheet, "Indicates given project should be exported as spritesheet"],
 		["--output", "-o"]: [CLI.set_output, "[path] Name of output file (with extension)"],
@@ -124,9 +120,6 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 
 	static func enable_export(_project: Project, _next_arg: String):
 		return true
-
-	static func enable_quit(_project: Project, _next_arg: String) -> void:
-		quit_when_done = true
 
 	static func enable_spritesheet(_project: Project, _next_arg: String):
 		Export.current_tab = Export.ExportTab.SPRITESHEET
@@ -482,8 +475,6 @@ func _handle_cmdline_arguments() -> void:
 				break
 	if should_export:
 		await Export.external_export(project)
-	if CLI.quit_when_done:
-		get_tree().quit()
 
 
 func _on_applinks_data_received(uri: String) -> void:

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -41,6 +41,9 @@ var _last_session_last_project := ""
 
 
 class CLI:
+	## Set when [code]--quit[/code] is passed, so Pixelorama closes once the CLI
+	## command (e.g. an export) has actually finished, instead of quitting immediately.
+	static var quit_when_done := false
 	static var args_list := {
 		["rel-dir="]:
 		[dummy, "(Default='PWD') The directory using which relative paths are resolved."],
@@ -49,6 +52,7 @@ class CLI:
 		["--size"]: [CLI.print_project_size, "Prints size of the given project"],
 		["--framecount"]: [CLI.print_frame_count, "Prints total frames in the current project"],
 		["--export", "-e"]: [CLI.enable_export, "Indicates given project should be exported"],
+		["--quit"]: [CLI.enable_quit, "Close pixelorama after the current command finishes"],
 		["--spritesheet", "-s"]:
 		[CLI.enable_spritesheet, "Indicates given project should be exported as spritesheet"],
 		["--output", "-o"]: [CLI.set_output, "[path] Name of output file (with extension)"],
@@ -120,6 +124,9 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 
 	static func enable_export(_project: Project, _next_arg: String):
 		return true
+
+	static func enable_quit(_project: Project, _next_arg: String) -> void:
+		quit_when_done = true
 
 	static func enable_spritesheet(_project: Project, _next_arg: String):
 		Export.current_tab = Export.ExportTab.SPRITESHEET
@@ -474,7 +481,9 @@ func _handle_cmdline_arguments() -> void:
 				get_tree().quit()
 				break
 	if should_export:
-		Export.external_export(project)
+		await Export.external_export(project)
+	if CLI.quit_when_done:
+		get_tree().quit()
 
 
 func _on_applinks_data_received(uri: String) -> void:


### PR DESCRIPTION
## Summary
- `--quit` was documented in the CLI help but never implemented, so it was treated as an unknown option and caused an immediate `get_tree().quit()`, aborting the command before the requested export ran.
- `Export.external_export()` didn't await its own async export pipeline (`export_processed_images`), so it could return before all frames were written, leading to incomplete exports (e.g. only one frame) in headless mode.

Fixes #1563

## Test plan
- [x] `godot --headless --path . --quit -- -e -o test.gif Misc/example_pxo_files/animated_layer_effect.pxo` exits cleanly (code 0) and produces a complete 6-frame GIF, instead of crashing/aborting.
- [x] gdformat / gdlint pass on the changed files.