### PR TITLE
Make each project have their own export profile

### DIFF
--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -121,7 +121,6 @@ class ExportProfile:
 			"new_dir_for_each_frame_tag": var_to_str(new_dir_for_each_frame_tag),
 			"number_of_digits": var_to_str(number_of_digits),
 			"separator_character": var_to_str(separator_character)
-
 		}
 
 

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -63,6 +63,10 @@ var export_progress := 0.0
 
 
 class ExportStruct:
+	var directory_path := ""
+	var file_name := "untitled"
+	var file_format := Export.FileFormat.PNG
+
 	var current_tab := Export.ExportTab.IMAGE
 	var export_json := false
 	var split_layers := false
@@ -91,10 +95,14 @@ class ExportStruct:
 			var default = get(key)
 			var value = str_to_var(data[key])
 			if default != null and typeof(default) == typeof(value): # property exists
+				prints(key, value)
 				set(key, value)
 
 	func serialize():
 		return {
+			"directory_path": var_to_str(directory_path),
+			"file_name": var_to_str(file_name),
+			"file_format": var_to_str(file_format),
 			"current_tab" : var_to_str(current_tab),
 			"export_json" : var_to_str(export_json),
 			"split_layers" : var_to_str(split_layers),
@@ -189,10 +197,10 @@ func external_export(project := Global.current_project) -> void:
 
 func process_data(project := Global.current_project) -> void:
 	var frames := _calculate_frames(project)
-	var export_setting := project.export_settings
-	if frames.size() * (export_setting.repeat_count + 1) > blended_frames.size():
+	var export_settings := project.export_settings
+	if frames.size() * (export_settings.repeat_count + 1) > blended_frames.size():
 		cache_blended_frames(project)
-	match export_setting.current_tab:
+	match export_settings.current_tab:
 		ExportTab.IMAGE:
 			process_animation(project)
 		ExportTab.SPRITESHEET:
@@ -214,29 +222,29 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var frames := _calculate_frames(project)
 	# Add additional repeated animation (Doing it here instead of _calculate_frames() to save
 	# compute power
-	var export_setting := project.export_settings
-	if export_setting.repeat_count > 0:
+	var export_settings := project.export_settings
+	if export_settings.repeat_count > 0:
 		var frames_copy := frames.duplicate()
-		for _r in export_setting.repeat_count:
+		for _r in export_settings.repeat_count:
 			frames.append_array(frames_copy)
 	# Then store the size of frames for other functions
-	export_setting.number_of_frames = frames.size()
+	export_settings.number_of_frames = frames.size()
 	# Used when the orientation is based off the animation tags
 	var tag_origins := {0: 0}
-	var frames_without_tag := export_setting.number_of_frames
+	var frames_without_tag := export_settings.number_of_frames
 	var spritesheet_columns := 1
 	var spritesheet_rows := 1
 	# If rows mode selected calculate columns count and vice versa
-	if export_setting.orientation == Orientation.COLUMNS:
+	if export_settings.orientation == Orientation.COLUMNS:
 		spritesheet_columns = frames_divided_by_spritesheet_lines()
-		spritesheet_rows = export_setting.lines_count
-	elif export_setting.orientation == Orientation.ROWS:
-		spritesheet_columns = export_setting.lines_count
+		spritesheet_rows = export_settings.lines_count
+	elif export_settings.orientation == Orientation.ROWS:
+		spritesheet_columns = export_settings.lines_count
 		spritesheet_rows = frames_divided_by_spritesheet_lines()
 	else:
 		spritesheet_rows = project.animation_tags.size() + 1
 		if spritesheet_rows == 1:
-			spritesheet_columns = export_setting.number_of_frames
+			spritesheet_columns = export_settings.number_of_frames
 		else:
 			var max_tag_size := 1
 			for tag in project.animation_tags:
@@ -250,7 +258,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 		if frames_without_tag == 0:
 			# If all frames have a tag, remove the first row
 			spritesheet_rows -= 1
-		if export_setting.orientation == Orientation.TAGS_BY_COLUMN:
+		if export_settings.orientation == Orientation.TAGS_BY_COLUMN:
 			# Switch rows and columns
 			var temp := spritesheet_rows
 			spritesheet_rows = spritesheet_columns
@@ -258,7 +266,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var width := project.size.x * spritesheet_columns
 	var height := project.size.y * spritesheet_rows
 	var splitter_array: Array[BaseLayer] = []
-	if export_setting.split_layers:
+	if export_settings.split_layers:
 		splitter_array = _calculate_layers_to_export(project)
 	var only_selected_cels := _export_only_selected_cels(project)
 	var sprite_sheets: Array[Image]  # Array of all apritesheets
@@ -272,7 +280,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 		var sheet_image := Image.create_empty(width, height, false, project.get_image_format())
 		var sheet_is_valid := false
 		for frame in frames:
-			if export_setting.orientation == Orientation.ROWS:
+			if export_settings.orientation == Orientation.ROWS:
 				if vv < spritesheet_columns:
 					origin.x = project.size.x * vv
 					vv += 1
@@ -281,7 +289,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.x = 0
 					vv = 1
 					origin.y = project.size.y * hh
-			elif export_setting.orientation == Orientation.COLUMNS:
+			elif export_settings.orientation == Orientation.COLUMNS:
 				if hh < spritesheet_rows:
 					origin.y = project.size.y * hh
 					hh += 1
@@ -290,7 +298,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.y = 0
 					hh = 1
 					origin.x = project.size.x * vv
-			elif export_setting.orientation == Orientation.TAGS_BY_ROW:
+			elif export_settings.orientation == Orientation.TAGS_BY_ROW:
 				var frame_index := project.frames.find(frame)
 				var frame_has_tag := false
 				for i in project.animation_tags.size():
@@ -309,7 +317,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.x = project.size.x * layer_tag_origins[0]
 					origin.y = 0
 					layer_tag_origins[0] += 1
-			elif export_setting.orientation == Orientation.TAGS_BY_COLUMN:
+			elif export_settings.orientation == Orientation.TAGS_BY_COLUMN:
 				var frame_index := project.frames.find(frame)
 				var frame_has_tag := false
 				for i in project.animation_tags.size():
@@ -328,7 +336,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.y = project.size.y * layer_tag_origins[0]
 					origin.x = 0
 					layer_tag_origins[0] += 1
-			if not export_setting.split_layers:
+			if not export_settings.split_layers:
 				sheet_image.blend_rect(
 					blended_frames[frame], Rect2i(Vector2i.ZERO, project.size), origin
 				)
@@ -344,13 +352,13 @@ func process_spritesheet(project := Global.current_project) -> void:
 					sheet_is_valid = true
 		if sheet_is_valid:
 			sprite_sheets.append(sheet_image)
-			if export_setting.split_layers and split_l < splitter_array.size():
+			if export_settings.split_layers and split_l < splitter_array.size():
 				sprite_sheet_layer_indices.append(splitter_array[split_l].index)
 			else:
 				sprite_sheet_layer_indices.append(-1)
 		if splitter_array.is_empty():
 			break
-	if not export_setting.sheet_layers_as_separate_files and sprite_sheets.size() > 1:
+	if not export_settings.sheet_layers_as_separate_files and sprite_sheets.size() > 1:
 		var big_image := Image.create(
 			width, height * sprite_sheets.size(), false, project.get_image_format()
 		)
@@ -373,9 +381,9 @@ func process_animation(project := Global.current_project) -> void:
 	processed_images.clear()
 	var frames := _calculate_frames(project)
 	var only_selected_cels := _export_only_selected_cels(project)
-	var export_setting := project.export_settings
+	var export_settings := project.export_settings
 	for frame in frames:
-		if export_setting.split_layers:
+		if export_settings.split_layers:
 			for layer in _calculate_layers_to_export(project):
 				if only_selected_cels and not _is_cel_selected(project, frame, layer.index):
 					continue
@@ -389,7 +397,7 @@ func process_animation(project := Global.current_project) -> void:
 		else:
 			var image := project.new_empty_image()
 			image.copy_from(blended_frames[frame])
-			if export_setting.erase_unselected_area and project.has_selection:
+			if export_settings.erase_unselected_area and project.has_selection:
 				var crop := project.new_empty_image()
 				var selection_image := project.selection_map.return_cropped_copy(
 					project, project.size
@@ -398,7 +406,7 @@ func process_animation(project := Global.current_project) -> void:
 					image, selection_image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO
 				)
 				image.copy_from(crop)
-			match export_setting.crop_mode:
+			match export_settings.crop_mode:
 				CropMode.CONTENT:
 					if image.get_used_rect().has_area():
 						image = image.get_region(image.get_used_rect())
@@ -415,7 +423,7 @@ func process_animation(project := Global.current_project) -> void:
 	# Add additional repeated animation (Doing it here instead of _calculate_frames() to save
 	# compute power
 	var un_repeated_size: int = processed_images.size()
-	for _r in export_setting.repeat_count:
+	for _r in export_settings.repeat_count:
 		for i in un_repeated_size:
 			processed_images.append(
 				ProcessedImage.new(
@@ -428,16 +436,16 @@ func process_animation(project := Global.current_project) -> void:
 
 
 func _calculate_frames(project := Global.current_project) -> Array[Frame]:
-	var export_setting = project.export_settings
-	var tag_index = export_setting.frame_current_tag - ExportFrames.size()
+	var export_settings := project.export_settings
+	var tag_index = export_settings.frame_current_tag - ExportFrames.size()
 	if tag_index >= project.animation_tags.size():
-		export_setting.frame_current_tag = ExportFrames.ALL_FRAMES
+		export_settings.frame_current_tag = ExportFrames.ALL_FRAMES
 	var frames: Array[Frame] = []
-	if export_setting.frame_current_tag >= ExportFrames.size():  # Export a specific tag
+	if export_settings.frame_current_tag >= ExportFrames.size():  # Export a specific tag
 		var frame_start: int = project.animation_tags[tag_index].from
 		var frame_end: int = project.animation_tags[tag_index].to
 		frames = project.frames.slice(frame_start - 1, frame_end, 1, true)
-	elif export_setting.frame_current_tag == ExportFrames.SELECTED_FRAMES:
+	elif export_settings.frame_current_tag == ExportFrames.SELECTED_FRAMES:
 		for cel in project.selected_cels:
 			var frame := project.frames[cel[0]]
 			if not frames.has(frame):
@@ -445,9 +453,9 @@ func _calculate_frames(project := Global.current_project) -> Array[Frame]:
 	else:  # All frames
 		frames = project.frames.duplicate()
 
-	if export_setting.direction == AnimationDirection.BACKWARDS:
+	if export_settings.direction == AnimationDirection.BACKWARDS:
 		frames.reverse()
-	elif export_setting.direction == AnimationDirection.PING_PONG:
+	elif export_settings.direction == AnimationDirection.PING_PONG:
 		var inverted_frames := frames.duplicate()
 		inverted_frames.reverse()
 		inverted_frames.remove_at(0)
@@ -459,19 +467,19 @@ func _calculate_frames(project := Global.current_project) -> Array[Frame]:
 
 func _calculate_layers_to_export(project := Global.current_project) -> Array[BaseLayer]:
 	var layers_to_export: Array[BaseLayer] = []
-	var export_setting = project.export_settings
+	var export_settings := project.export_settings
 	for i in project.layers.size():
 		var layer := project.layers[i]
 		if layer is GroupLayer or layer is AudioLayer:
 			continue
 		var include := false
-		match export_setting.export_layers:
+		match export_settings.export_layers:
 			VISIBLE_LAYERS:
 				include = layer.is_visible_in_hierarchy()
 			SELECTED_LAYERS:
 				include = layer.is_visible_in_hierarchy() and _is_layer_selected(project, i)
 			_:  # A specific layer was chosen from the dropdown
-				include = i == export_setting.export_layers - 2
+				include = i == export_settings.export_layers - 2
 		if include:
 			layers_to_export.append(layer)
 	return layers_to_export
@@ -501,9 +509,10 @@ func export_processed_images(
 	ignore_overwrites: bool, export_dialog: ConfirmationDialog, project := Global.current_project
 ) -> bool:
 	# Stop export if directory path or file name are not valid
-	var dir_exists := DirAccess.dir_exists_absolute(project.export_directory_path)
-	var is_valid_filename := project.file_name.is_valid_filename()
-	if project.export_directory_path.begins_with("content://"):
+	var export_settings := project.export_settings
+	var dir_exists := DirAccess.dir_exists_absolute(export_settings.directory_path)
+	var is_valid_filename := export_settings.file_name.is_valid_filename()
+	if export_settings.directory_path.begins_with("content://"):
 		dir_exists = true
 		is_valid_filename = true
 	if not dir_exists:
@@ -516,7 +525,6 @@ func export_processed_images(
 		export_dialog.open_path_validation_alert_popup(1)
 		return false
 
-	var export_setting = project.export_settings
 	var multiple_files := false
 	if not is_single_file_format(project):
 		multiple_files = true if processed_images.size() > 1 else false
@@ -531,9 +539,9 @@ func export_processed_images(
 		var frame_index := i + 1
 		var layer_index := -1
 		var actual_frame_index := processed_images[i].frame_index
-		if export_setting.split_layers:
+		if export_settings.split_layers:
 			layer_index = processed_images[i].layer_index
-			if export_setting.current_tab == ExportTab.IMAGE:
+			if export_settings.current_tab == ExportTab.IMAGE:
 				if actual_frame_index != previous_split_frame:
 					split_frame_counter += 1
 					previous_split_frame = actual_frame_index
@@ -545,12 +553,12 @@ func export_processed_images(
 		# if directories exist, and create them if not
 		if (
 			multiple_files
-			and export_setting.new_dir_for_each_frame_tag
-			and not export_setting.current_tab == ExportTab.SPRITESHEET
+			and export_settings.new_dir_for_each_frame_tag
+			and not export_settings.current_tab == ExportTab.SPRITESHEET
 		):
 			var frame_tag_directory := DirAccess.open(export_path.get_base_dir())
 			if not DirAccess.dir_exists_absolute(export_path.get_base_dir()):
-				frame_tag_directory = DirAccess.open(project.export_directory_path)
+				frame_tag_directory = DirAccess.open(export_settings.directory_path)
 				frame_tag_directory.make_dir(export_path.get_base_dir().get_file())
 
 		if not ignore_overwrites:  # Check if the files already exist
@@ -571,21 +579,21 @@ func export_processed_images(
 		if stop_export:  # User decided to stop export
 			return false
 
-	_scale_processed_images(export_setting.resize, export_setting.interpolation)
-	if export_setting.export_json:
+	_scale_processed_images(export_settings.resize, export_settings.interpolation)
+	if export_settings.export_json:
 		var json := JSON.stringify(project.serialize())
 		var json_file_name := project.name + ".json"
 		if OS.has_feature("web"):
 			var json_buffer := json.to_utf8_buffer()
 			JavaScriptBridge.download_buffer(json_buffer, json_file_name, "application/json")
 		else:
-			var json_path := project.export_directory_path.path_join(json_file_name)
+			var json_path := export_settings.directory_path.path_join(json_file_name)
 			var json_file := FileAccess.open(json_path, FileAccess.WRITE)
 			json_file.store_string(json)
 	# override if a custom export is chosen
-	if project.file_format in custom_exporter_generators.keys():
+	if export_settings.file_format in custom_exporter_generators.keys():
 		# Divert the path to the custom exporter instead
-		var custom_exporter: Object = custom_exporter_generators[project.file_format][0]
+		var custom_exporter: Object = custom_exporter_generators[export_settings.file_format][0]
 		if custom_exporter.has_method("override_export"):
 			var result := true
 			var details := {
@@ -607,7 +615,7 @@ func export_processed_images(
 			return result
 
 	if is_single_file_format(project):
-		if is_using_ffmpeg(project.file_format):
+		if is_using_ffmpeg(export_settings.file_format):
 			var video_exported := export_video(export_paths, project)
 			if not video_exported:
 				Global.popup_error(
@@ -616,7 +624,7 @@ func export_processed_images(
 				return false
 		else:
 			var exporter: AImgIOBaseExporter
-			if project.file_format == FileFormat.APNG:
+			if export_settings.file_format == FileFormat.APNG:
 				exporter = AImgIOAPNGExporter.new()
 			else:
 				exporter = GIFAnimationExporter.new()
@@ -638,13 +646,13 @@ func export_processed_images(
 				var buffer: PackedByteArray
 				var file_name := export_paths[i].get_file()
 				var mimetype := ""
-				if project.file_format == FileFormat.WEBP:
+				if export_settings.file_format == FileFormat.WEBP:
 					buffer = processed_images[i].image.save_webp_to_buffer()
 					mimetype = "image/webp"
-				elif project.file_format == FileFormat.JPEG:
+				elif export_settings.file_format == FileFormat.JPEG:
 					buffer = processed_images[i].image.save_jpg_to_buffer()
 					mimetype = "image/jpeg"
-				elif project.file_format == FileFormat.SVG:
+				elif export_settings.file_format == FileFormat.SVG:
 					var svg_str := image_to_svg(processed_images[i].image)
 					buffer = svg_str.to_utf8_buffer()
 					mimetype = "image/svg"
@@ -656,20 +664,20 @@ func export_processed_images(
 
 			else:
 				var err: Error
-				if project.file_format == FileFormat.PNG:
+				if export_settings.file_format == FileFormat.PNG:
 					err = processed_images[i].image.save_png(export_paths[i])
-				elif project.file_format == FileFormat.WEBP:
+				elif export_settings.file_format == FileFormat.WEBP:
 					err = processed_images[i].image.save_webp(export_paths[i])
-				elif project.file_format == FileFormat.JPEG:
+				elif export_settings.file_format == FileFormat.JPEG:
 					err = processed_images[i].image.save_jpg(
-						export_paths[i], export_setting.save_quality
+						export_paths[i], export_settings.save_quality
 					)
-				elif project.file_format == FileFormat.SVG:
+				elif export_settings.file_format == FileFormat.SVG:
 					var svg_str := image_to_svg(processed_images[i].image)
 					var svg_file := FileAccess.open(export_paths[i], FileAccess.WRITE)
 					err = FileAccess.get_open_error()
 					svg_file.store_string(svg_str)
-				elif project.file_format == FileFormat.EXR:
+				elif export_settings.file_format == FileFormat.EXR:
 					err = processed_images[i].image.save_exr(export_paths[i])
 				if err != OK:
 					Global.popup_error(
@@ -679,7 +687,10 @@ func export_processed_images(
 
 	Global.notification_label("File(s) exported")
 	# Store settings for quick export and when the dialog is opened again
-	var file_name_with_ext := project.file_name + file_format_string(project.file_format)
+	var file_name_with_ext := (
+		project.export_settings.file_name
+		+ file_format_string(project.export_settings.file_format)
+	)
 	project.was_exported = true
 	if project.export_overwrite:
 		Global.top_menu_container.file_menu.set_item_text(
@@ -689,9 +700,9 @@ func export_processed_images(
 		Global.top_menu_container.file_menu.set_item_text(
 			Global.FileMenu.EXPORT, tr("Export") + " %s" % file_name_with_ext
 		)
-	# NOTE: project.export_directory_path is already updated through ExportDialog.gd
+	# NOTE: export_settings.directory_path is already updated through ExportDialog.gd
 	# we only need to update the current_dir here after the export
-	Global.config_cache.set_value("data", "current_dir", project.export_directory_path)
+	Global.config_cache.set_value("data", "current_dir", export_settings.directory_path)
 	return true
 
 
@@ -701,9 +712,9 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var video_duration := 0
 	var input_file_path := temp_path.path_join("input.txt")
 	var input_file := FileAccess.open(input_file_path, FileAccess.WRITE)
-	var export_setting = project.export_settings
+	var export_settings := project.export_settings
 	for i in range(processed_images.size()):
-		var temp_file_name := str(i + 1).pad_zeros(export_setting.number_of_digits) + ".png"
+		var temp_file_name := str(i + 1).pad_zeros(export_settings.number_of_digits) + ".png"
 		var temp_file_path := temp_path.path_join(temp_file_name)
 		processed_images[i].image.save_png(temp_file_path)
 		input_file.store_line("file '" + temp_file_name + "'")
@@ -741,7 +752,7 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var adelay_string := ""
 	for layer in project.get_all_audio_layers():
 		if layer.audio is AudioStreamMP3 or layer.audio is AudioStreamWAV:
-			var temp_file_name := str(audio_layer_count + 1).pad_zeros(export_setting.number_of_digits)
+			var temp_file_name := str(audio_layer_count + 1).pad_zeros(export_settings.number_of_digits)
 			if layer.audio is AudioStreamMP3:
 				temp_file_name += ".mp3"
 			elif layer.audio is AudioStreamWAV:
@@ -935,7 +946,7 @@ func get_file_format_from_extension(file_extension: String) -> FileFormat:
 ## True when exporting to .gif, .apng and video
 ## False when exporting to .png, .jpg and static .webp
 func is_single_file_format(project := Global.current_project) -> bool:
-	return animated_formats.has(project.file_format)
+	return animated_formats.has(project.export_settings.file_format)
 
 
 func is_using_ffmpeg(format: FileFormat) -> bool:
@@ -954,21 +965,21 @@ func is_ffmpeg_installed() -> bool:
 func _create_export_path(
 	multifile: bool, project: Project, frame := 0, layer := -1, actual_frame_index := 0
 ) -> String:
-	var path := project.file_name
-	var export_setting := project.export_settings
+	var export_settings := project.export_settings
+	var path := export_settings.file_name
 	if path.contains("{name}"):
 		path = path.replace("{name}", project.name)
 	var path_extras := ""
-	var separator_character := export_setting.separator_character
+	var separator_character := export_settings.separator_character
 	# Only append frame number when there are multiple files exported
 	if multifile:
 		if layer > -1:
 			var layer_name := project.layers[layer].name
 			path_extras += "(%s) " % layer_name
 		var counter: String = (
-			str(layer).pad_zeros(export_setting.number_of_digits)
-			if export_setting.current_tab == ExportTab.SPRITESHEET
-			else str(str(frame).pad_zeros(export_setting.number_of_digits))
+			str(layer).pad_zeros(export_settings.number_of_digits)
+			if export_settings.current_tab == ExportTab.SPRITESHEET
+			else str(str(frame).pad_zeros(export_settings.number_of_digits))
 		)
 		path_extras += separator_character + counter
 	var frame_tag_and_start_id := _get_processed_image_tag_name_and_start_id(
@@ -982,31 +993,31 @@ func _create_export_path(
 		var regex := RegEx.new()
 		regex.compile("[^a-zA-Z0-9_]+")
 		var frame_tag_dir := regex.sub(frame_tag, "", true)
-		if export_setting.include_tag_in_filename:
+		if export_settings.include_tag_in_filename:
 			# (actual_frame_index - start_id + 2) makes frames id to start from 1
 			var tag_frame_number := str(actual_frame_index - start_id + 2).pad_zeros(
-				export_setting.number_of_digits
+				export_settings.number_of_digits
 			)
 			path_extras = (
 				separator_character + frame_tag_dir + separator_character + tag_frame_number
 			)
-		if export_setting.new_dir_for_each_frame_tag:
+		if export_settings.new_dir_for_each_frame_tag:
 			path += path_extras
-			return project.export_directory_path.path_join(frame_tag_dir).path_join(
-				path + file_format_string(project.file_format, true)
+			return export_settings.directory_path.path_join(frame_tag_dir).path_join(
+				path + file_format_string(export_settings.file_format, true)
 			)
 	path += path_extras
 
 	if OS.get_name() == "Android":
 		return (
-			project.export_directory_path
+			export_settings.directory_path
 			+ "#"
 			+ path
-			+ file_format_string(project.file_format, true)
+			+ file_format_string(export_settings.file_format, true)
 		)
 
-	return project.export_directory_path.path_join(
-		path + file_format_string(project.file_format, true)
+	return export_settings.directory_path.path_join(
+		path + file_format_string(export_settings.file_format, true)
 	)
 
 
@@ -1024,10 +1035,10 @@ func _get_processed_image_tag_name_and_start_id(project: Project, processed_imag
 func _blend_layers(
 	image: Image, frame: Frame, origin := Vector2i.ZERO, project := Global.current_project
 ) -> void:
-	var export_setting := project.export_settings
-	if export_setting.export_layers - 2 >= project.layers.size():
-		export_setting.export_layers = VISIBLE_LAYERS
-	if export_setting.export_layers == VISIBLE_LAYERS:
+	var export_settings := project.export_settings
+	if export_settings.export_layers - 2 >= project.layers.size():
+		export_settings.export_layers = VISIBLE_LAYERS
+	if export_settings.export_layers == VISIBLE_LAYERS:
 		var load_result_from_pxo := not project.save_path.is_empty() and not project.has_changed
 		if load_result_from_pxo:
 			# Attempt to read the image data directly from the pxo file, without having to blend
@@ -1057,20 +1068,20 @@ func _blend_layers(
 				load_result_from_pxo = false
 		if not load_result_from_pxo:
 			DrawingAlgos.blend_layers(image, frame, origin, project)
-	elif export_setting.export_layers == SELECTED_LAYERS:
+	elif export_settings.export_layers == SELECTED_LAYERS:
 		DrawingAlgos.blend_layers(image, frame, origin, project, false, true)
 	else:
-		var layer := project.layers[export_setting.export_layers - 2]
+		var layer := project.layers[export_settings.export_layers - 2]
 		var layer_image := Image.new()
 		if layer is GroupLayer:
 			layer_image.copy_from(layer.blend_children(frame, Vector2i.ZERO))
 		else:
 			layer_image.copy_from(
-				layer.display_effects(frame.cels[export_setting.export_layers - 2])
+				layer.display_effects(frame.cels[export_settings.export_layers - 2])
 			)
 		image.blend_rect(layer_image, Rect2i(Vector2i.ZERO, project.size), origin)
 
 
 func frames_divided_by_spritesheet_lines(project := Global.current_project) -> int:
-	var export_setting := project.export_settings
-	return ceili(export_setting.number_of_frames / float(export_setting.lines_count))
+	var export_settings := project.export_settings
+	return ceili(export_settings.number_of_frames / float(export_settings.lines_count))

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -46,34 +46,12 @@ var file_format_dictionary: Dictionary[FileFormat, Array] = {
 var custom_file_formats := {}
 var custom_exporter_generators := {}
 
-var current_tab := ExportTab.IMAGE
+
 ## All frames and their layers processed/blended into images
 var processed_images: Array[ProcessedImage] = []
 ## A dictionary that contains all of the blended frames.
 ## Changes when [method cache_blended_frames] is called.
 var blended_frames: Dictionary[Frame, Image] = {}
-var export_json := false
-var split_layers := false
-var sheet_layers_as_separate_files := false
-var crop_mode := CropMode.NONE
-var erase_unselected_area := false
-# Spritesheet options
-var orientation := Orientation.COLUMNS
-var lines_count := 1  ## How many rows/columns before new line is added
-
-# General options
-var frame_current_tag := 0  ## Export only current frame tag
-var export_layers := 0
-var number_of_frames := 1
-var direction := AnimationDirection.FORWARD
-var repeat_count := 0
-var resize := 100
-var save_quality := 0.75  ## Used when saving jpg and webp images. Goes from 0 to 1.
-var interpolation := Image.INTERPOLATE_NEAREST
-var include_tag_in_filename := false
-var new_dir_for_each_frame_tag := false  ## We don't need to store this after export
-var number_of_digits := 4
-var separator_character := "_"
 var stop_export := false  ## Export coroutine signal
 
 var file_exists_alert := "The following files already exist. Do you wish to overwrite them?\n%s"
@@ -82,6 +60,62 @@ var file_exists_alert := "The following files already exist. Do you wish to over
 var export_progress_fraction := 0.0
 var export_progress := 0.0
 @onready var gif_export_thread := Thread.new()
+
+
+class ExportStruct:
+	var current_tab := Export.ExportTab.IMAGE
+	var export_json := false
+	var split_layers := false
+	var sheet_layers_as_separate_files := false
+	var crop_mode := CropMode.NONE
+	var erase_unselected_area := false
+	# Spritesheet options
+	var orientation := Orientation.COLUMNS
+	var lines_count := 1  ## How many rows/columns before new line is added
+	# General options
+	var frame_current_tag := 0  ## Export only current frame tag
+	var export_layers := 0
+	var number_of_frames := 1
+	var direction := AnimationDirection.FORWARD
+	var repeat_count := 0
+	var resize := 100
+	var save_quality := 0.75  ## Used when saving jpg and webp images. Goes from 0 to 1.
+	var interpolation := Image.INTERPOLATE_NEAREST
+	var include_tag_in_filename := false
+	var new_dir_for_each_frame_tag := false  ## We don't need to store this after export
+	var number_of_digits := 4
+	var separator_character := "_"
+
+	func deserialize(data: Dictionary):
+		for key in data.keys():
+			var default = get(key)
+			var value = str_to_var(data[key])
+			if default != null and typeof(default) == typeof(value): # property exists
+				set(key, value)
+
+	func serialize():
+		return {
+			"current_tab" : var_to_str(current_tab),
+			"export_json" : var_to_str(export_json),
+			"split_layers" : var_to_str(split_layers),
+			"sheet_layers_as_separate_files" : var_to_str(sheet_layers_as_separate_files),
+			"crop_mode" : var_to_str(crop_mode),
+			"erase_unselected_area" : var_to_str(erase_unselected_area),
+			"orientation" : var_to_str(orientation),
+			"lines_count" : var_to_str(lines_count),
+			"frame_current_tag" : var_to_str(frame_current_tag),
+			"export_layers" : var_to_str(export_layers),
+			"number_of_frames" : var_to_str(number_of_frames),
+			"direction" : var_to_str(direction),
+			"repeat_count" : var_to_str(repeat_count),
+			"resize" : var_to_str(resize),
+			"save_quality" : var_to_str(save_quality),
+			"interpolation" : var_to_str(interpolation),
+			"include_tag_in_filename" : var_to_str(include_tag_in_filename),
+			"new_dir_for_each_frame_tag" : var_to_str(new_dir_for_each_frame_tag),
+			"number_of_digits" : var_to_str(number_of_digits),
+			"separator_character" : var_to_str(separator_character)
+		}
 
 
 class ProcessedImage:
@@ -155,9 +189,10 @@ func external_export(project := Global.current_project) -> void:
 
 func process_data(project := Global.current_project) -> void:
 	var frames := _calculate_frames(project)
-	if frames.size() * (repeat_count + 1) > blended_frames.size():
+	var export_setting := project.export_settings
+	if frames.size() * (export_setting.repeat_count + 1) > blended_frames.size():
 		cache_blended_frames(project)
-	match current_tab:
+	match export_setting.current_tab:
 		ExportTab.IMAGE:
 			process_animation(project)
 		ExportTab.SPRITESHEET:
@@ -179,28 +214,29 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var frames := _calculate_frames(project)
 	# Add additional repeated animation (Doing it here instead of _calculate_frames() to save
 	# compute power
-	if repeat_count > 0:
+	var export_setting := project.export_settings
+	if export_setting.repeat_count > 0:
 		var frames_copy := frames.duplicate()
-		for _r in repeat_count:
+		for _r in export_setting.repeat_count:
 			frames.append_array(frames_copy)
 	# Then store the size of frames for other functions
-	number_of_frames = frames.size()
+	export_setting.number_of_frames = frames.size()
 	# Used when the orientation is based off the animation tags
 	var tag_origins := {0: 0}
-	var frames_without_tag := number_of_frames
+	var frames_without_tag := export_setting.number_of_frames
 	var spritesheet_columns := 1
 	var spritesheet_rows := 1
 	# If rows mode selected calculate columns count and vice versa
-	if orientation == Orientation.COLUMNS:
+	if export_setting.orientation == Orientation.COLUMNS:
 		spritesheet_columns = frames_divided_by_spritesheet_lines()
-		spritesheet_rows = lines_count
-	elif orientation == Orientation.ROWS:
-		spritesheet_columns = lines_count
+		spritesheet_rows = export_setting.lines_count
+	elif export_setting.orientation == Orientation.ROWS:
+		spritesheet_columns = export_setting.lines_count
 		spritesheet_rows = frames_divided_by_spritesheet_lines()
 	else:
 		spritesheet_rows = project.animation_tags.size() + 1
 		if spritesheet_rows == 1:
-			spritesheet_columns = number_of_frames
+			spritesheet_columns = export_setting.number_of_frames
 		else:
 			var max_tag_size := 1
 			for tag in project.animation_tags:
@@ -214,7 +250,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 		if frames_without_tag == 0:
 			# If all frames have a tag, remove the first row
 			spritesheet_rows -= 1
-		if orientation == Orientation.TAGS_BY_COLUMN:
+		if export_setting.orientation == Orientation.TAGS_BY_COLUMN:
 			# Switch rows and columns
 			var temp := spritesheet_rows
 			spritesheet_rows = spritesheet_columns
@@ -222,9 +258,9 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var width := project.size.x * spritesheet_columns
 	var height := project.size.y * spritesheet_rows
 	var splitter_array: Array[BaseLayer] = []
-	if split_layers:
+	if export_setting.split_layers:
 		splitter_array = _calculate_layers_to_export(project)
-	var only_selected_cels := _export_only_selected_cels()
+	var only_selected_cels := _export_only_selected_cels(project)
 	var sprite_sheets: Array[Image]  # Array of all apritesheets
 	var sprite_sheet_layer_indices: Array[int] = []
 	# This is an imitation of a do-while loop. The loop ends early if split_layers is empty
@@ -236,7 +272,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 		var sheet_image := Image.create_empty(width, height, false, project.get_image_format())
 		var sheet_is_valid := false
 		for frame in frames:
-			if orientation == Orientation.ROWS:
+			if export_setting.orientation == Orientation.ROWS:
 				if vv < spritesheet_columns:
 					origin.x = project.size.x * vv
 					vv += 1
@@ -245,7 +281,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.x = 0
 					vv = 1
 					origin.y = project.size.y * hh
-			elif orientation == Orientation.COLUMNS:
+			elif export_setting.orientation == Orientation.COLUMNS:
 				if hh < spritesheet_rows:
 					origin.y = project.size.y * hh
 					hh += 1
@@ -254,7 +290,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.y = 0
 					hh = 1
 					origin.x = project.size.x * vv
-			elif orientation == Orientation.TAGS_BY_ROW:
+			elif export_setting.orientation == Orientation.TAGS_BY_ROW:
 				var frame_index := project.frames.find(frame)
 				var frame_has_tag := false
 				for i in project.animation_tags.size():
@@ -273,7 +309,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.x = project.size.x * layer_tag_origins[0]
 					origin.y = 0
 					layer_tag_origins[0] += 1
-			elif orientation == Orientation.TAGS_BY_COLUMN:
+			elif export_setting.orientation == Orientation.TAGS_BY_COLUMN:
 				var frame_index := project.frames.find(frame)
 				var frame_has_tag := false
 				for i in project.animation_tags.size():
@@ -292,7 +328,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.y = project.size.y * layer_tag_origins[0]
 					origin.x = 0
 					layer_tag_origins[0] += 1
-			if not split_layers:
+			if not export_setting.split_layers:
 				sheet_image.blend_rect(
 					blended_frames[frame], Rect2i(Vector2i.ZERO, project.size), origin
 				)
@@ -308,13 +344,13 @@ func process_spritesheet(project := Global.current_project) -> void:
 					sheet_is_valid = true
 		if sheet_is_valid:
 			sprite_sheets.append(sheet_image)
-			if split_layers and split_l < splitter_array.size():
+			if export_setting.split_layers and split_l < splitter_array.size():
 				sprite_sheet_layer_indices.append(splitter_array[split_l].index)
 			else:
 				sprite_sheet_layer_indices.append(-1)
 		if splitter_array.is_empty():
 			break
-	if not sheet_layers_as_separate_files and sprite_sheets.size() > 1:
+	if not export_setting.sheet_layers_as_separate_files and sprite_sheets.size() > 1:
 		var big_image := Image.create(
 			width, height * sprite_sheets.size(), false, project.get_image_format()
 		)
@@ -336,9 +372,10 @@ func process_spritesheet(project := Global.current_project) -> void:
 func process_animation(project := Global.current_project) -> void:
 	processed_images.clear()
 	var frames := _calculate_frames(project)
-	var only_selected_cels := _export_only_selected_cels()
+	var only_selected_cels := _export_only_selected_cels(project)
+	var export_setting := project.export_settings
 	for frame in frames:
-		if split_layers:
+		if export_setting.split_layers:
 			for layer in _calculate_layers_to_export(project):
 				if only_selected_cels and not _is_cel_selected(project, frame, layer.index):
 					continue
@@ -352,7 +389,7 @@ func process_animation(project := Global.current_project) -> void:
 		else:
 			var image := project.new_empty_image()
 			image.copy_from(blended_frames[frame])
-			if erase_unselected_area and project.has_selection:
+			if export_setting.erase_unselected_area and project.has_selection:
 				var crop := project.new_empty_image()
 				var selection_image := project.selection_map.return_cropped_copy(
 					project, project.size
@@ -361,7 +398,7 @@ func process_animation(project := Global.current_project) -> void:
 					image, selection_image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO
 				)
 				image.copy_from(crop)
-			match crop_mode:
+			match export_setting.crop_mode:
 				CropMode.CONTENT:
 					if image.get_used_rect().has_area():
 						image = image.get_region(image.get_used_rect())
@@ -378,7 +415,7 @@ func process_animation(project := Global.current_project) -> void:
 	# Add additional repeated animation (Doing it here instead of _calculate_frames() to save
 	# compute power
 	var un_repeated_size: int = processed_images.size()
-	for _r in repeat_count:
+	for _r in export_setting.repeat_count:
 		for i in un_repeated_size:
 			processed_images.append(
 				ProcessedImage.new(
@@ -391,15 +428,16 @@ func process_animation(project := Global.current_project) -> void:
 
 
 func _calculate_frames(project := Global.current_project) -> Array[Frame]:
-	var tag_index := frame_current_tag - ExportFrames.size()
+	var export_setting = project.export_settings
+	var tag_index = export_setting.frame_current_tag - ExportFrames.size()
 	if tag_index >= project.animation_tags.size():
-		frame_current_tag = ExportFrames.ALL_FRAMES
+		export_setting.frame_current_tag = ExportFrames.ALL_FRAMES
 	var frames: Array[Frame] = []
-	if frame_current_tag >= ExportFrames.size():  # Export a specific tag
+	if export_setting.frame_current_tag >= ExportFrames.size():  # Export a specific tag
 		var frame_start: int = project.animation_tags[tag_index].from
 		var frame_end: int = project.animation_tags[tag_index].to
 		frames = project.frames.slice(frame_start - 1, frame_end, 1, true)
-	elif frame_current_tag == ExportFrames.SELECTED_FRAMES:
+	elif export_setting.frame_current_tag == ExportFrames.SELECTED_FRAMES:
 		for cel in project.selected_cels:
 			var frame := project.frames[cel[0]]
 			if not frames.has(frame):
@@ -407,9 +445,9 @@ func _calculate_frames(project := Global.current_project) -> Array[Frame]:
 	else:  # All frames
 		frames = project.frames.duplicate()
 
-	if direction == AnimationDirection.BACKWARDS:
+	if export_setting.direction == AnimationDirection.BACKWARDS:
 		frames.reverse()
-	elif direction == AnimationDirection.PING_PONG:
+	elif export_setting.direction == AnimationDirection.PING_PONG:
 		var inverted_frames := frames.duplicate()
 		inverted_frames.reverse()
 		inverted_frames.remove_at(0)
@@ -421,18 +459,19 @@ func _calculate_frames(project := Global.current_project) -> Array[Frame]:
 
 func _calculate_layers_to_export(project := Global.current_project) -> Array[BaseLayer]:
 	var layers_to_export: Array[BaseLayer] = []
+	var export_setting = project.export_settings
 	for i in project.layers.size():
 		var layer := project.layers[i]
 		if layer is GroupLayer or layer is AudioLayer:
 			continue
 		var include := false
-		match export_layers:
+		match export_setting.export_layers:
 			VISIBLE_LAYERS:
 				include = layer.is_visible_in_hierarchy()
 			SELECTED_LAYERS:
 				include = layer.is_visible_in_hierarchy() and _is_layer_selected(project, i)
 			_:  # A specific layer was chosen from the dropdown
-				include = i == export_layers - 2
+				include = i == export_setting.export_layers - 2
 		if include:
 			layers_to_export.append(layer)
 	return layers_to_export
@@ -447,8 +486,11 @@ func _is_layer_selected(project: Project, layer_index: int) -> bool:
 
 ## True when both "Selected frames" and "Selected layers" are chosen, in which case only the exact
 ## cels the user selected are exported, instead of every selected layer at every selected frame.
-func _export_only_selected_cels() -> bool:
-	return frame_current_tag == ExportFrames.SELECTED_FRAMES and export_layers == SELECTED_LAYERS
+func _export_only_selected_cels(project: Project) -> bool:
+	return (
+		project.export_settings.frame_current_tag == ExportFrames.SELECTED_FRAMES
+		and project.export_settings.export_layers == SELECTED_LAYERS
+	)
 
 
 func _is_cel_selected(project: Project, frame: Frame, layer_index: int) -> bool:
@@ -474,6 +516,7 @@ func export_processed_images(
 		export_dialog.open_path_validation_alert_popup(1)
 		return false
 
+	var export_setting = project.export_settings
 	var multiple_files := false
 	if not is_single_file_format(project):
 		multiple_files = true if processed_images.size() > 1 else false
@@ -488,9 +531,9 @@ func export_processed_images(
 		var frame_index := i + 1
 		var layer_index := -1
 		var actual_frame_index := processed_images[i].frame_index
-		if split_layers:
+		if export_setting.split_layers:
 			layer_index = processed_images[i].layer_index
-			if current_tab == ExportTab.IMAGE:
+			if export_setting.current_tab == ExportTab.IMAGE:
 				if actual_frame_index != previous_split_frame:
 					split_frame_counter += 1
 					previous_split_frame = actual_frame_index
@@ -502,8 +545,8 @@ func export_processed_images(
 		# if directories exist, and create them if not
 		if (
 			multiple_files
-			and new_dir_for_each_frame_tag
-			and not current_tab == ExportTab.SPRITESHEET
+			and export_setting.new_dir_for_each_frame_tag
+			and not export_setting.current_tab == ExportTab.SPRITESHEET
 		):
 			var frame_tag_directory := DirAccess.open(export_path.get_base_dir())
 			if not DirAccess.dir_exists_absolute(export_path.get_base_dir()):
@@ -528,8 +571,8 @@ func export_processed_images(
 		if stop_export:  # User decided to stop export
 			return false
 
-	_scale_processed_images()
-	if export_json:
+	_scale_processed_images(export_setting.resize, export_setting.interpolation)
+	if export_setting.export_json:
 		var json := JSON.stringify(project.serialize())
 		var json_file_name := project.name + ".json"
 		if OS.has_feature("web"):
@@ -618,7 +661,9 @@ func export_processed_images(
 				elif project.file_format == FileFormat.WEBP:
 					err = processed_images[i].image.save_webp(export_paths[i])
 				elif project.file_format == FileFormat.JPEG:
-					err = processed_images[i].image.save_jpg(export_paths[i], save_quality)
+					err = processed_images[i].image.save_jpg(
+						export_paths[i], export_setting.save_quality
+					)
 				elif project.file_format == FileFormat.SVG:
 					var svg_str := image_to_svg(processed_images[i].image)
 					var svg_file := FileAccess.open(export_paths[i], FileAccess.WRITE)
@@ -656,8 +701,9 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var video_duration := 0
 	var input_file_path := temp_path.path_join("input.txt")
 	var input_file := FileAccess.open(input_file_path, FileAccess.WRITE)
+	var export_setting = project.export_settings
 	for i in range(processed_images.size()):
-		var temp_file_name := str(i + 1).pad_zeros(number_of_digits) + ".png"
+		var temp_file_name := str(i + 1).pad_zeros(export_setting.number_of_digits) + ".png"
 		var temp_file_path := temp_path.path_join(temp_file_name)
 		processed_images[i].image.save_png(temp_file_path)
 		input_file.store_line("file '" + temp_file_name + "'")
@@ -695,7 +741,7 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var adelay_string := ""
 	for layer in project.get_all_audio_layers():
 		if layer.audio is AudioStreamMP3 or layer.audio is AudioStreamWAV:
-			var temp_file_name := str(audio_layer_count + 1).pad_zeros(number_of_digits)
+			var temp_file_name := str(audio_layer_count + 1).pad_zeros(export_setting.number_of_digits)
 			if layer.audio is AudioStreamMP3:
 				temp_file_name += ".mp3"
 			elif layer.audio is AudioStreamWAV:
@@ -836,10 +882,10 @@ func _increase_export_progress(export_dialog: Node) -> void:
 	export_dialog.set_export_progress_bar(export_progress)
 
 
-func _scale_processed_images() -> void:
-	var resize_f := resize / 100.0
+func _scale_processed_images(resize_amount: int, interpolation := Image.INTERPOLATE_NEAREST) -> void:
+	var resize_f := resize_amount / 100.0
 	for processed_image in processed_images:
-		if is_equal_approx(resize, 1.0):
+		if is_equal_approx(resize_amount, 1.0):
 			continue
 		var image := processed_image.image
 		image.resize(image.get_size().x * resize_f, image.get_size().y * resize_f, interpolation)
@@ -909,18 +955,20 @@ func _create_export_path(
 	multifile: bool, project: Project, frame := 0, layer := -1, actual_frame_index := 0
 ) -> String:
 	var path := project.file_name
+	var export_setting := project.export_settings
 	if path.contains("{name}"):
 		path = path.replace("{name}", project.name)
 	var path_extras := ""
+	var separator_character := export_setting.separator_character
 	# Only append frame number when there are multiple files exported
 	if multifile:
 		if layer > -1:
 			var layer_name := project.layers[layer].name
 			path_extras += "(%s) " % layer_name
 		var counter: String = (
-			str(layer).pad_zeros(number_of_digits)
-			if current_tab == ExportTab.SPRITESHEET
-			else str(str(frame).pad_zeros(number_of_digits))
+			str(layer).pad_zeros(export_setting.number_of_digits)
+			if export_setting.current_tab == ExportTab.SPRITESHEET
+			else str(str(frame).pad_zeros(export_setting.number_of_digits))
 		)
 		path_extras += separator_character + counter
 	var frame_tag_and_start_id := _get_processed_image_tag_name_and_start_id(
@@ -934,15 +982,15 @@ func _create_export_path(
 		var regex := RegEx.new()
 		regex.compile("[^a-zA-Z0-9_]+")
 		var frame_tag_dir := regex.sub(frame_tag, "", true)
-		if include_tag_in_filename:
+		if export_setting.include_tag_in_filename:
 			# (actual_frame_index - start_id + 2) makes frames id to start from 1
 			var tag_frame_number := str(actual_frame_index - start_id + 2).pad_zeros(
-				number_of_digits
+				export_setting.number_of_digits
 			)
 			path_extras = (
 				separator_character + frame_tag_dir + separator_character + tag_frame_number
 			)
-		if new_dir_for_each_frame_tag:
+		if export_setting.new_dir_for_each_frame_tag:
 			path += path_extras
 			return project.export_directory_path.path_join(frame_tag_dir).path_join(
 				path + file_format_string(project.file_format, true)
@@ -976,9 +1024,10 @@ func _get_processed_image_tag_name_and_start_id(project: Project, processed_imag
 func _blend_layers(
 	image: Image, frame: Frame, origin := Vector2i.ZERO, project := Global.current_project
 ) -> void:
-	if export_layers - 2 >= project.layers.size():
-		export_layers = VISIBLE_LAYERS
-	if export_layers == VISIBLE_LAYERS:
+	var export_setting := project.export_settings
+	if export_setting.export_layers - 2 >= project.layers.size():
+		export_setting.export_layers = VISIBLE_LAYERS
+	if export_setting.export_layers == VISIBLE_LAYERS:
 		var load_result_from_pxo := not project.save_path.is_empty() and not project.has_changed
 		if load_result_from_pxo:
 			# Attempt to read the image data directly from the pxo file, without having to blend
@@ -1008,17 +1057,20 @@ func _blend_layers(
 				load_result_from_pxo = false
 		if not load_result_from_pxo:
 			DrawingAlgos.blend_layers(image, frame, origin, project)
-	elif export_layers == SELECTED_LAYERS:
+	elif export_setting.export_layers == SELECTED_LAYERS:
 		DrawingAlgos.blend_layers(image, frame, origin, project, false, true)
 	else:
-		var layer := project.layers[export_layers - 2]
+		var layer := project.layers[export_setting.export_layers - 2]
 		var layer_image := Image.new()
 		if layer is GroupLayer:
 			layer_image.copy_from(layer.blend_children(frame, Vector2i.ZERO))
 		else:
-			layer_image.copy_from(layer.display_effects(frame.cels[export_layers - 2]))
+			layer_image.copy_from(
+				layer.display_effects(frame.cels[export_setting.export_layers - 2])
+			)
 		image.blend_rect(layer_image, Rect2i(Vector2i.ZERO, project.size), origin)
 
 
-func frames_divided_by_spritesheet_lines() -> int:
-	return ceili(number_of_frames / float(lines_count))
+func frames_divided_by_spritesheet_lines(project := Global.current_project) -> int:
+	var export_setting := project.export_settings
+	return ceili(export_setting.number_of_frames / float(export_setting.lines_count))

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -62,7 +62,7 @@ var export_progress := 0.0
 @onready var gif_export_thread := Thread.new()
 
 
-class ExportStruct:
+class ExportProfile:
 	var directory_path := ""
 	var file_name := "untitled"
 	var file_format := Export.FileFormat.PNG
@@ -197,10 +197,10 @@ func external_export(project := Global.current_project) -> void:
 
 func process_data(project := Global.current_project) -> void:
 	var frames := _calculate_frames(project)
-	var export_settings := project.export_settings
-	if frames.size() * (export_settings.repeat_count + 1) > blended_frames.size():
+	var export_profile := project.export_profile
+	if frames.size() * (export_profile.repeat_count + 1) > blended_frames.size():
 		cache_blended_frames(project)
-	match export_settings.current_tab:
+	match export_profile.current_tab:
 		ExportTab.IMAGE:
 			process_animation(project)
 		ExportTab.SPRITESHEET:
@@ -222,29 +222,29 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var frames := _calculate_frames(project)
 	# Add additional repeated animation (Doing it here instead of _calculate_frames() to save
 	# compute power
-	var export_settings := project.export_settings
-	if export_settings.repeat_count > 0:
+	var export_profile := project.export_profile
+	if export_profile.repeat_count > 0:
 		var frames_copy := frames.duplicate()
-		for _r in export_settings.repeat_count:
+		for _r in export_profile.repeat_count:
 			frames.append_array(frames_copy)
 	# Then store the size of frames for other functions
-	export_settings.number_of_frames = frames.size()
+	export_profile.number_of_frames = frames.size()
 	# Used when the orientation is based off the animation tags
 	var tag_origins := {0: 0}
-	var frames_without_tag := export_settings.number_of_frames
+	var frames_without_tag := export_profile.number_of_frames
 	var spritesheet_columns := 1
 	var spritesheet_rows := 1
 	# If rows mode selected calculate columns count and vice versa
-	if export_settings.orientation == Orientation.COLUMNS:
+	if export_profile.orientation == Orientation.COLUMNS:
 		spritesheet_columns = frames_divided_by_spritesheet_lines()
-		spritesheet_rows = export_settings.lines_count
-	elif export_settings.orientation == Orientation.ROWS:
-		spritesheet_columns = export_settings.lines_count
+		spritesheet_rows = export_profile.lines_count
+	elif export_profile.orientation == Orientation.ROWS:
+		spritesheet_columns = export_profile.lines_count
 		spritesheet_rows = frames_divided_by_spritesheet_lines()
 	else:
 		spritesheet_rows = project.animation_tags.size() + 1
 		if spritesheet_rows == 1:
-			spritesheet_columns = export_settings.number_of_frames
+			spritesheet_columns = export_profile.number_of_frames
 		else:
 			var max_tag_size := 1
 			for tag in project.animation_tags:
@@ -258,7 +258,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 		if frames_without_tag == 0:
 			# If all frames have a tag, remove the first row
 			spritesheet_rows -= 1
-		if export_settings.orientation == Orientation.TAGS_BY_COLUMN:
+		if export_profile.orientation == Orientation.TAGS_BY_COLUMN:
 			# Switch rows and columns
 			var temp := spritesheet_rows
 			spritesheet_rows = spritesheet_columns
@@ -266,7 +266,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 	var width := project.size.x * spritesheet_columns
 	var height := project.size.y * spritesheet_rows
 	var splitter_array: Array[BaseLayer] = []
-	if export_settings.split_layers:
+	if export_profile.split_layers:
 		splitter_array = _calculate_layers_to_export(project)
 	var only_selected_cels := _export_only_selected_cels(project)
 	var sprite_sheets: Array[Image]  # Array of all apritesheets
@@ -280,7 +280,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 		var sheet_image := Image.create_empty(width, height, false, project.get_image_format())
 		var sheet_is_valid := false
 		for frame in frames:
-			if export_settings.orientation == Orientation.ROWS:
+			if export_profile.orientation == Orientation.ROWS:
 				if vv < spritesheet_columns:
 					origin.x = project.size.x * vv
 					vv += 1
@@ -289,7 +289,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.x = 0
 					vv = 1
 					origin.y = project.size.y * hh
-			elif export_settings.orientation == Orientation.COLUMNS:
+			elif export_profile.orientation == Orientation.COLUMNS:
 				if hh < spritesheet_rows:
 					origin.y = project.size.y * hh
 					hh += 1
@@ -298,7 +298,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.y = 0
 					hh = 1
 					origin.x = project.size.x * vv
-			elif export_settings.orientation == Orientation.TAGS_BY_ROW:
+			elif export_profile.orientation == Orientation.TAGS_BY_ROW:
 				var frame_index := project.frames.find(frame)
 				var frame_has_tag := false
 				for i in project.animation_tags.size():
@@ -317,7 +317,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.x = project.size.x * layer_tag_origins[0]
 					origin.y = 0
 					layer_tag_origins[0] += 1
-			elif export_settings.orientation == Orientation.TAGS_BY_COLUMN:
+			elif export_profile.orientation == Orientation.TAGS_BY_COLUMN:
 				var frame_index := project.frames.find(frame)
 				var frame_has_tag := false
 				for i in project.animation_tags.size():
@@ -336,7 +336,7 @@ func process_spritesheet(project := Global.current_project) -> void:
 					origin.y = project.size.y * layer_tag_origins[0]
 					origin.x = 0
 					layer_tag_origins[0] += 1
-			if not export_settings.split_layers:
+			if not export_profile.split_layers:
 				sheet_image.blend_rect(
 					blended_frames[frame], Rect2i(Vector2i.ZERO, project.size), origin
 				)
@@ -352,13 +352,13 @@ func process_spritesheet(project := Global.current_project) -> void:
 					sheet_is_valid = true
 		if sheet_is_valid:
 			sprite_sheets.append(sheet_image)
-			if export_settings.split_layers and split_l < splitter_array.size():
+			if export_profile.split_layers and split_l < splitter_array.size():
 				sprite_sheet_layer_indices.append(splitter_array[split_l].index)
 			else:
 				sprite_sheet_layer_indices.append(-1)
 		if splitter_array.is_empty():
 			break
-	if not export_settings.sheet_layers_as_separate_files and sprite_sheets.size() > 1:
+	if not export_profile.sheet_layers_as_separate_files and sprite_sheets.size() > 1:
 		var big_image := Image.create(
 			width, height * sprite_sheets.size(), false, project.get_image_format()
 		)
@@ -381,9 +381,9 @@ func process_animation(project := Global.current_project) -> void:
 	processed_images.clear()
 	var frames := _calculate_frames(project)
 	var only_selected_cels := _export_only_selected_cels(project)
-	var export_settings := project.export_settings
+	var export_profile := project.export_profile
 	for frame in frames:
-		if export_settings.split_layers:
+		if export_profile.split_layers:
 			for layer in _calculate_layers_to_export(project):
 				if only_selected_cels and not _is_cel_selected(project, frame, layer.index):
 					continue
@@ -397,7 +397,7 @@ func process_animation(project := Global.current_project) -> void:
 		else:
 			var image := project.new_empty_image()
 			image.copy_from(blended_frames[frame])
-			if export_settings.erase_unselected_area and project.has_selection:
+			if export_profile.erase_unselected_area and project.has_selection:
 				var crop := project.new_empty_image()
 				var selection_image := project.selection_map.return_cropped_copy(
 					project, project.size
@@ -406,7 +406,7 @@ func process_animation(project := Global.current_project) -> void:
 					image, selection_image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i.ZERO
 				)
 				image.copy_from(crop)
-			match export_settings.crop_mode:
+			match export_profile.crop_mode:
 				CropMode.CONTENT:
 					if image.get_used_rect().has_area():
 						image = image.get_region(image.get_used_rect())
@@ -423,7 +423,7 @@ func process_animation(project := Global.current_project) -> void:
 	# Add additional repeated animation (Doing it here instead of _calculate_frames() to save
 	# compute power
 	var un_repeated_size: int = processed_images.size()
-	for _r in export_settings.repeat_count:
+	for _r in export_profile.repeat_count:
 		for i in un_repeated_size:
 			processed_images.append(
 				ProcessedImage.new(
@@ -436,16 +436,16 @@ func process_animation(project := Global.current_project) -> void:
 
 
 func _calculate_frames(project := Global.current_project) -> Array[Frame]:
-	var export_settings := project.export_settings
-	var tag_index = export_settings.frame_current_tag - ExportFrames.size()
+	var export_profile := project.export_profile
+	var tag_index = export_profile.frame_current_tag - ExportFrames.size()
 	if tag_index >= project.animation_tags.size():
-		export_settings.frame_current_tag = ExportFrames.ALL_FRAMES
+		export_profile.frame_current_tag = ExportFrames.ALL_FRAMES
 	var frames: Array[Frame] = []
-	if export_settings.frame_current_tag >= ExportFrames.size():  # Export a specific tag
+	if export_profile.frame_current_tag >= ExportFrames.size():  # Export a specific tag
 		var frame_start: int = project.animation_tags[tag_index].from
 		var frame_end: int = project.animation_tags[tag_index].to
 		frames = project.frames.slice(frame_start - 1, frame_end, 1, true)
-	elif export_settings.frame_current_tag == ExportFrames.SELECTED_FRAMES:
+	elif export_profile.frame_current_tag == ExportFrames.SELECTED_FRAMES:
 		for cel in project.selected_cels:
 			var frame := project.frames[cel[0]]
 			if not frames.has(frame):
@@ -453,9 +453,9 @@ func _calculate_frames(project := Global.current_project) -> Array[Frame]:
 	else:  # All frames
 		frames = project.frames.duplicate()
 
-	if export_settings.direction == AnimationDirection.BACKWARDS:
+	if export_profile.direction == AnimationDirection.BACKWARDS:
 		frames.reverse()
-	elif export_settings.direction == AnimationDirection.PING_PONG:
+	elif export_profile.direction == AnimationDirection.PING_PONG:
 		var inverted_frames := frames.duplicate()
 		inverted_frames.reverse()
 		inverted_frames.remove_at(0)
@@ -467,19 +467,19 @@ func _calculate_frames(project := Global.current_project) -> Array[Frame]:
 
 func _calculate_layers_to_export(project := Global.current_project) -> Array[BaseLayer]:
 	var layers_to_export: Array[BaseLayer] = []
-	var export_settings := project.export_settings
+	var export_profile := project.export_profile
 	for i in project.layers.size():
 		var layer := project.layers[i]
 		if layer is GroupLayer or layer is AudioLayer:
 			continue
 		var include := false
-		match export_settings.export_layers:
+		match export_profile.export_layers:
 			VISIBLE_LAYERS:
 				include = layer.is_visible_in_hierarchy()
 			SELECTED_LAYERS:
 				include = layer.is_visible_in_hierarchy() and _is_layer_selected(project, i)
 			_:  # A specific layer was chosen from the dropdown
-				include = i == export_settings.export_layers - 2
+				include = i == export_profile.export_layers - 2
 		if include:
 			layers_to_export.append(layer)
 	return layers_to_export
@@ -496,8 +496,8 @@ func _is_layer_selected(project: Project, layer_index: int) -> bool:
 ## cels the user selected are exported, instead of every selected layer at every selected frame.
 func _export_only_selected_cels(project: Project) -> bool:
 	return (
-		project.export_settings.frame_current_tag == ExportFrames.SELECTED_FRAMES
-		and project.export_settings.export_layers == SELECTED_LAYERS
+		project.export_profile.frame_current_tag == ExportFrames.SELECTED_FRAMES
+		and project.export_profile.export_layers == SELECTED_LAYERS
 	)
 
 
@@ -509,10 +509,10 @@ func export_processed_images(
 	ignore_overwrites: bool, export_dialog: ConfirmationDialog, project := Global.current_project
 ) -> bool:
 	# Stop export if directory path or file name are not valid
-	var export_settings := project.export_settings
-	var dir_exists := DirAccess.dir_exists_absolute(export_settings.directory_path)
-	var is_valid_filename := export_settings.file_name.is_valid_filename()
-	if export_settings.directory_path.begins_with("content://"):
+	var export_profile := project.export_profile
+	var dir_exists := DirAccess.dir_exists_absolute(export_profile.directory_path)
+	var is_valid_filename := export_profile.file_name.is_valid_filename()
+	if export_profile.directory_path.begins_with("content://"):
 		dir_exists = true
 		is_valid_filename = true
 	if not dir_exists:
@@ -539,9 +539,9 @@ func export_processed_images(
 		var frame_index := i + 1
 		var layer_index := -1
 		var actual_frame_index := processed_images[i].frame_index
-		if export_settings.split_layers:
+		if export_profile.split_layers:
 			layer_index = processed_images[i].layer_index
-			if export_settings.current_tab == ExportTab.IMAGE:
+			if export_profile.current_tab == ExportTab.IMAGE:
 				if actual_frame_index != previous_split_frame:
 					split_frame_counter += 1
 					previous_split_frame = actual_frame_index
@@ -553,12 +553,12 @@ func export_processed_images(
 		# if directories exist, and create them if not
 		if (
 			multiple_files
-			and export_settings.new_dir_for_each_frame_tag
-			and not export_settings.current_tab == ExportTab.SPRITESHEET
+			and export_profile.new_dir_for_each_frame_tag
+			and not export_profile.current_tab == ExportTab.SPRITESHEET
 		):
 			var frame_tag_directory := DirAccess.open(export_path.get_base_dir())
 			if not DirAccess.dir_exists_absolute(export_path.get_base_dir()):
-				frame_tag_directory = DirAccess.open(export_settings.directory_path)
+				frame_tag_directory = DirAccess.open(export_profile.directory_path)
 				frame_tag_directory.make_dir(export_path.get_base_dir().get_file())
 
 		if not ignore_overwrites:  # Check if the files already exist
@@ -579,21 +579,21 @@ func export_processed_images(
 		if stop_export:  # User decided to stop export
 			return false
 
-	_scale_processed_images(export_settings.resize, export_settings.interpolation)
-	if export_settings.export_json:
+	_scale_processed_images(export_profile.resize, export_profile.interpolation)
+	if export_profile.export_json:
 		var json := JSON.stringify(project.serialize())
 		var json_file_name := project.name + ".json"
 		if OS.has_feature("web"):
 			var json_buffer := json.to_utf8_buffer()
 			JavaScriptBridge.download_buffer(json_buffer, json_file_name, "application/json")
 		else:
-			var json_path := export_settings.directory_path.path_join(json_file_name)
+			var json_path := export_profile.directory_path.path_join(json_file_name)
 			var json_file := FileAccess.open(json_path, FileAccess.WRITE)
 			json_file.store_string(json)
 	# override if a custom export is chosen
-	if export_settings.file_format in custom_exporter_generators.keys():
+	if export_profile.file_format in custom_exporter_generators.keys():
 		# Divert the path to the custom exporter instead
-		var custom_exporter: Object = custom_exporter_generators[export_settings.file_format][0]
+		var custom_exporter: Object = custom_exporter_generators[export_profile.file_format][0]
 		if custom_exporter.has_method("override_export"):
 			var result := true
 			var details := {
@@ -615,7 +615,7 @@ func export_processed_images(
 			return result
 
 	if is_single_file_format(project):
-		if is_using_ffmpeg(export_settings.file_format):
+		if is_using_ffmpeg(export_profile.file_format):
 			var video_exported := export_video(export_paths, project)
 			if not video_exported:
 				Global.popup_error(
@@ -624,7 +624,7 @@ func export_processed_images(
 				return false
 		else:
 			var exporter: AImgIOBaseExporter
-			if export_settings.file_format == FileFormat.APNG:
+			if export_profile.file_format == FileFormat.APNG:
 				exporter = AImgIOAPNGExporter.new()
 			else:
 				exporter = GIFAnimationExporter.new()
@@ -646,13 +646,13 @@ func export_processed_images(
 				var buffer: PackedByteArray
 				var file_name := export_paths[i].get_file()
 				var mimetype := ""
-				if export_settings.file_format == FileFormat.WEBP:
+				if export_profile.file_format == FileFormat.WEBP:
 					buffer = processed_images[i].image.save_webp_to_buffer()
 					mimetype = "image/webp"
-				elif export_settings.file_format == FileFormat.JPEG:
+				elif export_profile.file_format == FileFormat.JPEG:
 					buffer = processed_images[i].image.save_jpg_to_buffer()
 					mimetype = "image/jpeg"
-				elif export_settings.file_format == FileFormat.SVG:
+				elif export_profile.file_format == FileFormat.SVG:
 					var svg_str := image_to_svg(processed_images[i].image)
 					buffer = svg_str.to_utf8_buffer()
 					mimetype = "image/svg"
@@ -664,20 +664,20 @@ func export_processed_images(
 
 			else:
 				var err: Error
-				if export_settings.file_format == FileFormat.PNG:
+				if export_profile.file_format == FileFormat.PNG:
 					err = processed_images[i].image.save_png(export_paths[i])
-				elif export_settings.file_format == FileFormat.WEBP:
+				elif export_profile.file_format == FileFormat.WEBP:
 					err = processed_images[i].image.save_webp(export_paths[i])
-				elif export_settings.file_format == FileFormat.JPEG:
+				elif export_profile.file_format == FileFormat.JPEG:
 					err = processed_images[i].image.save_jpg(
-						export_paths[i], export_settings.save_quality
+						export_paths[i], export_profile.save_quality
 					)
-				elif export_settings.file_format == FileFormat.SVG:
+				elif export_profile.file_format == FileFormat.SVG:
 					var svg_str := image_to_svg(processed_images[i].image)
 					var svg_file := FileAccess.open(export_paths[i], FileAccess.WRITE)
 					err = FileAccess.get_open_error()
 					svg_file.store_string(svg_str)
-				elif export_settings.file_format == FileFormat.EXR:
+				elif export_profile.file_format == FileFormat.EXR:
 					err = processed_images[i].image.save_exr(export_paths[i])
 				if err != OK:
 					Global.popup_error(
@@ -688,8 +688,8 @@ func export_processed_images(
 	Global.notification_label("File(s) exported")
 	# Store settings for quick export and when the dialog is opened again
 	var file_name_with_ext := (
-		project.export_settings.file_name
-		+ file_format_string(project.export_settings.file_format)
+		project.export_profile.file_name
+		+ file_format_string(project.export_profile.file_format)
 	)
 	project.was_exported = true
 	if project.export_overwrite:
@@ -700,9 +700,9 @@ func export_processed_images(
 		Global.top_menu_container.file_menu.set_item_text(
 			Global.FileMenu.EXPORT, tr("Export") + " %s" % file_name_with_ext
 		)
-	# NOTE: export_settings.directory_path is already updated through ExportDialog.gd
+	# NOTE: export_profile.directory_path is already updated through ExportDialog.gd
 	# we only need to update the current_dir here after the export
-	Global.config_cache.set_value("data", "current_dir", export_settings.directory_path)
+	Global.config_cache.set_value("data", "current_dir", export_profile.directory_path)
 	return true
 
 
@@ -712,9 +712,9 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var video_duration := 0
 	var input_file_path := temp_path.path_join("input.txt")
 	var input_file := FileAccess.open(input_file_path, FileAccess.WRITE)
-	var export_settings := project.export_settings
+	var export_profile := project.export_profile
 	for i in range(processed_images.size()):
-		var temp_file_name := str(i + 1).pad_zeros(export_settings.number_of_digits) + ".png"
+		var temp_file_name := str(i + 1).pad_zeros(export_profile.number_of_digits) + ".png"
 		var temp_file_path := temp_path.path_join(temp_file_name)
 		processed_images[i].image.save_png(temp_file_path)
 		input_file.store_line("file '" + temp_file_name + "'")
@@ -752,7 +752,7 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var adelay_string := ""
 	for layer in project.get_all_audio_layers():
 		if layer.audio is AudioStreamMP3 or layer.audio is AudioStreamWAV:
-			var temp_file_name := str(audio_layer_count + 1).pad_zeros(export_settings.number_of_digits)
+			var temp_file_name := str(audio_layer_count + 1).pad_zeros(export_profile.number_of_digits)
 			if layer.audio is AudioStreamMP3:
 				temp_file_name += ".mp3"
 			elif layer.audio is AudioStreamWAV:
@@ -946,7 +946,7 @@ func get_file_format_from_extension(file_extension: String) -> FileFormat:
 ## True when exporting to .gif, .apng and video
 ## False when exporting to .png, .jpg and static .webp
 func is_single_file_format(project := Global.current_project) -> bool:
-	return animated_formats.has(project.export_settings.file_format)
+	return animated_formats.has(project.export_profile.file_format)
 
 
 func is_using_ffmpeg(format: FileFormat) -> bool:
@@ -965,21 +965,21 @@ func is_ffmpeg_installed() -> bool:
 func _create_export_path(
 	multifile: bool, project: Project, frame := 0, layer := -1, actual_frame_index := 0
 ) -> String:
-	var export_settings := project.export_settings
-	var path := export_settings.file_name
+	var export_profile := project.export_profile
+	var path := export_profile.file_name
 	if path.contains("{name}"):
 		path = path.replace("{name}", project.name)
 	var path_extras := ""
-	var separator_character := export_settings.separator_character
+	var separator_character := export_profile.separator_character
 	# Only append frame number when there are multiple files exported
 	if multifile:
 		if layer > -1:
 			var layer_name := project.layers[layer].name
 			path_extras += "(%s) " % layer_name
 		var counter: String = (
-			str(layer).pad_zeros(export_settings.number_of_digits)
-			if export_settings.current_tab == ExportTab.SPRITESHEET
-			else str(str(frame).pad_zeros(export_settings.number_of_digits))
+			str(layer).pad_zeros(export_profile.number_of_digits)
+			if export_profile.current_tab == ExportTab.SPRITESHEET
+			else str(str(frame).pad_zeros(export_profile.number_of_digits))
 		)
 		path_extras += separator_character + counter
 	var frame_tag_and_start_id := _get_processed_image_tag_name_and_start_id(
@@ -993,31 +993,31 @@ func _create_export_path(
 		var regex := RegEx.new()
 		regex.compile("[^a-zA-Z0-9_]+")
 		var frame_tag_dir := regex.sub(frame_tag, "", true)
-		if export_settings.include_tag_in_filename:
+		if export_profile.include_tag_in_filename:
 			# (actual_frame_index - start_id + 2) makes frames id to start from 1
 			var tag_frame_number := str(actual_frame_index - start_id + 2).pad_zeros(
-				export_settings.number_of_digits
+				export_profile.number_of_digits
 			)
 			path_extras = (
 				separator_character + frame_tag_dir + separator_character + tag_frame_number
 			)
-		if export_settings.new_dir_for_each_frame_tag:
+		if export_profile.new_dir_for_each_frame_tag:
 			path += path_extras
-			return export_settings.directory_path.path_join(frame_tag_dir).path_join(
-				path + file_format_string(export_settings.file_format, true)
+			return export_profile.directory_path.path_join(frame_tag_dir).path_join(
+				path + file_format_string(export_profile.file_format, true)
 			)
 	path += path_extras
 
 	if OS.get_name() == "Android":
 		return (
-			export_settings.directory_path
+			export_profile.directory_path
 			+ "#"
 			+ path
-			+ file_format_string(export_settings.file_format, true)
+			+ file_format_string(export_profile.file_format, true)
 		)
 
-	return export_settings.directory_path.path_join(
-		path + file_format_string(export_settings.file_format, true)
+	return export_profile.directory_path.path_join(
+		path + file_format_string(export_profile.file_format, true)
 	)
 
 
@@ -1035,10 +1035,10 @@ func _get_processed_image_tag_name_and_start_id(project: Project, processed_imag
 func _blend_layers(
 	image: Image, frame: Frame, origin := Vector2i.ZERO, project := Global.current_project
 ) -> void:
-	var export_settings := project.export_settings
-	if export_settings.export_layers - 2 >= project.layers.size():
-		export_settings.export_layers = VISIBLE_LAYERS
-	if export_settings.export_layers == VISIBLE_LAYERS:
+	var export_profile := project.export_profile
+	if export_profile.export_layers - 2 >= project.layers.size():
+		export_profile.export_layers = VISIBLE_LAYERS
+	if export_profile.export_layers == VISIBLE_LAYERS:
 		var load_result_from_pxo := not project.save_path.is_empty() and not project.has_changed
 		if load_result_from_pxo:
 			# Attempt to read the image data directly from the pxo file, without having to blend
@@ -1068,20 +1068,20 @@ func _blend_layers(
 				load_result_from_pxo = false
 		if not load_result_from_pxo:
 			DrawingAlgos.blend_layers(image, frame, origin, project)
-	elif export_settings.export_layers == SELECTED_LAYERS:
+	elif export_profile.export_layers == SELECTED_LAYERS:
 		DrawingAlgos.blend_layers(image, frame, origin, project, false, true)
 	else:
-		var layer := project.layers[export_settings.export_layers - 2]
+		var layer := project.layers[export_profile.export_layers - 2]
 		var layer_image := Image.new()
 		if layer is GroupLayer:
 			layer_image.copy_from(layer.blend_children(frame, Vector2i.ZERO))
 		else:
 			layer_image.copy_from(
-				layer.display_effects(frame.cels[export_settings.export_layers - 2])
+				layer.display_effects(frame.cels[export_profile.export_layers - 2])
 			)
 		image.blend_rect(layer_image, Rect2i(Vector2i.ZERO, project.size), origin)
 
 
 func frames_divided_by_spritesheet_lines(project := Global.current_project) -> int:
-	var export_settings := project.export_settings
-	return ceili(export_settings.number_of_frames / float(export_settings.lines_count))
+	var export_profile := project.export_profile
+	return ceili(export_profile.number_of_frames / float(export_profile.lines_count))

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -46,7 +46,6 @@ var file_format_dictionary: Dictionary[FileFormat, Array] = {
 var custom_file_formats := {}
 var custom_exporter_generators := {}
 
-
 ## All frames and their layers processed/blended into images
 var processed_images: Array[ProcessedImage] = []
 ## A dictionary that contains all of the blended frames.
@@ -94,7 +93,7 @@ class ExportProfile:
 		for key in data.keys():
 			var default = get(key)
 			var value = str_to_var(data[key])
-			if default != null and typeof(default) == typeof(value): # property exists
+			if default != null and typeof(default) == typeof(value):  # property exists
 				set(key, value)
 
 	func serialize():
@@ -102,26 +101,27 @@ class ExportProfile:
 			"directory_path": var_to_str(directory_path),
 			"file_name": var_to_str(file_name),
 			"file_format": var_to_str(file_format),
-			"current_tab" : var_to_str(current_tab),
-			"export_json" : var_to_str(export_json),
-			"split_layers" : var_to_str(split_layers),
-			"sheet_layers_as_separate_files" : var_to_str(sheet_layers_as_separate_files),
-			"crop_mode" : var_to_str(crop_mode),
-			"erase_unselected_area" : var_to_str(erase_unselected_area),
-			"orientation" : var_to_str(orientation),
-			"lines_count" : var_to_str(lines_count),
-			"frame_current_tag" : var_to_str(frame_current_tag),
-			"export_layers" : var_to_str(export_layers),
-			"number_of_frames" : var_to_str(number_of_frames),
-			"direction" : var_to_str(direction),
-			"repeat_count" : var_to_str(repeat_count),
-			"resize" : var_to_str(resize),
-			"save_quality" : var_to_str(save_quality),
-			"interpolation" : var_to_str(interpolation),
-			"include_tag_in_filename" : var_to_str(include_tag_in_filename),
-			"new_dir_for_each_frame_tag" : var_to_str(new_dir_for_each_frame_tag),
-			"number_of_digits" : var_to_str(number_of_digits),
-			"separator_character" : var_to_str(separator_character)
+			"current_tab": var_to_str(current_tab),
+			"export_json": var_to_str(export_json),
+			"split_layers": var_to_str(split_layers),
+			"sheet_layers_as_separate_files": var_to_str(sheet_layers_as_separate_files),
+			"crop_mode": var_to_str(crop_mode),
+			"erase_unselected_area": var_to_str(erase_unselected_area),
+			"orientation": var_to_str(orientation),
+			"lines_count": var_to_str(lines_count),
+			"frame_current_tag": var_to_str(frame_current_tag),
+			"export_layers": var_to_str(export_layers),
+			"number_of_frames": var_to_str(number_of_frames),
+			"direction": var_to_str(direction),
+			"repeat_count": var_to_str(repeat_count),
+			"resize": var_to_str(resize),
+			"save_quality": var_to_str(save_quality),
+			"interpolation": var_to_str(interpolation),
+			"include_tag_in_filename": var_to_str(include_tag_in_filename),
+			"new_dir_for_each_frame_tag": var_to_str(new_dir_for_each_frame_tag),
+			"number_of_digits": var_to_str(number_of_digits),
+			"separator_character": var_to_str(separator_character)
+
 		}
 
 
@@ -687,8 +687,7 @@ func export_processed_images(
 	Global.notification_label("File(s) exported")
 	# Store settings for quick export and when the dialog is opened again
 	var file_name_with_ext := (
-		project.export_profile.file_name
-		+ file_format_string(project.export_profile.file_format)
+		project.export_profile.file_name + file_format_string(project.export_profile.file_format)
 	)
 	project.was_exported = true
 	if project.export_overwrite:
@@ -751,7 +750,9 @@ func export_video(export_paths: PackedStringArray, project: Project) -> bool:
 	var adelay_string := ""
 	for layer in project.get_all_audio_layers():
 		if layer.audio is AudioStreamMP3 or layer.audio is AudioStreamWAV:
-			var temp_file_name := str(audio_layer_count + 1).pad_zeros(export_profile.number_of_digits)
+			var temp_file_name := str(audio_layer_count + 1).pad_zeros(
+				export_profile.number_of_digits
+			)
 			if layer.audio is AudioStreamMP3:
 				temp_file_name += ".mp3"
 			elif layer.audio is AudioStreamWAV:
@@ -892,7 +893,9 @@ func _increase_export_progress(export_dialog: Node) -> void:
 	export_dialog.set_export_progress_bar(export_progress)
 
 
-func _scale_processed_images(resize_amount: int, interpolation := Image.INTERPOLATE_NEAREST) -> void:
+func _scale_processed_images(
+	resize_amount: int, interpolation := Image.INTERPOLATE_NEAREST
+) -> void:
 	var resize_f := resize_amount / 100.0
 	for processed_image in processed_images:
 		if is_equal_approx(resize_amount, 1.0):

--- a/src/Autoload/Export.gd
+++ b/src/Autoload/Export.gd
@@ -95,7 +95,6 @@ class ExportProfile:
 			var default = get(key)
 			var value = str_to_var(data[key])
 			if default != null and typeof(default) == typeof(value): # property exists
-				prints(key, value)
 				set(key, value)
 
 	func serialize():

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -385,8 +385,8 @@ func open_pxo_file(path: String, is_backup := false, replace_empty := true) -> v
 				if cel is CelTileMap:
 					cel.find_times_used_of_tiles()
 		zip_reader.close()
-	if new_project.export_directory_path.is_empty():
-		new_project.export_directory_path = path.get_base_dir()
+	if new_project.export_settings.directory_path.is_empty():
+		new_project.export_settings.directory_path = path.get_base_dir()
 
 	if empty_project:
 		Global.project_switched.emit()
@@ -647,8 +647,8 @@ func save_pxo_file(
 		Global.config_cache.set_value("data", "current_dir", path.get_base_dir())
 		Global.config_cache.set_value("data", "last_project_path", path)
 		Global.config_cache.save(Global.CONFIG_PATH)
-		if project.export_directory_path.is_empty():
-			project.export_directory_path = path.get_base_dir()
+		if project.export_settings.directory_path.is_empty():
+			project.export_settings.directory_path = path.get_base_dir()
 		Global.top_menu_container.file_menu.set_item_text(
 			Global.FileMenu.SAVE, tr("Save") + " %s" % path.uri_decode().get_file()
 		)
@@ -1077,8 +1077,8 @@ func set_new_imported_tab(project: Project, path: String) -> void:
 	)
 	if project.has_changed:
 		get_window().title = get_window().title + "(*)"
-	project.export_directory_path = path.get_base_dir()
-	project.file_name = file_name.get_basename()
+	project.export_settings.directory_path = path.get_base_dir()
+	project.export_settings.file_name = file_name.get_basename()
 	project.was_exported = true
 	if path.get_extension().to_lower() == "png":
 		project.export_overwrite = true
@@ -1159,7 +1159,7 @@ func open_gif_file(path: String) -> bool:
 		var frame := Frame.new([cel], delay)
 		new_project.frames.append(frame)
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.file_name = new_project.name
+	new_project.export_settings.file_name = new_project.name
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 	return true
@@ -1274,7 +1274,7 @@ func open_ora_file(path: String) -> void:
 	new_project.selected_cels.clear()
 	new_project.change_cel(0, new_project.layers.find(selected_layer))
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.file_name = new_project.name
+	new_project.export_settings.file_name = new_project.name
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 
@@ -1290,7 +1290,7 @@ func open_piskel_file(path: String) -> void:
 	new_project.size = Vector2i(piskel.width, piskel.height)
 	new_project.fps = piskel.fps
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.file_name = new_project.name
+	new_project.export_settings.file_name = new_project.name
 	var n_of_frames := 0
 	for i in piskel.layers.size():
 		var piskel_layer_str = piskel.layers[i]
@@ -1352,7 +1352,7 @@ func update_autosave() -> void:
 func _on_Autosave_timeout() -> void:
 	for i in Global.projects.size():
 		var project := Global.projects[i]
-		var p_name: String = project.file_name
+		var p_name: String = project.export_settings.file_name
 		if project.backup_path.is_empty():
 			project.backup_path = (current_session_backup.path_join(
 				"(" + p_name + " backup)-" + str(Time.get_unix_time_from_system()) + "-%s" % i

--- a/src/Autoload/OpenSave.gd
+++ b/src/Autoload/OpenSave.gd
@@ -385,8 +385,8 @@ func open_pxo_file(path: String, is_backup := false, replace_empty := true) -> v
 				if cel is CelTileMap:
 					cel.find_times_used_of_tiles()
 		zip_reader.close()
-	if new_project.export_settings.directory_path.is_empty():
-		new_project.export_settings.directory_path = path.get_base_dir()
+	if new_project.export_profile.directory_path.is_empty():
+		new_project.export_profile.directory_path = path.get_base_dir()
 
 	if empty_project:
 		Global.project_switched.emit()
@@ -647,8 +647,8 @@ func save_pxo_file(
 		Global.config_cache.set_value("data", "current_dir", path.get_base_dir())
 		Global.config_cache.set_value("data", "last_project_path", path)
 		Global.config_cache.save(Global.CONFIG_PATH)
-		if project.export_settings.directory_path.is_empty():
-			project.export_settings.directory_path = path.get_base_dir()
+		if project.export_profile.directory_path.is_empty():
+			project.export_profile.directory_path = path.get_base_dir()
 		Global.top_menu_container.file_menu.set_item_text(
 			Global.FileMenu.SAVE, tr("Save") + " %s" % path.uri_decode().get_file()
 		)
@@ -1077,8 +1077,8 @@ func set_new_imported_tab(project: Project, path: String) -> void:
 	)
 	if project.has_changed:
 		get_window().title = get_window().title + "(*)"
-	project.export_settings.directory_path = path.get_base_dir()
-	project.export_settings.file_name = file_name.get_basename()
+	project.export_profile.directory_path = path.get_base_dir()
+	project.export_profile.file_name = file_name.get_basename()
 	project.was_exported = true
 	if path.get_extension().to_lower() == "png":
 		project.export_overwrite = true
@@ -1159,7 +1159,7 @@ func open_gif_file(path: String) -> bool:
 		var frame := Frame.new([cel], delay)
 		new_project.frames.append(frame)
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.export_settings.file_name = new_project.name
+	new_project.export_profile.file_name = new_project.name
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 	return true
@@ -1274,7 +1274,7 @@ func open_ora_file(path: String) -> void:
 	new_project.selected_cels.clear()
 	new_project.change_cel(0, new_project.layers.find(selected_layer))
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.export_settings.file_name = new_project.name
+	new_project.export_profile.file_name = new_project.name
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 
@@ -1290,7 +1290,7 @@ func open_piskel_file(path: String) -> void:
 	new_project.size = Vector2i(piskel.width, piskel.height)
 	new_project.fps = piskel.fps
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.export_settings.file_name = new_project.name
+	new_project.export_profile.file_name = new_project.name
 	var n_of_frames := 0
 	for i in piskel.layers.size():
 		var piskel_layer_str = piskel.layers[i]
@@ -1352,7 +1352,7 @@ func update_autosave() -> void:
 func _on_Autosave_timeout() -> void:
 	for i in Global.projects.size():
 		var project := Global.projects[i]
-		var p_name: String = project.export_settings.file_name
+		var p_name: String = project.export_profile.file_name
 		if project.backup_path.is_empty():
 			project.backup_path = (current_session_backup.path_join(
 				"(" + p_name + " backup)-" + str(Time.get_unix_time_from_system()) + "-%s" % i

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -553,7 +553,7 @@ func deserialize(dict: Dictionary, zip_reader: ZIPReader = null, file: FileAcces
 	if typeof(exp_settings) == TYPE_DICTIONARY:
 		export_profile.deserialize(exp_settings)
 	if not DirAccess.dir_exists_absolute(export_profile.directory_path):
-			export_profile.directory_path = ""
+		export_profile.directory_path = ""
 	if export_profile.file_name.is_empty() or export_profile.file_name == "untitled":
 		export_profile.file_name = name
 	fps = dict.get("fps", fps)

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -114,7 +114,7 @@ var cameras_zoom: PackedVector2Array = [
 ]
 var cameras_offset: PackedVector2Array = [Vector2.ZERO, Vector2.ZERO, Vector2.ZERO]
 
-var save_path := "" ## Path the pxo gets saved to (or is loaded from)
+var save_path := ""  ## Path the pxo gets saved to (or is loaded from)
 var was_exported := false
 var export_overwrite := false
 var backup_path := ""

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -25,7 +25,7 @@ var name := "":
 		var project_index := Global.projects.find(self)
 		if project_index < Global.tabs.tab_count and project_index > -1:
 			Global.tabs.set_tab_title(project_index, name)
-		export_settings.file_name = name
+		export_profile.file_name = name
 var size: Vector2i:
 	set = _size_changed
 var undo_redo := UndoRedo.new()
@@ -118,7 +118,7 @@ var save_path := "" ## Path the pxo gets saved to (or is loaded from)
 var was_exported := false
 var export_overwrite := false
 var backup_path := ""
-var export_settings := Export.ExportStruct.new()
+var export_profile := Export.ExportProfile.new()
 
 
 func _init(_frames: Array[Frame] = [], _name := tr("untitled"), _size := Vector2i(64, 64)) -> void:
@@ -161,9 +161,9 @@ func _init(_frames: Array[Frame] = [], _name := tr("untitled"), _size := Vector2
 	Global.canvas.add_child(diagonal_x_minus_y_symmetry_axis)
 
 	if OS.get_name() == "Web":
-		export_settings.directory_path = "user://"
+		export_profile.directory_path = "user://"
 	else:
-		export_settings.directory_path = Global.config_cache.get_value(
+		export_profile.directory_path = Global.config_cache.get_value(
 			"data", "current_dir", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP)
 		)
 	initialize_attribution_data()
@@ -343,7 +343,7 @@ func serialize() -> Dictionary:
 		"author_contact": author_contact,
 		"author_company": author_company,
 		"metadata": metadata,
-		"export_settings": export_settings.serialize()
+		"export_profile": export_profile.serialize()
 	}
 
 	serialized.emit(project_data)
@@ -549,13 +549,13 @@ func deserialize(dict: Dictionary, zip_reader: ZIPReader = null, file: FileAcces
 			var new_pos := y_symmetry_axis.points[point]
 			new_pos.x = floorf(x_symmetry_point / 2 + 1)
 			y_symmetry_axis.set_point_position(point, new_pos)
-	var exp_settings = dict.get("export_settings", {})
+	var exp_settings = dict.get("export_profile", {})
 	if typeof(exp_settings) == TYPE_DICTIONARY:
-		export_settings.deserialize(exp_settings)
-	if not DirAccess.dir_exists_absolute(export_settings.directory_path):
-			export_settings.directory_path = ""
-	if export_settings.file_name.is_empty() or export_settings.file_name == "untitled":
-		export_settings.file_name = name
+		export_profile.deserialize(exp_settings)
+	if not DirAccess.dir_exists_absolute(export_profile.directory_path):
+			export_profile.directory_path = ""
+	if export_profile.file_name.is_empty() or export_profile.file_name == "untitled":
+		export_profile.file_name = name
 	fps = dict.get("fps", fps)
 	license = dict.get("license", license)
 	author_display_name = dict.get("author_display_name", "")

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -122,6 +122,7 @@ var file_format := Export.FileFormat.PNG
 var was_exported := false
 var export_overwrite := false
 var backup_path := ""
+var export_settings := Export.ExportStruct.new()
 
 
 func _init(_frames: Array[Frame] = [], _name := tr("untitled"), _size := Vector2i(64, 64)) -> void:
@@ -348,7 +349,8 @@ func serialize() -> Dictionary:
 		"author_real_name": author_real_name,
 		"author_contact": author_contact,
 		"author_company": author_company,
-		"metadata": metadata
+		"metadata": metadata,
+		"export_settings": export_settings.serialize()
 	}
 
 	serialized.emit(project_data)
@@ -554,6 +556,9 @@ func deserialize(dict: Dictionary, zip_reader: ZIPReader = null, file: FileAcces
 			var new_pos := y_symmetry_axis.points[point]
 			new_pos.x = floorf(x_symmetry_point / 2 + 1)
 			y_symmetry_axis.set_point_position(point, new_pos)
+	var exp_settings = dict.get("export_settings", {})
+	if typeof(exp_settings) == TYPE_DICTIONARY:
+		export_settings.deserialize(exp_settings)
 	export_directory_path = dict.get("export_directory_path", export_directory_path)
 	if not DirAccess.dir_exists_absolute(export_directory_path):
 		export_directory_path = ""

--- a/src/Classes/Project.gd
+++ b/src/Classes/Project.gd
@@ -25,7 +25,7 @@ var name := "":
 		var project_index := Global.projects.find(self)
 		if project_index < Global.tabs.tab_count and project_index > -1:
 			Global.tabs.set_tab_title(project_index, name)
-		file_name = name
+		export_settings.file_name = name
 var size: Vector2i:
 	set = _size_changed
 var undo_redo := UndoRedo.new()
@@ -114,11 +114,7 @@ var cameras_zoom: PackedVector2Array = [
 ]
 var cameras_offset: PackedVector2Array = [Vector2.ZERO, Vector2.ZERO, Vector2.ZERO]
 
-# Export directory path and export file name
-var save_path := ""
-var export_directory_path := ""
-var file_name := "untitled"
-var file_format := Export.FileFormat.PNG
+var save_path := "" ## Path the pxo gets saved to (or is loaded from)
 var was_exported := false
 var export_overwrite := false
 var backup_path := ""
@@ -165,9 +161,9 @@ func _init(_frames: Array[Frame] = [], _name := tr("untitled"), _size := Vector2
 	Global.canvas.add_child(diagonal_x_minus_y_symmetry_axis)
 
 	if OS.get_name() == "Web":
-		export_directory_path = "user://"
+		export_settings.directory_path = "user://"
 	else:
-		export_directory_path = Global.config_cache.get_value(
+		export_settings.directory_path = Global.config_cache.get_value(
 			"data", "current_dir", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP)
 		)
 	initialize_attribution_data()
@@ -339,9 +335,6 @@ func serialize() -> Dictionary:
 		"reference_images": reference_image_data,
 		"tilesets": tileset_data,
 		"vanishing_points": vanishing_points,
-		"export_directory_path": export_directory_path,
-		"export_file_name": file_name,
-		"export_file_format": file_format,
 		"fps": fps,
 		"license": license,
 		"user_data": user_data,
@@ -559,13 +552,10 @@ func deserialize(dict: Dictionary, zip_reader: ZIPReader = null, file: FileAcces
 	var exp_settings = dict.get("export_settings", {})
 	if typeof(exp_settings) == TYPE_DICTIONARY:
 		export_settings.deserialize(exp_settings)
-	export_directory_path = dict.get("export_directory_path", export_directory_path)
-	if not DirAccess.dir_exists_absolute(export_directory_path):
-		export_directory_path = ""
-	file_name = dict.get("export_file_name", file_name)
-	if file_name.is_empty() or file_name == "untitled":
-		file_name = name
-	file_format = dict.get("export_file_format", file_format)
+	if not DirAccess.dir_exists_absolute(export_settings.directory_path):
+			export_settings.directory_path = ""
+	if export_settings.file_name.is_empty() or export_settings.file_name == "untitled":
+		export_settings.file_name = name
 	fps = dict.get("fps", fps)
 	license = dict.get("license", license)
 	author_display_name = dict.get("author_display_name", "")

--- a/src/Classes/SoftwareParsers/AsepriteParser.gd
+++ b/src/Classes/SoftwareParsers/AsepriteParser.gd
@@ -452,7 +452,7 @@ static func open_aseprite_file(path: String) -> void:
 	organize_layer_child_levels(new_project)
 	new_project.order_layers()
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.file_name = new_project.name
+	new_project.export_settings.file_name = new_project.name
 	new_project.palettes = palettes
 	new_project.project_current_palette_name = project_current_palette_name
 	Global.projects.append(new_project)

--- a/src/Classes/SoftwareParsers/AsepriteParser.gd
+++ b/src/Classes/SoftwareParsers/AsepriteParser.gd
@@ -452,7 +452,7 @@ static func open_aseprite_file(path: String) -> void:
 	organize_layer_child_levels(new_project)
 	new_project.order_layers()
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.export_settings.file_name = new_project.name
+	new_project.export_profile.file_name = new_project.name
 	new_project.palettes = palettes
 	new_project.project_current_palette_name = project_current_palette_name
 	Global.projects.append(new_project)

--- a/src/Classes/SoftwareParsers/KritaParser.gd
+++ b/src/Classes/SoftwareParsers/KritaParser.gd
@@ -243,7 +243,7 @@ static func open_kra_file(path: String) -> void:
 	new_project.order_layers()
 	new_project.selected_cels.clear()
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.file_name = new_project.name
+	new_project.export_settings.file_name = new_project.name
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 	new_project.change_cel(0, new_project.layers.find(selected_layer))

--- a/src/Classes/SoftwareParsers/KritaParser.gd
+++ b/src/Classes/SoftwareParsers/KritaParser.gd
@@ -243,7 +243,7 @@ static func open_kra_file(path: String) -> void:
 	new_project.order_layers()
 	new_project.selected_cels.clear()
 	new_project.save_path = path.get_basename() + ".pxo"
-	new_project.export_settings.file_name = new_project.name
+	new_project.export_profile.file_name = new_project.name
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 	new_project.change_cel(0, new_project.layers.find(selected_layer))

--- a/src/Classes/SoftwareParsers/PhotoshopParser.gd
+++ b/src/Classes/SoftwareParsers/PhotoshopParser.gd
@@ -463,7 +463,7 @@ static func psd_to_pxo_project(psd_project: PhotoshopProject, add_frames := true
 		Global.canvas.add_child(guide)
 
 	new_project.save_path = psd_project.path.get_basename() + ".pxo"
-	new_project.export_settings.file_name = new_project.name
+	new_project.export_profile.file_name = new_project.name
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 

--- a/src/Classes/SoftwareParsers/PhotoshopParser.gd
+++ b/src/Classes/SoftwareParsers/PhotoshopParser.gd
@@ -463,7 +463,7 @@ static func psd_to_pxo_project(psd_project: PhotoshopProject, add_frames := true
 		Global.canvas.add_child(guide)
 
 	new_project.save_path = psd_project.path.get_basename() + ".pxo"
-	new_project.file_name = new_project.name
+	new_project.export_settings.file_name = new_project.name
 	Global.projects.append(new_project)
 	Global.tabs.current_tab = Global.tabs.get_tab_count() - 1
 

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -121,8 +121,8 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 	static func enable_export(_project: Project, _next_arg: String):
 		return true
 
-	static func enable_spritesheet(_project: Project, _next_arg: String):
-		Export.current_tab = Export.ExportTab.SPRITESHEET
+	static func enable_spritesheet(project: Project, _next_arg: String):
+		project.export_settings.current_tab = Export.ExportTab.SPRITESHEET
 		return true
 
 	static func set_output(project: Project, next_arg: String) -> void:
@@ -134,13 +134,14 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 			var extension := next_arg.get_extension()
 			project.file_format = Export.get_file_format_from_extension(extension)
 
-	static func set_export_scale(_project: Project, next_arg: String) -> void:
+	static func set_export_scale(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
 			if next_arg.is_valid_float():
-				Export.resize = next_arg.to_float() * 100
+				project.export_settings.resize = next_arg.to_float() * 100
 
 	static func set_frames(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
+			var export_setting := project.export_settings
 			if next_arg.contains("-"):
 				var frame_numbers := next_arg.split("-")
 				if frame_numbers.size() > 1:
@@ -156,36 +157,37 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 					for frame in range(frame_number_1, frame_number_2 + 1):
 						project.selected_cels.append([frame, project.current_layer])
 						project.change_cel(frame)
-						Export.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
+						export_setting.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
 			elif next_arg.is_valid_int():
 				var frame_number := next_arg.to_int() - 1
 				frame_number = clampi(frame_number, 0, project.frames.size() - 1)
 				project.selected_cels = [[frame_number, project.current_layer]]
 				project.change_cel(frame_number)
-				Export.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
+				export_setting.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
 
-	static func set_direction(_project: Project, next_arg: String) -> void:
+	static func set_direction(project: Project, next_arg: String) -> void:
+		var export_setting := project.export_settings
 		if not next_arg.is_empty():
 			next_arg = next_arg.to_lower()
 			if next_arg == "0" or next_arg.contains("forward"):
-				Export.direction = Export.AnimationDirection.FORWARD
+				export_setting.direction = Export.AnimationDirection.FORWARD
 			elif next_arg == "1" or next_arg.contains("backward"):
-				Export.direction = Export.AnimationDirection.BACKWARDS
+				export_setting.direction = Export.AnimationDirection.BACKWARDS
 			elif next_arg == "2" or next_arg.contains("ping"):
-				Export.direction = Export.AnimationDirection.PING_PONG
+				export_setting.direction = Export.AnimationDirection.PING_PONG
 			else:
-				print(Export.AnimationDirection.keys()[Export.direction])
+				print(Export.AnimationDirection.keys()[export_setting.direction])
 		else:
-			print(Export.AnimationDirection.keys()[Export.direction])
+			print(Export.AnimationDirection.keys()[export_setting.direction])
 
-	static func set_json(_project: Project, _next_arg: String) -> void:
-		Export.export_json = true
+	static func set_json(project: Project, _next_arg: String) -> void:
+		project.export_settings.export_json = true
 
-	static func set_split_layers(_project: Project, _next_arg: String) -> void:
-		Export.split_layers = true
+	static func set_split_layers(project: Project, _next_arg: String) -> void:
+		project.export_settings.split_layers = true
 
-	static func set_sheet_layers_as_separate_files(_project: Project, _next_arg: String) -> void:
-		Export.sheet_layers_as_separate_files = true
+	static func set_sheet_layers_as_separate_files(project: Project, _next_arg: String) -> void:
+		project.export_settings.sheet_layers_as_separate_files = true
 
 	static func dummy(_project: Project, _next_arg: String) -> void:
 		pass

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -130,9 +130,9 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 			project.file_name = next_arg.get_file().get_basename()
 			var directory_path = next_arg.get_base_dir()
 			if directory_path != ".":
-				project.export_directory_path = directory_path
+				project.export_settings.directory_path = directory_path
 			var extension := next_arg.get_extension()
-			project.file_format = Export.get_file_format_from_extension(extension)
+			project.export_settings.file_format = Export.get_file_format_from_extension(extension)
 
 	static func set_export_scale(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
@@ -141,7 +141,7 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 
 	static func set_frames(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
-			var export_setting := project.export_settings
+			var export_settings := project.export_settings
 			if next_arg.contains("-"):
 				var frame_numbers := next_arg.split("-")
 				if frame_numbers.size() > 1:
@@ -157,28 +157,28 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 					for frame in range(frame_number_1, frame_number_2 + 1):
 						project.selected_cels.append([frame, project.current_layer])
 						project.change_cel(frame)
-						export_setting.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
+						export_settings.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
 			elif next_arg.is_valid_int():
 				var frame_number := next_arg.to_int() - 1
 				frame_number = clampi(frame_number, 0, project.frames.size() - 1)
 				project.selected_cels = [[frame_number, project.current_layer]]
 				project.change_cel(frame_number)
-				export_setting.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
+				export_settings.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
 
 	static func set_direction(project: Project, next_arg: String) -> void:
-		var export_setting := project.export_settings
+		var export_settings := project.export_settings
 		if not next_arg.is_empty():
 			next_arg = next_arg.to_lower()
 			if next_arg == "0" or next_arg.contains("forward"):
-				export_setting.direction = Export.AnimationDirection.FORWARD
+				export_settings.direction = Export.AnimationDirection.FORWARD
 			elif next_arg == "1" or next_arg.contains("backward"):
-				export_setting.direction = Export.AnimationDirection.BACKWARDS
+				export_settings.direction = Export.AnimationDirection.BACKWARDS
 			elif next_arg == "2" or next_arg.contains("ping"):
-				export_setting.direction = Export.AnimationDirection.PING_PONG
+				export_settings.direction = Export.AnimationDirection.PING_PONG
 			else:
-				print(Export.AnimationDirection.keys()[export_setting.direction])
+				print(Export.AnimationDirection.keys()[export_settings.direction])
 		else:
-			print(Export.AnimationDirection.keys()[export_setting.direction])
+			print(Export.AnimationDirection.keys()[export_settings.direction])
 
 	static func set_json(project: Project, _next_arg: String) -> void:
 		project.export_settings.export_json = true
@@ -264,9 +264,9 @@ func _input(event: InputEvent) -> void:
 
 
 func _project_switched() -> void:
-	if Global.current_project.export_directory_path != "":
-		open_sprite_dialog.current_dir = Global.current_project.export_directory_path
-		save_sprite_dialog.current_dir = Global.current_project.export_directory_path
+	if Global.current_project.export_settings.directory_path != "":
+		open_sprite_dialog.current_dir = Global.current_project.export_settings.directory_path
+		save_sprite_dialog.current_dir = Global.current_project.export_settings.directory_path
 
 
 # Taken from

--- a/src/Main.gd
+++ b/src/Main.gd
@@ -122,7 +122,7 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 		return true
 
 	static func enable_spritesheet(project: Project, _next_arg: String):
-		project.export_settings.current_tab = Export.ExportTab.SPRITESHEET
+		project.export_profile.current_tab = Export.ExportTab.SPRITESHEET
 		return true
 
 	static func set_output(project: Project, next_arg: String) -> void:
@@ -130,18 +130,18 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 			project.file_name = next_arg.get_file().get_basename()
 			var directory_path = next_arg.get_base_dir()
 			if directory_path != ".":
-				project.export_settings.directory_path = directory_path
+				project.export_profile.directory_path = directory_path
 			var extension := next_arg.get_extension()
-			project.export_settings.file_format = Export.get_file_format_from_extension(extension)
+			project.export_profile.file_format = Export.get_file_format_from_extension(extension)
 
 	static func set_export_scale(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
 			if next_arg.is_valid_float():
-				project.export_settings.resize = next_arg.to_float() * 100
+				project.export_profile.resize = next_arg.to_float() * 100
 
 	static func set_frames(project: Project, next_arg: String) -> void:
 		if not next_arg.is_empty():
-			var export_settings := project.export_settings
+			var export_profile := project.export_profile
 			if next_arg.contains("-"):
 				var frame_numbers := next_arg.split("-")
 				if frame_numbers.size() > 1:
@@ -157,37 +157,37 @@ some useful [b][SYSTEM OPTIONS][/b] are:
 					for frame in range(frame_number_1, frame_number_2 + 1):
 						project.selected_cels.append([frame, project.current_layer])
 						project.change_cel(frame)
-						export_settings.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
+						export_profile.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
 			elif next_arg.is_valid_int():
 				var frame_number := next_arg.to_int() - 1
 				frame_number = clampi(frame_number, 0, project.frames.size() - 1)
 				project.selected_cels = [[frame_number, project.current_layer]]
 				project.change_cel(frame_number)
-				export_settings.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
+				export_profile.frame_current_tag = Export.ExportFrames.SELECTED_FRAMES
 
 	static func set_direction(project: Project, next_arg: String) -> void:
-		var export_settings := project.export_settings
+		var export_profile := project.export_profile
 		if not next_arg.is_empty():
 			next_arg = next_arg.to_lower()
 			if next_arg == "0" or next_arg.contains("forward"):
-				export_settings.direction = Export.AnimationDirection.FORWARD
+				export_profile.direction = Export.AnimationDirection.FORWARD
 			elif next_arg == "1" or next_arg.contains("backward"):
-				export_settings.direction = Export.AnimationDirection.BACKWARDS
+				export_profile.direction = Export.AnimationDirection.BACKWARDS
 			elif next_arg == "2" or next_arg.contains("ping"):
-				export_settings.direction = Export.AnimationDirection.PING_PONG
+				export_profile.direction = Export.AnimationDirection.PING_PONG
 			else:
-				print(Export.AnimationDirection.keys()[export_settings.direction])
+				print(Export.AnimationDirection.keys()[export_profile.direction])
 		else:
-			print(Export.AnimationDirection.keys()[export_settings.direction])
+			print(Export.AnimationDirection.keys()[export_profile.direction])
 
 	static func set_json(project: Project, _next_arg: String) -> void:
-		project.export_settings.export_json = true
+		project.export_profile.export_json = true
 
 	static func set_split_layers(project: Project, _next_arg: String) -> void:
-		project.export_settings.split_layers = true
+		project.export_profile.split_layers = true
 
 	static func set_sheet_layers_as_separate_files(project: Project, _next_arg: String) -> void:
-		project.export_settings.sheet_layers_as_separate_files = true
+		project.export_profile.sheet_layers_as_separate_files = true
 
 	static func dummy(_project: Project, _next_arg: String) -> void:
 		pass
@@ -264,9 +264,9 @@ func _input(event: InputEvent) -> void:
 
 
 func _project_switched() -> void:
-	if Global.current_project.export_settings.directory_path != "":
-		open_sprite_dialog.current_dir = Global.current_project.export_settings.directory_path
-		save_sprite_dialog.current_dir = Global.current_project.export_settings.directory_path
+	if Global.current_project.export_profile.directory_path != "":
+		open_sprite_dialog.current_dir = Global.current_project.export_profile.directory_path
+		save_sprite_dialog.current_dir = Global.current_project.export_profile.directory_path
 
 
 # Taken from

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -90,10 +90,11 @@ func show_tab() -> void:
 	get_tree().call_group("ExportSpritesheetOptions", "hide")
 	set_file_format_selector()
 	create_frame_tag_list()
-	frames_option_button.select(Export.frame_current_tag)
+	var export_setting := Global.current_project.export_settings
+	frames_option_button.select(export_setting.frame_current_tag)
 	create_layer_list()
-	layers_option_button.select(Export.export_layers)
-	match Export.current_tab:
+	layers_option_button.select(export_setting.export_layers)
+	match export_setting.current_tab:
 		Export.ExportTab.IMAGE:
 			Export.process_animation()
 			get_tree().call_group("ExportImageOptions", "show")
@@ -106,15 +107,15 @@ func show_tab() -> void:
 		Export.ExportTab.SPRITESHEET:
 			frame_timer.stop()
 			Export.process_spritesheet()
-			spritesheet_orientation.selected = Export.orientation
-			spritesheet_lines_count.max_value = Export.number_of_frames
-			spritesheet_lines_count.value = Export.lines_count
-			spritesheet_layers_as_separate_files.disabled = !Export.split_layers
+			spritesheet_orientation.selected = export_setting.orientation
+			spritesheet_lines_count.max_value = export_setting.number_of_frames
+			spritesheet_lines_count.value = export_setting.lines_count
+			spritesheet_layers_as_separate_files.disabled = !export_setting.split_layers
 			get_tree().call_group("ExportSpritesheetOptions", "show")
 			_handle_orientation_ui()
 	set_preview()
 	update_dimensions_label()
-	tabs.current_tab = Export.current_tab
+	tabs.current_tab = export_setting.current_tab
 	if OS.get_name() == "Web":
 		get_tree().call_group("NotHTML5", "hide")
 	elif OS.get_name() == "Android":
@@ -138,12 +139,13 @@ func _set_project_export_settings(
 
 
 func set_preview() -> void:
+	var export_setting := Global.current_project.export_settings
 	_preview_images = Export.processed_images
 	if _preview_images.is_empty():
 		return
 	var preview_data := {
 		"exporter_id": Global.current_project.file_format,
-		"export_tab": Export.current_tab,
+		"export_tab": export_setting.current_tab,
 		"preview_images": _preview_images,
 	}
 	about_to_preview.emit(preview_data)
@@ -220,7 +222,7 @@ func remove_previews() -> void:
 
 
 func set_file_format_selector() -> void:
-	match Export.current_tab:
+	match Global.current_project.export_settings.current_tab:
 		Export.ExportTab.IMAGE:
 			_set_file_format_selector_suitable_file_formats(image_exports)
 		Export.ExportTab.SPRITESHEET:
@@ -293,7 +295,8 @@ func create_layer_list() -> void:
 
 func update_dimensions_label() -> void:
 	if _preview_images.size() > 0:
-		var new_size: Vector2i = _preview_images[0].image.get_size() * (Export.resize / 100.0)
+		var export_setting := Global.current_project.export_settings
+		var new_size: Vector2i = _preview_images[0].image.get_size() * (export_setting.resize / 100.0)
 		dimension_label.text = str(new_size.x, "×", new_size.y)
 
 
@@ -343,8 +346,9 @@ func _on_about_to_popup() -> void:
 		_set_project_export_settings(default_directory_path, project.file_name, project.file_format)
 
 	# If export already occurred - sets GUI to show previous settings
-	options_resize.value = Export.resize
-	options_interpolation.selected = Export.interpolation
+	var export_setting := project.export_settings
+	options_resize.value = export_setting.resize
+	options_interpolation.selected = export_setting.interpolation
 	directory_path_label.text = project.export_directory_path
 	var file_ext := Export.file_format_string(project.file_format)
 	if OS.get_name() == "Web" or OS.get_name() == "Android":
@@ -361,12 +365,12 @@ func _on_about_to_popup() -> void:
 
 
 func _on_tab_bar_tab_changed(tab: Export.ExportTab) -> void:
-	Export.current_tab = tab
+	Global.current_project.export_settings.current_tab = tab
 	show_tab()
 
 
 func _on_orientation_item_selected(id: Export.Orientation) -> void:
-	Export.orientation = id
+	Global.current_project.export_settings.orientation = id
 	_handle_orientation_ui()
 	spritesheet_lines_count.value = Export.frames_divided_by_spritesheet_lines()
 	Export.process_spritesheet()
@@ -375,11 +379,11 @@ func _on_orientation_item_selected(id: Export.Orientation) -> void:
 
 
 func _handle_orientation_ui() -> void:
-	if Export.orientation == Export.Orientation.ROWS:
+	if Global.current_project.export_settings.orientation == Export.Orientation.ROWS:
 		spritesheet_lines_count_label.visible = true
 		spritesheet_lines_count.visible = true
 		spritesheet_lines_count_label.text = "Columns:"
-	elif Export.orientation == Export.Orientation.COLUMNS:
+	elif Global.current_project.export_settings.orientation == Export.Orientation.COLUMNS:
 		spritesheet_lines_count_label.visible = true
 		spritesheet_lines_count.visible = true
 		spritesheet_lines_count_label.text = "Rows:"
@@ -389,41 +393,41 @@ func _handle_orientation_ui() -> void:
 
 
 func _on_lines_count_value_changed(value: float) -> void:
-	Export.lines_count = value
+	Global.current_project.export_settings.lines_count = value
 	Export.process_spritesheet()
 	update_dimensions_label()
 	set_preview()
 
 
 func _on_direction_item_selected(id: Export.AnimationDirection) -> void:
-	Export.direction = id
+	Global.current_project.export_settings.direction = id
 	preview_current_frame = 0
 	Export.process_data()
 	set_preview()
-	spritesheet_lines_count.max_value = Export.number_of_frames
+	spritesheet_lines_count.max_value = Global.current_project.export_settings.number_of_frames
 	update_dimensions_label()
 
 
 func _on_repeat_count_changed(value: int) -> void:
-	Export.repeat_count = value
+	Global.current_project.export_settings.repeat_count = value
 	preview_current_frame = 0
 	Export.process_data()
 	set_preview()
-	spritesheet_lines_count.max_value = Export.number_of_frames
+	spritesheet_lines_count.max_value = Global.current_project.export_settings.number_of_frames
 	update_dimensions_label()
 
 
 func _on_resize_value_changed(value: float) -> void:
-	Export.resize = value
+	Global.current_project.export_settings.resize = value
 	update_dimensions_label()
 
 
 func _on_quality_value_changed(value: float) -> void:
-	Export.save_quality = value / 100.0
+	Global.current_project.export_settings.save_quality = value / 100.0
 
 
 func _on_interpolation_item_selected(id: Image.Interpolation) -> void:
-	Export.interpolation = id
+	Global.current_project.export_settings.interpolation = id
 
 
 func _on_confirmed() -> void:
@@ -539,57 +543,59 @@ func _on_ExportDialog_visibility_changed() -> void:
 
 
 func _on_export_json_toggled(toggled_on: bool) -> void:
-	Export.export_json = toggled_on
+	Global.current_project.export_settings.export_json = toggled_on
 
 
 func _on_split_layers_toggled(toggled_on: bool) -> void:
-	Export.split_layers = toggled_on
-	spritesheet_layers_as_separate_files.disabled = !Export.split_layers
+	var export_setting := Global.current_project.export_settings
+	export_setting.split_layers = toggled_on
+	spritesheet_layers_as_separate_files.disabled = !export_setting.split_layers
 	Export.process_data()
 	set_preview()
 
 
 func _on_layers_as_separate_files_toggled(toggled_on: bool) -> void:
-	Export.sheet_layers_as_separate_files = toggled_on
+	Global.current_project.export_settings.sheet_layers_as_separate_files = toggled_on
 	Export.process_data()
 	set_preview()
 
 
 func _on_include_tags_in_filename_toggled(button_pressed: bool) -> void:
-	Export.include_tag_in_filename = button_pressed
+	Global.current_project.export_settings.include_tag_in_filename = button_pressed
 
 
 func _on_multiple_animations_directories_toggled(button_pressed: bool) -> void:
-	Export.new_dir_for_each_frame_tag = button_pressed
+	Global.current_project.export_settings.new_dir_for_each_frame_tag = button_pressed
 
 
 func _on_crop_image_option_selected(index: int) -> void:
-	Export.crop_mode = index as Export.CropMode
+	Global.current_project.export_settings.crop_mode = index as Export.CropMode
 	erase_outside_selection.disabled = index == Export.CropMode.SELECTION
 	Export.process_data()
 	set_preview()
 
 
 func _on_clip_images_selection_toggled(toggled_on: bool) -> void:
-	Export.erase_unselected_area = toggled_on
+	Global.current_project.export_settings.erase_unselected_area = toggled_on
 	Export.process_data()
 	set_preview()
 
 
 func _on_frames_item_selected(id: int) -> void:
-	Export.frame_current_tag = id
+	var export_setting := Global.current_project.export_settings
+	export_setting.frame_current_tag = id
 	Export.process_data()
 	set_preview()
-	spritesheet_lines_count.max_value = Export.number_of_frames
-	spritesheet_lines_count.value = Export.lines_count
+	spritesheet_lines_count.max_value = export_setting.number_of_frames
+	spritesheet_lines_count.value = export_setting.lines_count
 
 
 func _on_layers_item_selected(id: int) -> void:
-	Export.export_layers = id
+	Global.current_project.export_settings.export_layers = id
 	Export.cache_blended_frames()
 	Export.process_data()
 	set_preview()
 
 
 func _on_separator_character_text_changed(new_text: String) -> void:
-	Export.separator_character = new_text
+	Global.current_project.export_settings.separator_character = new_text

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -100,11 +100,11 @@ func show_tab() -> void:
 	get_tree().call_group("ExportSpritesheetOptions", "hide")
 	set_file_format_selector()
 	create_frame_tag_list()
-	var export_settings := Global.current_project.export_settings
-	frames_option_button.select(export_settings.frame_current_tag)
+	var export_profile := Global.current_project.export_profile
+	frames_option_button.select(export_profile.frame_current_tag)
 	create_layer_list()
-	layers_option_button.select(export_settings.export_layers)
-	match export_settings.current_tab:
+	layers_option_button.select(export_profile.export_layers)
+	match export_profile.current_tab:
 		Export.ExportTab.IMAGE:
 			Export.process_animation()
 			get_tree().call_group("ExportImageOptions", "show")
@@ -117,15 +117,15 @@ func show_tab() -> void:
 		Export.ExportTab.SPRITESHEET:
 			frame_timer.stop()
 			Export.process_spritesheet()
-			spritesheet_orientation.selected = export_settings.orientation
-			spritesheet_lines_count.max_value = export_settings.number_of_frames
-			spritesheet_lines_count.value = export_settings.lines_count
-			spritesheet_layers_as_separate_files.disabled = !export_settings.split_layers
+			spritesheet_orientation.selected = export_profile.orientation
+			spritesheet_lines_count.max_value = export_profile.number_of_frames
+			spritesheet_lines_count.value = export_profile.lines_count
+			spritesheet_layers_as_separate_files.disabled = !export_profile.split_layers
 			get_tree().call_group("ExportSpritesheetOptions", "show")
 			_handle_orientation_ui()
 	set_preview()
 	update_dimensions_label()
-	tabs.current_tab = export_settings.current_tab
+	tabs.current_tab = export_profile.current_tab
 	if OS.get_name() == "Web":
 		get_tree().call_group("NotHTML5", "hide")
 	elif OS.get_name() == "Android":
@@ -137,25 +137,25 @@ func _set_project_export_settings(
 ) -> void:
 	var project := Global.current_project
 	var settings_changed := (
-		project.export_settings.directory_path != directory_path
-		or project.export_settings.file_name != file_name
-		or project.export_settings.file_format != file_format
+		project.export_profile.directory_path != directory_path
+		or project.export_profile.file_name != file_name
+		or project.export_profile.file_format != file_format
 	)
-	project.export_settings.directory_path = directory_path
-	project.export_settings.file_name = file_name
-	project.export_settings.file_format = file_format
+	project.export_profile.directory_path = directory_path
+	project.export_profile.file_name = file_name
+	project.export_profile.file_format = file_format
 	if settings_changed and not _is_initializing_export_settings:
 		project.has_changed = true
 
 
 func set_preview() -> void:
-	var export_settings := Global.current_project.export_settings
+	var export_profile := Global.current_project.export_profile
 	_preview_images = Export.processed_images
 	if _preview_images.is_empty():
 		return
 	var preview_data := {
-		"exporter_id": export_settings.file_format,
-		"export_tab": export_settings.current_tab,
+		"exporter_id": export_profile.file_format,
+		"export_tab": export_profile.current_tab,
 		"preview_images": _preview_images,
 	}
 	about_to_preview.emit(preview_data)
@@ -232,7 +232,7 @@ func remove_previews() -> void:
 
 
 func set_file_format_selector() -> void:
-	match Global.current_project.export_settings.current_tab:
+	match Global.current_project.export_profile.current_tab:
 		Export.ExportTab.IMAGE:
 			_set_file_format_selector_suitable_file_formats(image_exports)
 		Export.ExportTab.SPRITESHEET:
@@ -243,7 +243,7 @@ func set_file_format_selector() -> void:
 ## Note that if the current format is in the list, it stays for consistency.
 func _set_file_format_selector_suitable_file_formats(formats: Array[Export.FileFormat]) -> void:
 	var project := Global.current_project
-	var export_settings := project.export_settings
+	var export_profile := project.export_profile
 	file_format_options.clear()
 	path_dialog_popup.clear_filters()
 	var ffmpeg_installed := Export.is_ffmpeg_installed()
@@ -252,7 +252,7 @@ func _set_file_format_selector_suitable_file_formats(formats: Array[Export.FileF
 		if i == Export.FileFormat.EXR:
 			if OS.get_name() == "Android" or OS.get_name() == "Web":
 				continue
-		if export_settings.file_format == i:
+		if export_profile.file_format == i:
 			needs_update = false
 		if not ffmpeg_installed:
 			if i in Export.ffmpeg_formats:
@@ -264,11 +264,11 @@ func _set_file_format_selector_suitable_file_formats(formats: Array[Export.FileF
 				"*" + Export.file_format_string(i), Export.file_format_description(i)
 			)
 	if needs_update:
-		_set_project_export_settings(export_settings.directory_path, export_settings.file_name, formats[0])
-	file_format_options.selected = file_format_options.get_item_index(export_settings.file_format)
+		_set_project_export_settings(export_profile.directory_path, export_profile.file_name, formats[0])
+	file_format_options.selected = file_format_options.get_item_index(export_profile.file_format)
 	if OS.get_name() == "Android":
-		var file_ext_str := "*" + Export.file_format_string(export_settings.file_format)
-		var file_format_description := Export.file_format_description(export_settings.file_format)
+		var file_ext_str := "*" + Export.file_format_string(export_profile.file_format)
+		var file_format_description := Export.file_format_description(export_profile.file_format)
 		path_dialog_popup.add_filter(file_ext_str, file_format_description)
 
 
@@ -306,8 +306,8 @@ func create_layer_list() -> void:
 
 func update_dimensions_label() -> void:
 	if _preview_images.size() > 0:
-		var export_settings := Global.current_project.export_settings
-		var new_size: Vector2i = _preview_images[0].image.get_size() * (export_settings.resize / 100.0)
+		var export_profile := Global.current_project.export_profile
+		var new_size: Vector2i = _preview_images[0].image.get_size() * (export_profile.resize / 100.0)
 		dimension_label.text = str(new_size.x, "×", new_size.y)
 
 
@@ -346,42 +346,42 @@ func _on_about_to_popup() -> void:
 	get_ok_button().text = "Export"
 	Global.transform_content_confirmed.emit()
 	var project := Global.current_project
-	var export_settings := project.export_settings
+	var export_profile := project.export_profile
 	# If we're on Web, don't let the user change the directory path
 	if OS.get_name() == "Web":
-		_set_project_export_settings("user://", export_settings.file_name, export_settings.file_format)
+		_set_project_export_settings("user://", export_profile.file_name, export_profile.file_format)
 
-	if export_settings.directory_path.is_empty():
+	if export_profile.directory_path.is_empty():
 		var default_directory_path: String = Global.config_cache.get_value(
 			"data", "current_dir", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP)
 		)
-		_set_project_export_settings(default_directory_path, export_settings.file_name, export_settings.file_format)
+		_set_project_export_settings(default_directory_path, export_profile.file_name, export_profile.file_format)
 
 	# If export already occurred - sets GUI to show previous settings
 	# we don't emit signals because there settings are already set, so nothing new is changed.
-	options_resize.set_value_no_signal(export_settings.resize)
-	options_interpolation.selected = export_settings.interpolation
-	options_quality.set_value_no_signal(export_settings.save_quality * 100.0)
-	direction_option_button.selected = export_settings.direction
-	repeat_count_spinbox.set_value_no_signal(export_settings.repeat_count)
-	split_layers_checkbox.set_pressed_no_signal(export_settings.split_layers)
-	crop_image_option.selected = export_settings.crop_mode
-	erase_outside_selection.disabled = (export_settings.crop_mode == Export.CropMode.SELECTION)
-	erase_outside_selection.set_pressed_no_signal(export_settings.erase_unselected_area)
-	separator_character_edit.text = export_settings.separator_character
-	export_json_checkbox.set_pressed_no_signal(export_settings.export_json)
-	include_tags_in_filename_checkbox.set_pressed_no_signal(export_settings.include_tag_in_filename)
+	options_resize.set_value_no_signal(export_profile.resize)
+	options_interpolation.selected = export_profile.interpolation
+	options_quality.set_value_no_signal(export_profile.save_quality * 100.0)
+	direction_option_button.selected = export_profile.direction
+	repeat_count_spinbox.set_value_no_signal(export_profile.repeat_count)
+	split_layers_checkbox.set_pressed_no_signal(export_profile.split_layers)
+	crop_image_option.selected = export_profile.crop_mode
+	erase_outside_selection.disabled = (export_profile.crop_mode == Export.CropMode.SELECTION)
+	erase_outside_selection.set_pressed_no_signal(export_profile.erase_unselected_area)
+	separator_character_edit.text = export_profile.separator_character
+	export_json_checkbox.set_pressed_no_signal(export_profile.export_json)
+	include_tags_in_filename_checkbox.set_pressed_no_signal(export_profile.include_tag_in_filename)
 	multiple_animations_directories_checkbox.set_pressed_no_signal(
-		export_settings.new_dir_for_each_frame_tag
+		export_profile.new_dir_for_each_frame_tag
 	)
 
-	directory_path_label.text = export_settings.directory_path
-	var file_ext := Export.file_format_string(export_settings.file_format)
+	directory_path_label.text = export_profile.directory_path
+	var file_ext := Export.file_format_string(export_profile.file_format)
 	if OS.get_name() == "Web" or OS.get_name() == "Android":
-		path_line_edit.text = export_settings.file_name + file_ext
+		path_line_edit.text = export_profile.file_name + file_ext
 	else:
-		path_line_edit.text = export_settings.directory_path.path_join(export_settings.file_name) + file_ext
-	path_dialog_popup.current_dir = export_settings.directory_path
+		path_line_edit.text = export_profile.directory_path.path_join(export_profile.file_name) + file_ext
+	path_dialog_popup.current_dir = export_profile.directory_path
 	Export.cache_blended_frames()
 	show_tab()
 
@@ -391,12 +391,12 @@ func _on_about_to_popup() -> void:
 
 
 func _on_tab_bar_tab_changed(tab: Export.ExportTab) -> void:
-	Global.current_project.export_settings.current_tab = tab
+	Global.current_project.export_profile.current_tab = tab
 	show_tab()
 
 
 func _on_orientation_item_selected(id: Export.Orientation) -> void:
-	Global.current_project.export_settings.orientation = id
+	Global.current_project.export_profile.orientation = id
 	_handle_orientation_ui()
 	spritesheet_lines_count.value = Export.frames_divided_by_spritesheet_lines()
 	Export.process_spritesheet()
@@ -405,11 +405,11 @@ func _on_orientation_item_selected(id: Export.Orientation) -> void:
 
 
 func _handle_orientation_ui() -> void:
-	if Global.current_project.export_settings.orientation == Export.Orientation.ROWS:
+	if Global.current_project.export_profile.orientation == Export.Orientation.ROWS:
 		spritesheet_lines_count_label.visible = true
 		spritesheet_lines_count.visible = true
 		spritesheet_lines_count_label.text = "Columns:"
-	elif Global.current_project.export_settings.orientation == Export.Orientation.COLUMNS:
+	elif Global.current_project.export_profile.orientation == Export.Orientation.COLUMNS:
 		spritesheet_lines_count_label.visible = true
 		spritesheet_lines_count.visible = true
 		spritesheet_lines_count_label.text = "Rows:"
@@ -419,41 +419,41 @@ func _handle_orientation_ui() -> void:
 
 
 func _on_lines_count_value_changed(value: float) -> void:
-	Global.current_project.export_settings.lines_count = value
+	Global.current_project.export_profile.lines_count = value
 	Export.process_spritesheet()
 	update_dimensions_label()
 	set_preview()
 
 
 func _on_direction_item_selected(id: Export.AnimationDirection) -> void:
-	Global.current_project.export_settings.direction = id
+	Global.current_project.export_profile.direction = id
 	preview_current_frame = 0
 	Export.process_data()
 	set_preview()
-	spritesheet_lines_count.max_value = Global.current_project.export_settings.number_of_frames
+	spritesheet_lines_count.max_value = Global.current_project.export_profile.number_of_frames
 	update_dimensions_label()
 
 
 func _on_repeat_count_changed(value: int) -> void:
-	Global.current_project.export_settings.repeat_count = value
+	Global.current_project.export_profile.repeat_count = value
 	preview_current_frame = 0
 	Export.process_data()
 	set_preview()
-	spritesheet_lines_count.max_value = Global.current_project.export_settings.number_of_frames
+	spritesheet_lines_count.max_value = Global.current_project.export_profile.number_of_frames
 	update_dimensions_label()
 
 
 func _on_resize_value_changed(value: float) -> void:
-	Global.current_project.export_settings.resize = value
+	Global.current_project.export_profile.resize = value
 	update_dimensions_label()
 
 
 func _on_quality_value_changed(value: float) -> void:
-	Global.current_project.export_settings.save_quality = value / 100.0
+	Global.current_project.export_profile.save_quality = value / 100.0
 
 
 func _on_interpolation_item_selected(id: Image.Interpolation) -> void:
-	Global.current_project.export_settings.interpolation = id
+	Global.current_project.export_profile.interpolation = id
 
 
 func _on_confirmed() -> void:
@@ -473,8 +473,8 @@ func _on_path_button_pressed() -> void:
 
 func _on_path_line_edit_text_changed(new_text: String) -> void:
 	var project := Global.current_project
-	var export_settings := project.export_settings
-	var directory_path := export_settings.directory_path
+	var export_profile := project.export_profile
+	var directory_path := export_profile.directory_path
 	if OS.get_name() != "Android":
 		directory_path = new_text.get_base_dir()
 	var file_name := new_text.get_file().get_basename()
@@ -507,7 +507,7 @@ func _on_path_dialog_dir_selected(dir: String) -> void:
 	directory_path_label.text = dir
 	var project := Global.current_project
 	_set_project_export_settings(
-		dir, project.export_settings.file_name, project.export_settings.file_format
+		dir, project.export_profile.file_name, project.export_profile.file_format
 	)
 
 
@@ -572,59 +572,59 @@ func _on_ExportDialog_visibility_changed() -> void:
 
 
 func _on_export_json_toggled(toggled_on: bool) -> void:
-	Global.current_project.export_settings.export_json = toggled_on
+	Global.current_project.export_profile.export_json = toggled_on
 
 
 func _on_split_layers_toggled(toggled_on: bool) -> void:
-	var export_settings := Global.current_project.export_settings
-	export_settings.split_layers = toggled_on
-	spritesheet_layers_as_separate_files.disabled = !export_settings.split_layers
+	var export_profile := Global.current_project.export_profile
+	export_profile.split_layers = toggled_on
+	spritesheet_layers_as_separate_files.disabled = !export_profile.split_layers
 	Export.process_data()
 	set_preview()
 
 
 func _on_layers_as_separate_files_toggled(toggled_on: bool) -> void:
-	Global.current_project.export_settings.sheet_layers_as_separate_files = toggled_on
+	Global.current_project.export_profile.sheet_layers_as_separate_files = toggled_on
 	Export.process_data()
 	set_preview()
 
 
 func _on_include_tags_in_filename_toggled(button_pressed: bool) -> void:
-	Global.current_project.export_settings.include_tag_in_filename = button_pressed
+	Global.current_project.export_profile.include_tag_in_filename = button_pressed
 
 
 func _on_multiple_animations_directories_toggled(button_pressed: bool) -> void:
-	Global.current_project.export_settings.new_dir_for_each_frame_tag = button_pressed
+	Global.current_project.export_profile.new_dir_for_each_frame_tag = button_pressed
 
 
 func _on_crop_image_option_selected(index: int) -> void:
-	Global.current_project.export_settings.crop_mode = index as Export.CropMode
+	Global.current_project.export_profile.crop_mode = index as Export.CropMode
 	erase_outside_selection.disabled = index == Export.CropMode.SELECTION
 	Export.process_data()
 	set_preview()
 
 
 func _on_clip_images_selection_toggled(toggled_on: bool) -> void:
-	Global.current_project.export_settings.erase_unselected_area = toggled_on
+	Global.current_project.export_profile.erase_unselected_area = toggled_on
 	Export.process_data()
 	set_preview()
 
 
 func _on_frames_item_selected(id: int) -> void:
-	var export_settings := Global.current_project.export_settings
-	export_settings.frame_current_tag = id
+	var export_profile := Global.current_project.export_profile
+	export_profile.frame_current_tag = id
 	Export.process_data()
 	set_preview()
-	spritesheet_lines_count.max_value = export_settings.number_of_frames
-	spritesheet_lines_count.value = export_settings.lines_count
+	spritesheet_lines_count.max_value = export_profile.number_of_frames
+	spritesheet_lines_count.value = export_profile.lines_count
 
 
 func _on_layers_item_selected(id: int) -> void:
-	Global.current_project.export_settings.export_layers = id
+	Global.current_project.export_profile.export_layers = id
 	Export.cache_blended_frames()
 	Export.process_data()
 	set_preview()
 
 
 func _on_separator_character_text_changed(new_text: String) -> void:
-	Global.current_project.export_settings.separator_character = new_text
+	Global.current_project.export_profile.separator_character = new_text

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -59,7 +59,6 @@ var _is_initializing_export_settings := false
 @onready var erase_outside_selection: CheckBox = %EraseOutsideSelection
 @onready var crop_image_option: OptionButton = %CropImages
 
-
 @onready var directory_path_label: Label = %DirectoryPathLabel
 @onready var path_line_edit: LineEdit = $"%PathLineEdit"
 @onready var file_format_options: OptionButton = $"%FileFormat"
@@ -264,7 +263,9 @@ func _set_file_format_selector_suitable_file_formats(formats: Array[Export.FileF
 				"*" + Export.file_format_string(i), Export.file_format_description(i)
 			)
 	if needs_update:
-		_set_project_export_settings(export_profile.directory_path, export_profile.file_name, formats[0])
+		_set_project_export_settings(
+			export_profile.directory_path, export_profile.file_name, formats[0]
+		)
 	file_format_options.selected = file_format_options.get_item_index(export_profile.file_format)
 	if OS.get_name() == "Android":
 		var file_ext_str := "*" + Export.file_format_string(export_profile.file_format)
@@ -307,7 +308,9 @@ func create_layer_list() -> void:
 func update_dimensions_label() -> void:
 	if _preview_images.size() > 0:
 		var export_profile := Global.current_project.export_profile
-		var new_size: Vector2i = _preview_images[0].image.get_size() * (export_profile.resize / 100.0)
+		var new_size: Vector2i = (
+			_preview_images[0].image.get_size() * (export_profile.resize / 100.0)
+		)
 		dimension_label.text = str(new_size.x, "×", new_size.y)
 
 
@@ -349,13 +352,17 @@ func _on_about_to_popup() -> void:
 	var export_profile := project.export_profile
 	# If we're on Web, don't let the user change the directory path
 	if OS.get_name() == "Web":
-		_set_project_export_settings("user://", export_profile.file_name, export_profile.file_format)
+		_set_project_export_settings(
+			"user://", export_profile.file_name, export_profile.file_format
+		)
 
 	if export_profile.directory_path.is_empty():
 		var default_directory_path: String = Global.config_cache.get_value(
 			"data", "current_dir", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP)
 		)
-		_set_project_export_settings(default_directory_path, export_profile.file_name, export_profile.file_format)
+		_set_project_export_settings(
+			default_directory_path, export_profile.file_name, export_profile.file_format
+		)
 
 	# If export already occurred - sets GUI to show previous settings
 	# we don't emit signals because there settings are already set, so nothing new is changed.
@@ -380,7 +387,9 @@ func _on_about_to_popup() -> void:
 	if OS.get_name() == "Web" or OS.get_name() == "Android":
 		path_line_edit.text = export_profile.file_name + file_ext
 	else:
-		path_line_edit.text = export_profile.directory_path.path_join(export_profile.file_name) + file_ext
+		path_line_edit.text = (
+			export_profile.directory_path.path_join(export_profile.file_name) + file_ext
+		)
 	path_dialog_popup.current_dir = export_profile.directory_path
 	Export.cache_blended_frames()
 	show_tab()

--- a/src/UI/Dialogs/ExportDialog.gd
+++ b/src/UI/Dialogs/ExportDialog.gd
@@ -44,15 +44,25 @@ var _is_initializing_export_settings := false
 
 @onready var frames_option_button: OptionButton = $"%Frames"
 @onready var layers_option_button: OptionButton = $"%Layers"
-@onready var options_resize: ValueSlider = $"%Resize"
+@onready var split_layers_checkbox: CheckBox = %SplitLayers
+@onready var direction_option_button: OptionButton = %Direction
+@onready var repeat_count_spinbox: SpinBox = %RepeatCount
 @onready var dimension_label: Label = $"%DimensionLabel"
-@onready var crop_image_option: OptionButton = %CropImages
+@onready var options_resize: ValueSlider = $"%Resize"
+@onready var options_quality: ValueSlider = %Quality
+
+@onready var options_interpolation: OptionButton = $"%Interpolation"
+@onready var separator_character_edit: LineEdit = %SeparatorCharacter
+@onready var export_json_checkbox: CheckBox = %ExportJSON
+@onready var include_tags_in_filename_checkbox: CheckBox = %IncludeTagsInFilename
+@onready var multiple_animations_directories_checkbox: CheckBox = %MultipleAnimationsDirectories
 @onready var erase_outside_selection: CheckBox = %EraseOutsideSelection
+@onready var crop_image_option: OptionButton = %CropImages
+
 
 @onready var directory_path_label: Label = %DirectoryPathLabel
 @onready var path_line_edit: LineEdit = $"%PathLineEdit"
 @onready var file_format_options: OptionButton = $"%FileFormat"
-@onready var options_interpolation: OptionButton = $"%Interpolation"
 
 @onready var file_exists_alert_popup: AcceptDialog = $FileExistsAlert
 @onready var path_validation_alert_popup: AcceptDialog = $PathValidationAlert
@@ -90,11 +100,11 @@ func show_tab() -> void:
 	get_tree().call_group("ExportSpritesheetOptions", "hide")
 	set_file_format_selector()
 	create_frame_tag_list()
-	var export_setting := Global.current_project.export_settings
-	frames_option_button.select(export_setting.frame_current_tag)
+	var export_settings := Global.current_project.export_settings
+	frames_option_button.select(export_settings.frame_current_tag)
 	create_layer_list()
-	layers_option_button.select(export_setting.export_layers)
-	match export_setting.current_tab:
+	layers_option_button.select(export_settings.export_layers)
+	match export_settings.current_tab:
 		Export.ExportTab.IMAGE:
 			Export.process_animation()
 			get_tree().call_group("ExportImageOptions", "show")
@@ -107,15 +117,15 @@ func show_tab() -> void:
 		Export.ExportTab.SPRITESHEET:
 			frame_timer.stop()
 			Export.process_spritesheet()
-			spritesheet_orientation.selected = export_setting.orientation
-			spritesheet_lines_count.max_value = export_setting.number_of_frames
-			spritesheet_lines_count.value = export_setting.lines_count
-			spritesheet_layers_as_separate_files.disabled = !export_setting.split_layers
+			spritesheet_orientation.selected = export_settings.orientation
+			spritesheet_lines_count.max_value = export_settings.number_of_frames
+			spritesheet_lines_count.value = export_settings.lines_count
+			spritesheet_layers_as_separate_files.disabled = !export_settings.split_layers
 			get_tree().call_group("ExportSpritesheetOptions", "show")
 			_handle_orientation_ui()
 	set_preview()
 	update_dimensions_label()
-	tabs.current_tab = export_setting.current_tab
+	tabs.current_tab = export_settings.current_tab
 	if OS.get_name() == "Web":
 		get_tree().call_group("NotHTML5", "hide")
 	elif OS.get_name() == "Android":
@@ -127,25 +137,25 @@ func _set_project_export_settings(
 ) -> void:
 	var project := Global.current_project
 	var settings_changed := (
-		project.export_directory_path != directory_path
-		or project.file_name != file_name
-		or project.file_format != file_format
+		project.export_settings.directory_path != directory_path
+		or project.export_settings.file_name != file_name
+		or project.export_settings.file_format != file_format
 	)
-	project.export_directory_path = directory_path
-	project.file_name = file_name
-	project.file_format = file_format
+	project.export_settings.directory_path = directory_path
+	project.export_settings.file_name = file_name
+	project.export_settings.file_format = file_format
 	if settings_changed and not _is_initializing_export_settings:
 		project.has_changed = true
 
 
 func set_preview() -> void:
-	var export_setting := Global.current_project.export_settings
+	var export_settings := Global.current_project.export_settings
 	_preview_images = Export.processed_images
 	if _preview_images.is_empty():
 		return
 	var preview_data := {
-		"exporter_id": Global.current_project.file_format,
-		"export_tab": export_setting.current_tab,
+		"exporter_id": export_settings.file_format,
+		"export_tab": export_settings.current_tab,
 		"preview_images": _preview_images,
 	}
 	about_to_preview.emit(preview_data)
@@ -233,6 +243,7 @@ func set_file_format_selector() -> void:
 ## Note that if the current format is in the list, it stays for consistency.
 func _set_file_format_selector_suitable_file_formats(formats: Array[Export.FileFormat]) -> void:
 	var project := Global.current_project
+	var export_settings := project.export_settings
 	file_format_options.clear()
 	path_dialog_popup.clear_filters()
 	var ffmpeg_installed := Export.is_ffmpeg_installed()
@@ -241,7 +252,7 @@ func _set_file_format_selector_suitable_file_formats(formats: Array[Export.FileF
 		if i == Export.FileFormat.EXR:
 			if OS.get_name() == "Android" or OS.get_name() == "Web":
 				continue
-		if project.file_format == i:
+		if export_settings.file_format == i:
 			needs_update = false
 		if not ffmpeg_installed:
 			if i in Export.ffmpeg_formats:
@@ -253,11 +264,11 @@ func _set_file_format_selector_suitable_file_formats(formats: Array[Export.FileF
 				"*" + Export.file_format_string(i), Export.file_format_description(i)
 			)
 	if needs_update:
-		_set_project_export_settings(project.export_directory_path, project.file_name, formats[0])
-	file_format_options.selected = file_format_options.get_item_index(project.file_format)
+		_set_project_export_settings(export_settings.directory_path, export_settings.file_name, formats[0])
+	file_format_options.selected = file_format_options.get_item_index(export_settings.file_format)
 	if OS.get_name() == "Android":
-		var file_ext_str := "*" + Export.file_format_string(project.file_format)
-		var file_format_description := Export.file_format_description(project.file_format)
+		var file_ext_str := "*" + Export.file_format_string(export_settings.file_format)
+		var file_format_description := Export.file_format_description(export_settings.file_format)
 		path_dialog_popup.add_filter(file_ext_str, file_format_description)
 
 
@@ -295,8 +306,8 @@ func create_layer_list() -> void:
 
 func update_dimensions_label() -> void:
 	if _preview_images.size() > 0:
-		var export_setting := Global.current_project.export_settings
-		var new_size: Vector2i = _preview_images[0].image.get_size() * (export_setting.resize / 100.0)
+		var export_settings := Global.current_project.export_settings
+		var new_size: Vector2i = _preview_images[0].image.get_size() * (export_settings.resize / 100.0)
 		dimension_label.text = str(new_size.x, "×", new_size.y)
 
 
@@ -335,27 +346,42 @@ func _on_about_to_popup() -> void:
 	get_ok_button().text = "Export"
 	Global.transform_content_confirmed.emit()
 	var project := Global.current_project
+	var export_settings := project.export_settings
 	# If we're on Web, don't let the user change the directory path
 	if OS.get_name() == "Web":
-		_set_project_export_settings("user://", project.file_name, project.file_format)
+		_set_project_export_settings("user://", export_settings.file_name, export_settings.file_format)
 
-	if project.export_directory_path.is_empty():
+	if export_settings.directory_path.is_empty():
 		var default_directory_path: String = Global.config_cache.get_value(
 			"data", "current_dir", OS.get_system_dir(OS.SYSTEM_DIR_DESKTOP)
 		)
-		_set_project_export_settings(default_directory_path, project.file_name, project.file_format)
+		_set_project_export_settings(default_directory_path, export_settings.file_name, export_settings.file_format)
 
 	# If export already occurred - sets GUI to show previous settings
-	var export_setting := project.export_settings
-	options_resize.value = export_setting.resize
-	options_interpolation.selected = export_setting.interpolation
-	directory_path_label.text = project.export_directory_path
-	var file_ext := Export.file_format_string(project.file_format)
+	# we don't emit signals because there settings are already set, so nothing new is changed.
+	options_resize.set_value_no_signal(export_settings.resize)
+	options_interpolation.selected = export_settings.interpolation
+	options_quality.set_value_no_signal(export_settings.save_quality * 100.0)
+	direction_option_button.selected = export_settings.direction
+	repeat_count_spinbox.set_value_no_signal(export_settings.repeat_count)
+	split_layers_checkbox.set_pressed_no_signal(export_settings.split_layers)
+	crop_image_option.selected = export_settings.crop_mode
+	erase_outside_selection.disabled = (export_settings.crop_mode == Export.CropMode.SELECTION)
+	erase_outside_selection.set_pressed_no_signal(export_settings.erase_unselected_area)
+	separator_character_edit.text = export_settings.separator_character
+	export_json_checkbox.set_pressed_no_signal(export_settings.export_json)
+	include_tags_in_filename_checkbox.set_pressed_no_signal(export_settings.include_tag_in_filename)
+	multiple_animations_directories_checkbox.set_pressed_no_signal(
+		export_settings.new_dir_for_each_frame_tag
+	)
+
+	directory_path_label.text = export_settings.directory_path
+	var file_ext := Export.file_format_string(export_settings.file_format)
 	if OS.get_name() == "Web" or OS.get_name() == "Android":
-		path_line_edit.text = project.file_name + file_ext
+		path_line_edit.text = export_settings.file_name + file_ext
 	else:
-		path_line_edit.text = project.export_directory_path.path_join(project.file_name) + file_ext
-	path_dialog_popup.current_dir = project.export_directory_path
+		path_line_edit.text = export_settings.directory_path.path_join(export_settings.file_name) + file_ext
+	path_dialog_popup.current_dir = export_settings.directory_path
 	Export.cache_blended_frames()
 	show_tab()
 
@@ -447,7 +473,8 @@ func _on_path_button_pressed() -> void:
 
 func _on_path_line_edit_text_changed(new_text: String) -> void:
 	var project := Global.current_project
-	var directory_path := project.export_directory_path
+	var export_settings := project.export_settings
+	var directory_path := export_settings.directory_path
 	if OS.get_name() != "Android":
 		directory_path = new_text.get_base_dir()
 	var file_name := new_text.get_file().get_basename()
@@ -479,7 +506,9 @@ func _on_path_dialog_file_selected(path: String) -> void:
 func _on_path_dialog_dir_selected(dir: String) -> void:
 	directory_path_label.text = dir
 	var project := Global.current_project
-	_set_project_export_settings(dir, project.file_name, project.file_format)
+	_set_project_export_settings(
+		dir, project.export_settings.file_name, project.export_settings.file_format
+	)
 
 
 func _on_path_dialog_canceled() -> void:
@@ -547,9 +576,9 @@ func _on_export_json_toggled(toggled_on: bool) -> void:
 
 
 func _on_split_layers_toggled(toggled_on: bool) -> void:
-	var export_setting := Global.current_project.export_settings
-	export_setting.split_layers = toggled_on
-	spritesheet_layers_as_separate_files.disabled = !export_setting.split_layers
+	var export_settings := Global.current_project.export_settings
+	export_settings.split_layers = toggled_on
+	spritesheet_layers_as_separate_files.disabled = !export_settings.split_layers
 	Export.process_data()
 	set_preview()
 
@@ -582,12 +611,12 @@ func _on_clip_images_selection_toggled(toggled_on: bool) -> void:
 
 
 func _on_frames_item_selected(id: int) -> void:
-	var export_setting := Global.current_project.export_settings
-	export_setting.frame_current_tag = id
+	var export_settings := Global.current_project.export_settings
+	export_settings.frame_current_tag = id
 	Export.process_data()
 	set_preview()
-	spritesheet_lines_count.max_value = export_setting.number_of_frames
-	spritesheet_lines_count.value = export_setting.lines_count
+	spritesheet_lines_count.max_value = export_settings.number_of_frames
+	spritesheet_lines_count.value = export_settings.lines_count
 
 
 func _on_layers_item_selected(id: int) -> void:

--- a/src/UI/Dialogs/ExportDialog.tscn
+++ b/src/UI/Dialogs/ExportDialog.tscn
@@ -149,6 +149,7 @@ popup/item_1/text = "Selected layers"
 popup/item_1/id = 1
 
 [node name="SplitLayers" type="CheckBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer/LayersContainer" unique_id=287230239 groups=["ExportImageOptions", "ExportSpritesheetOptions", "NotAndroid"]]
+unique_name_in_owner = true
 layout_mode = 2
 mouse_default_cursor_shape = 2
 text = "Split layers"
@@ -158,6 +159,7 @@ layout_mode = 2
 text = "Direction:"
 
 [node name="Direction" type="OptionButton" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer" unique_id=72482042]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -176,6 +178,7 @@ layout_mode = 2
 text = "Repeat times:"
 
 [node name="RepeatCount" type="SpinBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/GridContainer" unique_id=1383852018]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "The number of times the animation is repeated in addition to the original animation."
@@ -320,11 +323,13 @@ size_flags_horizontal = 3
 text = "Separator character(s):"
 
 [node name="SeparatorCharacter" type="LineEdit" parent="VBoxContainer/VSplitContainer/VBoxContainer/AdvancedOptions/GridContainer" unique_id=863531641 groups=["ExportImageOptions", "ExportMultipleFilesEditableOptions", "ExportSpritesheetOptions"]]
+unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "The character(s) that separate the file name and the frame number"
 text = "_"
 
 [node name="ExportJSON" type="CheckBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/AdvancedOptions/GridContainer" unique_id=459971663 groups=["NotAndroid"]]
+unique_name_in_owner = true
 layout_mode = 2
 mouse_default_cursor_shape = 2
 text = "Export JSON data"
@@ -336,11 +341,13 @@ mouse_default_cursor_shape = 2
 text = "Layers as separate files"
 
 [node name="IncludeTagsInFilename" type="CheckBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/AdvancedOptions/GridContainer" unique_id=64815569 groups=["ExportImageOptions", "ExportMultipleFilesOptions", "NotAndroid"]]
+unique_name_in_owner = true
 layout_mode = 2
 mouse_default_cursor_shape = 2
 text = "Include frame tags in the file name"
 
 [node name="MultipleAnimationsDirectories" type="CheckBox" parent="VBoxContainer/VSplitContainer/VBoxContainer/AdvancedOptions/GridContainer" unique_id=2068197934 groups=["ExportImageOptions", "ExportMultipleFilesOptions", "NotAndroid", "NotHTML5"]]
+unique_name_in_owner = true
 visible = false
 layout_mode = 2
 tooltip_text = "Creates multiple files but every file is stored in different folder that corresponds to its frame tag"

--- a/src/UI/TopMenuContainer/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer/TopMenuContainer.gd
@@ -233,7 +233,7 @@ func _update_file_menu_buttons(project: Project) -> void:
 	else:
 		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save") + " %s" % export_profile.file_name)
 	if project.was_exported:
-		var f_name := " %s" % (project.file_name + Export.file_format_string(export_profile.file_format))
+		var f_name := " %s" % (export_profile.file_name + Export.file_format_string(export_profile.file_format))
 		if project.export_overwrite:
 			file_menu.set_item_text(Global.FileMenu.EXPORT, tr("Overwrite") + f_name)
 		else:

--- a/src/UI/TopMenuContainer/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer/TopMenuContainer.gd
@@ -227,12 +227,13 @@ func _on_cursor_position_text_changed(text: String) -> void:
 func _update_file_menu_buttons(project: Project) -> void:
 	if not is_instance_valid(file_menu):
 		return
-	if project.export_directory_path.is_empty():
+	var export_settings = project.export_settings
+	if export_settings.directory_path.is_empty():
 		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save"))
 	else:
-		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save") + " %s" % project.file_name)
+		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save") + " %s" % export_settings.file_name)
 	if project.was_exported:
-		var f_name := " %s" % (project.file_name + Export.file_format_string(project.file_format))
+		var f_name := " %s" % (project.file_name + Export.file_format_string(export_settings.file_format))
 		if project.export_overwrite:
 			file_menu.set_item_text(Global.FileMenu.EXPORT, tr("Overwrite") + f_name)
 		else:

--- a/src/UI/TopMenuContainer/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer/TopMenuContainer.gd
@@ -233,7 +233,10 @@ func _update_file_menu_buttons(project: Project) -> void:
 	else:
 		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save") + " %s" % export_profile.file_name)
 	if project.was_exported:
-		var f_name := " %s" % (export_profile.file_name + Export.file_format_string(export_profile.file_format))
+		var f_name := (
+			" %s"
+			% (export_profile.file_name + Export.file_format_string(export_profile.file_format))
+		)
 		if project.export_overwrite:
 			file_menu.set_item_text(Global.FileMenu.EXPORT, tr("Overwrite") + f_name)
 		else:

--- a/src/UI/TopMenuContainer/TopMenuContainer.gd
+++ b/src/UI/TopMenuContainer/TopMenuContainer.gd
@@ -227,13 +227,13 @@ func _on_cursor_position_text_changed(text: String) -> void:
 func _update_file_menu_buttons(project: Project) -> void:
 	if not is_instance_valid(file_menu):
 		return
-	var export_settings = project.export_settings
-	if export_settings.directory_path.is_empty():
+	var export_profile = project.export_profile
+	if export_profile.directory_path.is_empty():
 		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save"))
 	else:
-		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save") + " %s" % export_settings.file_name)
+		file_menu.set_item_text(Global.FileMenu.SAVE, tr("Save") + " %s" % export_profile.file_name)
 	if project.was_exported:
-		var f_name := " %s" % (project.file_name + Export.file_format_string(export_settings.file_format))
+		var f_name := " %s" % (project.file_name + Export.file_format_string(export_profile.file_format))
 		if project.export_overwrite:
 			file_menu.set_item_text(Global.FileMenu.EXPORT, tr("Overwrite") + f_name)
 		else:


### PR DESCRIPTION
Added an ExportProfile subclass in `Export` Autoload, each project has it's own copy of it and gets saved/loaded with the project. All export related variables have been moved to this sub-class

Testing is required (mostly just verification that i didn't miss something)

Supersedes PR: https://github.com/Orama-Interactive/Pixelorama/pull/1562
Fixes: https://github.com/Orama-Interactive/Pixelorama/issues/1503