### PR TITLE
Fix text applied by text tool not having correct transparent colors

### DIFF
--- a/src/Tools/UtilityTools/Text.gd
+++ b/src/Tools/UtilityTools/Text.gd
@@ -119,7 +119,9 @@ func text_to_pixels() -> void:
 
 	var undo_data := _get_undo_data()
 	var project := Global.current_project
-	var image := project.frames[project.current_frame].cels[project.current_layer].get_image()
+	var cel_image := project.frames[project.current_frame].cels[project.current_layer].get_image()
+	if cel_image == null:
+		return
 
 	var vp := RenderingServer.viewport_create()
 	var canvas := RenderingServer.canvas_create()
@@ -135,8 +137,6 @@ func text_to_pixels() -> void:
 	var ci_rid := RenderingServer.canvas_item_create()
 	RenderingServer.viewport_set_canvas_transform(vp, canvas, Transform2D())
 	RenderingServer.canvas_item_set_parent(ci_rid, canvas)
-	var texture := RenderingServer.texture_2d_create(image)
-	RenderingServer.canvas_item_add_texture_rect(ci_rid, Rect2(Vector2.ZERO, project.size), texture)
 	RenderingServer.canvas_item_set_material(ci_rid, NEW_CANVAS_ITEM_MATERIAL.get_rid())
 	var text := text_edit.text
 	var color := tool_slot.color
@@ -149,19 +149,20 @@ func text_to_pixels() -> void:
 
 	RenderingServer.viewport_set_update_mode(vp, RenderingServer.VIEWPORT_UPDATE_ONCE)
 	RenderingServer.force_draw(false)
-	var viewport_texture := RenderingServer.texture_2d_get(RenderingServer.viewport_get_texture(vp))
+	var viewport_image := RenderingServer.texture_2d_get(RenderingServer.viewport_get_texture(vp))
 	RenderingServer.free_rid(vp)
 	RenderingServer.free_rid(canvas)
 	RenderingServer.free_rid(ci_rid)
-	RenderingServer.free_rid(texture)
-	viewport_texture.convert(image.get_format())
+	viewport_image.convert(cel_image.get_format())
 
 	text_edit.queue_free()
 	text_edit = null
-	if not viewport_texture.is_empty():
-		image.copy_from(viewport_texture)
-		if image is ImageExtended:
-			image.convert_rgb_to_indexed()
+	if not viewport_image.is_empty():
+		cel_image.blend_rect(
+			viewport_image, Rect2i(Vector2i.ZERO, cel_image.get_size()), Vector2i.ZERO
+		)
+		if cel_image is ImageExtended:
+			cel_image.convert_rgb_to_indexed()
 		commit_undo("Draw", undo_data)
 
 


### PR DESCRIPTION
## What problem(s) does this PR solve, or what new features does it implement?
Fixes: https://github.com/Orama-Interactive/Pixelorama/issues/1556

## Additional information
Instead of rendering text directly on cel image, this PR does it on a separate image and then blends it with the cel's image. This makes godot auto resolve the Colors whose alpha was zero but had non-zero RGB components.

This Also ends up fixing the following issues as well:

- The original issue of colors bleeding in drop shadow
<img width="96" height="96" alt="3" src="https://github.com/user-attachments/assets/11c15264-68a2-4c9e-b5d5-d25295370f48" />

- Colors getting distorted when new text was written such that it overlapped with some previous text
<img width="96" height="96" alt="4" src="https://github.com/user-attachments/assets/fe19d732-9866-4be4-82e9-6bd0f663cd5f" />

- Boxes appeared in background of text when it was applied (similar to the issue on previous line)
<img width="96" height="96" alt="1" src="https://github.com/user-attachments/assets/37220077-2266-412a-9c5f-5e2bda284823" />

- Some transparent areas were not filled when bucket tool was applied after writing text on a new layer
<img width="96" height="96" alt="2" src="https://github.com/user-attachments/assets/1c8ca8d4-71c6-4e6e-9179-4b82cbc0e385" />


## Is this PR co-authored by generative AI/LLM?
No