### PR TITLE
A more powerful Index Map

### DIFF
--- a/src/Classes/AnimatableObject.gd
+++ b/src/Classes/AnimatableObject.gd
@@ -206,6 +206,11 @@ func deserialize(dict: Dictionary) -> void:
 		animated_params = str_to_var(dict["animated_params"])
 
 
+## preserves compatibility for name changes across different version.
+func is_param_valid(_param_name: StringName) -> bool:
+	return true
+
+
 ## Meant to be overridden by inherited classes, automatically calls it if keyframe is set
 func _on_keyframe_set(_param_name: String) -> void:
 	pass

--- a/src/Classes/LayerEffect.gd
+++ b/src/Classes/LayerEffect.gd
@@ -48,6 +48,14 @@ func deserialize(dict: Dictionary) -> void:
 	super(dict)
 
 
+func is_param_valid(param_name: StringName) -> bool:
+	var uniforms := shader.get_shader_uniform_list()
+	for uniform in uniforms:
+		if param_name == (uniform["name"] as String):
+			return true
+	return false
+
+
 func _set_params_from_shader() -> void:
 	if not is_instance_valid(shader):
 		return

--- a/src/Shaders/Effects/IndexMap.gdshader
+++ b/src/Shaders/Effects/IndexMap.gdshader
@@ -3,20 +3,40 @@ shader_type canvas_item;
 render_mode unshaded;
 
 uniform sampler2D map_texture : filter_nearest;  // The map texture
-uniform bool include_alpha = false;
+uniform ivec2 offset = ivec2(0); // Offset value for the lookup coordinates in pixels
+// If true, the aplha from the map colors are used as well.
+uniform bool use_pixel_position_for_transparent_colors = false;
+// If true, the aplha from the map colors are used as well.
+uniform bool import_alpha_values = false;
 
 // (begin DESCRIPTION)
-// The Red and Green values (0-255) of tool color will be treated as an x and y position
-// respectively instead of color components.
-// When you draw, color will be taken from the x-y position in the "Map Texture".
+// The Red and Green values (0-255) of your tool's color will be treated as coordinates X and Y
+// instead of as regular R and G color components.
+// When you draw, the X and Y components are looked up in the "Map Texture", and color at that
+// position in the Map Texture is displayed
+// If "Use pixel position for transparent colors" is enabled, then for transparent colors,
+// their "Canvas position" will be looked up in the "Map Texture" instead of the color.
+// Optionally you can also set some offset to the returned color i-e (X, Y) + Offset
+// If "Import alpha values" is enabled, the aplha from the "Map Texture's" color is used as well.
 // (end DESCRIPTION)
 void fragment() {
-	vec4 col = texture(TEXTURE, UV);
+	vec4 coordinate = texture(TEXTURE, UV);
+	vec2 image_size = vec2(textureSize(TEXTURE, 0));
+	bool should_import_alpha = import_alpha_values;
+	vec2 max_coordinate_vector = vec2(255.0, 255.0);
+	if (use_pixel_position_for_transparent_colors && COLOR.a < 0.0001) {
+		should_import_alpha = true;
+		coordinate = vec4(UV.r, UV.g, 0, 1);
+		max_coordinate_vector = image_size;
+	}
+
 	vec2 map_size = vec2(textureSize(map_texture, 0));
-	vec2 lookup_uv = vec2(round(col.x * 255.0)/(map_size.x), round(col.y * 255.0)/(map_size.y));
-	vec4 index_color = texture(map_texture, lookup_uv);
+	vec2 lookup_uv = (coordinate.xy * max_coordinate_vector) / (map_size);
+	vec2 offset_uv = vec2(offset) / map_size;
+
+	vec4 index_color = texture(map_texture, lookup_uv + offset_uv);
 	COLOR.rgb = index_color.rgb;
-	if (include_alpha) {
+	if (should_import_alpha) {
 		COLOR.a = index_color.a;
 	}
 }

--- a/src/Shaders/Effects/IndexMap.gdshader
+++ b/src/Shaders/Effects/IndexMap.gdshader
@@ -4,10 +4,11 @@ render_mode unshaded;
 
 uniform sampler2D map_texture : filter_nearest;  // The map texture
 uniform ivec2 offset = ivec2(0); // Offset value for the lookup coordinates in pixels
+uniform bool wrap_around = false; // Wraps the coordinates if offset causes them out of area.
 // If true, the aplha from the map colors are used as well.
 uniform bool use_pixel_position_for_transparent_colors = false;
 // If true, the aplha from the map colors are used as well.
-uniform bool import_alpha_values = false;
+uniform bool include_alpha = false;
 
 // (begin DESCRIPTION)
 // The Red and Green values (0-255) of your tool's color will be treated as coordinates X and Y
@@ -17,12 +18,12 @@ uniform bool import_alpha_values = false;
 // If "Use pixel position for transparent colors" is enabled, then for transparent colors,
 // their "Canvas position" will be looked up in the "Map Texture" instead of the color.
 // Optionally you can also set some offset to the returned color i-e (X, Y) + Offset
-// If "Import alpha values" is enabled, the aplha from the "Map Texture's" color is used as well.
+// If "Include alpha" is enabled, the aplha from the "Map Texture's" color is used as well.
 // (end DESCRIPTION)
 void fragment() {
 	vec4 coordinate = texture(TEXTURE, UV);
 	vec2 image_size = vec2(textureSize(TEXTURE, 0));
-	bool should_import_alpha = import_alpha_values;
+	bool should_import_alpha = include_alpha;
 	vec2 max_coordinate_vector = vec2(255.0, 255.0);
 	if (use_pixel_position_for_transparent_colors && COLOR.a < 0.0001) {
 		should_import_alpha = true;
@@ -31,10 +32,11 @@ void fragment() {
 	}
 
 	vec2 map_size = vec2(textureSize(map_texture, 0));
-	vec2 lookup_uv = (coordinate.xy * max_coordinate_vector) / (map_size);
-	vec2 offset_uv = vec2(offset) / map_size;
-
-	vec4 index_color = texture(map_texture, lookup_uv + offset_uv);
+	vec2 lookup_uv = ((coordinate.xy * max_coordinate_vector) + vec2(offset)) / (map_size);
+	if (wrap_around) {
+		lookup_uv = fract(lookup_uv);
+	}
+	vec4 index_color = texture(map_texture, lookup_uv);
 	COLOR.rgb = index_color.rgb;
 	if (should_import_alpha) {
 		COLOR.a = index_color.a;

--- a/src/Shaders/Effects/IndexMap.gdshader
+++ b/src/Shaders/Effects/IndexMap.gdshader
@@ -3,42 +3,72 @@ shader_type canvas_item;
 render_mode unshaded;
 
 uniform sampler2D map_texture : filter_nearest;  // The map texture
-uniform ivec2 offset = ivec2(0); // Offset value for the lookup coordinates in pixels
-uniform bool wrap_around = false; // Wraps the coordinates if offset causes them out of area.
-// If true, the alpha from the map colors are used as well.
-uniform bool use_pixel_position_for_transparent_colors = false;
-// If true, the alpha from the map colors are used as well.
-uniform bool include_alpha = false;
+uniform bool wrap_around = false;  // Wraps the coordinates if offset causes them out of area.
+uniform bool include_alpha = false;  // If true, the alpha from the map colors are used as well.
+uniform bool use_pixel_position_by_default = false;
+// When true shows the indices as colors.
+uniform bool show_intermediate_texture = false;
+uniform ivec2 offset = ivec2(0);  // Offset value for the lookup coordinates in pixels
+// Scale value for the lookup coordinates in multiples of map_texture size.
+uniform vec2 scale = vec2(1.0);
 
 // (begin DESCRIPTION)
 // The Red and Green values (0-255) of your tool's color will be treated as coordinates X and Y
 // instead of as regular R and G color components.
 // When you draw, the X and Y components are looked up in the "Map Texture", and color at that
 // position in the Map Texture is displayed
-// If "Use pixel position for transparent colors" is enabled, then for transparent colors,
+//
+// If "Use pixel position by default" is enabled, then for transparent colors,
 // their "Canvas position" will be looked up in the "Map Texture" instead of the color.
+//
 // Optionally you can also set some offset to the returned color i-e (X, Y) + Offset
+//
 // If "Include alpha" is enabled, the alpha from the "Map Texture's" color is used as well.
+//
+// "Show intermediate texture" returns the image with R and G components equal to the X and Y
+// coordinates of the color to be used for lookup (After applying all the offset/wrap/zoom
+// calculations). Note that This can currently only show X and Y coordinates that are less than 255.
 // (end DESCRIPTION)
 void fragment() {
 	vec4 coordinate = texture(TEXTURE, UV);
 	vec2 image_size = vec2(textureSize(TEXTURE, 0));
 	bool should_import_alpha = include_alpha;
-	vec2 max_coordinate_vector = vec2(255.0, 255.0);
-	if (use_pixel_position_for_transparent_colors && COLOR.a < 0.0001) {
+	vec2 anti_normalize_vector = vec2(255.0, 255.0);
+	if (use_pixel_position_by_default && COLOR.a < 0.0001) {
 		should_import_alpha = true;
 		coordinate = vec4(UV.r, UV.g, 0, 1);
-		max_coordinate_vector = image_size;
+		anti_normalize_vector = image_size;
 	}
 
 	vec2 map_size = vec2(textureSize(map_texture, 0));
-	vec2 lookup_uv = ((coordinate.xy * max_coordinate_vector) + vec2(offset)) / (map_size);
+	vec2 offset_lookup_uv = ((coordinate.rg * anti_normalize_vector) + vec2(offset)) / map_size;
+	vec2 zoomed_lookup_uv = ((offset_lookup_uv - vec2(0.5)) / scale) + vec2(0.5);
 	if (wrap_around) {
-		lookup_uv = fract(lookup_uv);
+		zoomed_lookup_uv = fract(zoomed_lookup_uv);
 	}
-	vec4 index_color = texture(map_texture, lookup_uv);
-	COLOR.rgb = index_color.rgb;
-	if (should_import_alpha) {
-		COLOR.a = index_color.a;
+	if (show_intermediate_texture) {
+		// While we can still do computations for numbers greater than 255 like when
+		// use_pixel_position_by_default is true, But for previewing, using
+		// Color as X, Y places a limitation that we can not display indices greater than 255.
+		vec2 lookup_coord_normalized = (zoomed_lookup_uv * map_size) / vec2(255.0, 255.0);
+		COLOR.rgb = vec3(lookup_coord_normalized.x, lookup_coord_normalized.y, 0.0);
+		if (use_pixel_position_by_default && COLOR.a < 0.0001) {
+			COLOR.a = 1.0;
+		}
+		if (
+			lookup_coord_normalized.x < 0.0
+			|| lookup_coord_normalized.x > 1.0
+			|| lookup_coord_normalized.y < 0.0
+			|| lookup_coord_normalized.y > 1.0
+		) {
+			COLOR.rgba = vec4(0.0, 0.0, 0.0, 0.0);
+		}
+	}
+	else {
+		vec4 index_color = texture(map_texture, zoomed_lookup_uv);
+		COLOR.rgb = index_color.rgb;
+		if (should_import_alpha) {
+			COLOR.a = index_color.a;
+		}
 	}
 }

--- a/src/Shaders/Effects/IndexMap.gdshader
+++ b/src/Shaders/Effects/IndexMap.gdshader
@@ -5,9 +5,9 @@ render_mode unshaded;
 uniform sampler2D map_texture : filter_nearest;  // The map texture
 uniform ivec2 offset = ivec2(0); // Offset value for the lookup coordinates in pixels
 uniform bool wrap_around = false; // Wraps the coordinates if offset causes them out of area.
-// If true, the aplha from the map colors are used as well.
+// If true, the alpha from the map colors are used as well.
 uniform bool use_pixel_position_for_transparent_colors = false;
-// If true, the aplha from the map colors are used as well.
+// If true, the alpha from the map colors are used as well.
 uniform bool include_alpha = false;
 
 // (begin DESCRIPTION)
@@ -18,7 +18,7 @@ uniform bool include_alpha = false;
 // If "Use pixel position for transparent colors" is enabled, then for transparent colors,
 // their "Canvas position" will be looked up in the "Map Texture" instead of the color.
 // Optionally you can also set some offset to the returned color i-e (X, Y) + Offset
-// If "Include alpha" is enabled, the aplha from the "Map Texture's" color is used as well.
+// If "Include alpha" is enabled, the alpha from the "Map Texture's" color is used as well.
 // (end DESCRIPTION)
 void fragment() {
 	vec4 coordinate = texture(TEXTURE, UV);

--- a/src/Shaders/Effects/IndexMap.gdshader
+++ b/src/Shaders/Effects/IndexMap.gdshader
@@ -41,8 +41,10 @@ void fragment() {
 	}
 
 	vec2 map_size = vec2(textureSize(map_texture, 0));
-	vec2 offset_lookup_uv = ((coordinate.rg * anti_normalize_vector) + vec2(offset)) / map_size;
-	vec2 zoomed_lookup_uv = ((offset_lookup_uv - vec2(0.5)) / scale) + vec2(0.5);
+	vec2 offset_lookup_uv = ((coordinate.rg * anti_normalize_vector) - vec2(offset)) / map_size;
+
+	vec2 zoom_center = (vec2(0.5) * (image_size / map_size)) - (vec2(offset) / map_size);
+	vec2 zoomed_lookup_uv = ((offset_lookup_uv - zoom_center) / scale) + zoom_center;
 	if (wrap_around) {
 		zoomed_lookup_uv = fract(zoomed_lookup_uv);
 	}

--- a/src/UI/Timeline/KeyframeTimeline/KeyframeTimeline.gd
+++ b/src/UI/Timeline/KeyframeTimeline/KeyframeTimeline.gd
@@ -136,6 +136,8 @@ func recreate_timeline() -> void:
 			effect.name, KeyframeAnimationTrack.TrackTypes.LAYER_EFFECT, layer_item
 		)
 		for param_name in effect.params:
+			if not effect.is_param_valid(param_name):
+				continue
 			if param_name in ["PXO_time", "PXO_frame_index", "PXO_layer_index"]:
 				continue
 			var value = effect.params[param_name]


### PR DESCRIPTION
## What problem(s) does this PR solve, or what new features does it implement?
This PR adds more features to the Index map effect that are now possible due to the key frame timeline.
- Added a `Use pixel position for transparent colors`. When enabled, Index map effect uses the "Canvas position" for look up in "Map Texture" instead of the R,G values of the color.
- You can now wrap the coordinates if offset causes them out of Map texture's area.
- You can now also set some offset to the look up coordinates i-e (X, Y) + Offset.
- Scaling can also be gone using the index map.
- Added a checkbox that stops the process at the intermediate stage and returns the image with R and G components equal to the X and Y coordinates of the color to be used for lookup (After applying all the offset/wrap/zoom calculations). This is meant to be used in cases where we want to use the index map and not want to draw indices by hand.

## Video
https://github.com/user-attachments/assets/5373bfb1-5ec6-40b8-9d54-59a36073be9e

## Demo Project
[Demo.zip](https://github.com/user-attachments/files/31037235/Demo.zip)


## Is this PR co-authored by generative AI/LLM?
No

## Status: Ready for review