### PR TITLE
Turn off redundant  flags for windows with  flag enabled

### DIFF
--- a/src/Preferences/PreferencesDialog.tscn
+++ b/src/Preferences/PreferencesDialog.tscn
@@ -1817,7 +1817,6 @@ text = "Pixelorama must be restarted for changes to take effect."
 mode = 1
 title = "Open File(s)"
 size = Vector2i(560, 400)
-always_on_top = true
 ok_button_text = "Open"
 file_mode = 1
 access = 2
@@ -1826,10 +1825,10 @@ show_hidden_files = true
 
 [node name="ExtensionExplorer" parent="." unique_id=523014809 instance=ExtResource("8_jmnx8")]
 transient = true
+always_on_top = false
 
 [node name="EnableExtensionConfirmation" type="ConfirmationDialog" parent="." unique_id=1187640624]
 unique_name_in_owner = true
-always_on_top = true
 dialog_text = "Are you sure you want to enable this extension? Make sure to only enable extensions from sources that you trust."
 dialog_autowrap = true
 
@@ -1837,13 +1836,11 @@ dialog_autowrap = true
 unique_name_in_owner = true
 position = Vector2i(0, 36)
 size = Vector2i(400, 100)
-always_on_top = true
 ok_button_text = "Delete Permanently"
 dialog_text = "Are you sure you want to delete this extension?"
 dialog_autowrap = true
 
 [node name="ResetOptionsConfirmation" type="ConfirmationDialog" parent="." unique_id=1646743103]
-always_on_top = true
 dialog_text = "Are you sure you want to reset the selected options? There will be no way to undo this."
 
 [connection signal="about_to_popup" from="." to="." method="_on_PreferencesDialog_about_to_show"]


### PR DESCRIPTION
Needed because of https://github.com/godotengine/godot/issues/117698.