### PR TITLE
Allow smoothly moving values when sliding even when the bounds have reached.

### DIFF
--- a/src/UI/Nodes/Sliders/ValueSlider.gd
+++ b/src/UI/Nodes/Sliders/ValueSlider.gd
@@ -187,7 +187,12 @@ func _gui_input(event: InputEvent) -> void:
 			if event.shift_pressed:
 				x_delta *= 0.1
 			if show_progress:
-				ratio = get_meta("start_ratio") + x_delta / size.x
+				# NOTE: changing ratio can only happen between [0,1]. We need to increment value
+				# even when the bounds have reached
+				var new_ratio: float = get_meta("start_ratio") + x_delta / size.x
+				value = (
+					_start_value + (max_value - min_value) * (new_ratio - get_meta("start_ratio"))
+				)
 			else:
 				value = _start_value + x_delta * step
 			# Snap when snap_by_default is true, do the opposite when Control is pressed


### PR DESCRIPTION
## What problem(s) does this PR solve, or what new features does it implement?
One of the pain points for me regarding value sliders is that they are very limiting after the bounds are reached. YES i can manually type in greater or smaller numbers but it's very destructive and slow to workflow (Especially when setting negative values for vector2 and vector3 sliders in shader fx).

The solution i have come up with is to allow sliders to behave like how it is handles in blender. The slider is now still responsive to dragging even when the bar has reached bounds. For cases when users want to immediately move to a smaller value they would have to type the value in the slider or drag it back, but the benefits in return is well worth it.

## Is this PR co-authored by generative AI/LLM?
No