### PR TITLE
Use _unhandled_input for tool switching

### DIFF
--- a/src/Autoload/Tools.gd
+++ b/src/Autoload/Tools.gd
@@ -685,7 +685,7 @@ func is_placing_tiles() -> bool:
 	return Global.current_project.get_current_cel() is CelTileMap and TileSetPanel.placing_tiles
 
 
-func has_selection_tool() -> bool:
+func selection_tool_has_selection() -> bool:
 	if not Global.current_project.has_selection:
 		return false
 	for mouse_button in _slots:

--- a/src/Tools/BaseSelectionTool.gd
+++ b/src/Tools/BaseSelectionTool.gd
@@ -45,9 +45,9 @@ func _ready() -> void:
 
 
 func set_confirm_buttons_visibility() -> void:
+	await get_tree().process_frame
 	if not is_inside_tree():
 		return
-	await get_tree().process_frame
 	set_spinbox_values()
 	get_tree().set_group(
 		&"ShowOnActiveTransformation", "visible", transformation_handles.is_transforming()

--- a/src/Tools/BaseShapeDrawer.gd
+++ b/src/Tools/BaseShapeDrawer.gd
@@ -61,8 +61,10 @@ func _input(event: InputEvent) -> void:
 	if _drawing:
 		if event.is_action_pressed("shape_displace"):
 			_displace_origin = true
+			get_viewport().set_input_as_handled()
 		elif event.is_action_released("shape_displace"):
 			_displace_origin = false
+			get_viewport().set_input_as_handled()
 	else:
 		super(event)
 

--- a/src/Tools/DesignTools/IsometricBoxTool.gd
+++ b/src/Tools/DesignTools/IsometricBoxTool.gd
@@ -146,6 +146,7 @@ func _create_brush_indicator() -> BitMap:
 func _input(event: InputEvent) -> void:
 	if _drawing:
 		if event.is_action_pressed("change_tool_mode"):
+			get_viewport().set_input_as_handled()
 			if _control_pts.size() > 0:
 				_current_state -= 1
 				_control_pts.resize(_control_pts.size() - 1)
@@ -167,6 +168,7 @@ func cursor_move(pos: Vector2i) -> void:
 		pos.x = Global.current_project.size.x - pos.x - 1
 	if _drawing:
 		if Input.is_action_pressed("shape_displace"):
+			get_viewport().set_input_as_handled()
 			_origin += pos - _last_pixel
 			for i in _control_pts.size():
 				_control_pts[i] = _control_pts[i] + pos - _last_pixel

--- a/src/Tools/DesignTools/LineTool.gd
+++ b/src/Tools/DesignTools/LineTool.gd
@@ -34,8 +34,10 @@ func _input(event: InputEvent) -> void:
 	if _drawing:
 		if event.is_action_pressed("shape_displace"):
 			_displace_origin = true
+			get_viewport().set_input_as_handled()
 		elif event.is_action_released("shape_displace"):
 			_displace_origin = false
+			get_viewport().set_input_as_handled()
 	else:
 		super(event)
 

--- a/src/Tools/SelectionTools/RectSelect.gd
+++ b/src/Tools/SelectionTools/RectSelect.gd
@@ -11,16 +11,22 @@ func _input(event: InputEvent) -> void:
 	if !_move and _rect.has_area():
 		if event.is_action_pressed("shape_perfect"):
 			_square = true
+			get_viewport().set_input_as_handled()
 		elif event.is_action_released("shape_perfect"):
 			_square = false
+			get_viewport().set_input_as_handled()
 		if event.is_action_pressed("shape_center"):
 			_expand_from_center = true
+			get_viewport().set_input_as_handled()
 		elif event.is_action_released("shape_center"):
 			_expand_from_center = false
+			get_viewport().set_input_as_handled()
 		if event.is_action_pressed("shape_displace"):
 			_displace_origin = true
+			get_viewport().set_input_as_handled()
 		elif event.is_action_released("shape_displace"):
 			_displace_origin = false
+			get_viewport().set_input_as_handled()
 
 
 func draw_move(pos: Vector2i) -> void:

--- a/src/UI/Canvas/CanvasCamera.gd
+++ b/src/UI/Canvas/CanvasCamera.gd
@@ -97,7 +97,11 @@ func _input(event: InputEvent) -> void:
 	else:
 		var dir := Input.get_vector(&"camera_left", &"camera_right", &"camera_up", &"camera_down")
 		var root := get_tree().current_scene
-		if dir != Vector2.ZERO and not Tools.has_selection_tool() and not root.is_writing_text:
+		if (
+			dir != Vector2.ZERO
+			and not Tools.selection_tool_has_selection()
+			and not root.is_writing_text
+		):
 			offset = offset + (dir.rotated(camera_angle) / zoom) * CAMERA_SPEED_RATE
 
 

--- a/src/UI/Canvas/TransformationHandles.gd
+++ b/src/UI/Canvas/TransformationHandles.gd
@@ -113,7 +113,7 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
-	if not Tools.has_selection_tool():
+	if not Tools.selection_tool_has_selection():
 		return
 	var project := Global.current_project
 	if not project.layers[project.current_layer].can_layer_get_drawn():
@@ -166,7 +166,7 @@ func _draw() -> void:
 		var preview_color := Color(1, 1, 1, Global.transformation_preview_alpha)
 		draw_texture(image_texture, Vector2.ZERO, preview_color)
 	draw_set_transform(position_tmp, rotation, scale_tmp)
-	if not Tools.has_selection_tool():
+	if not Tools.selection_tool_has_selection():
 		return
 	# Draw handles
 	for handle in handles:

--- a/src/UI/Nodes/Sliders/ValueSlider.gd
+++ b/src/UI/Nodes/Sliders/ValueSlider.gd
@@ -187,7 +187,12 @@ func _gui_input(event: InputEvent) -> void:
 			if event.shift_pressed:
 				x_delta *= 0.1
 			if show_progress:
-				ratio = get_meta("start_ratio") + x_delta / size.x
+				# NOTE: changing ratio can only happen between [0,1]. We need to increment value
+				# even when the bounds have reached
+				var new_ratio: float = get_meta("start_ratio") + x_delta / size.x
+				value = (
+					_start_value + (max_value - min_value) * (new_ratio - get_meta("start_ratio"))
+				)
 			else:
 				value = _start_value + x_delta * step
 			# Snap when snap_by_default is true, do the opposite when Control is pressed

--- a/src/UI/Nodes/Sliders/ValueSlider.gd
+++ b/src/UI/Nodes/Sliders/ValueSlider.gd
@@ -187,12 +187,7 @@ func _gui_input(event: InputEvent) -> void:
 			if event.shift_pressed:
 				x_delta *= 0.1
 			if show_progress:
-				# NOTE: changing ratio can only happen between [0,1]. We need to increment value
-				# even when the bounds have reached
-				var new_ratio: float = get_meta("start_ratio") + x_delta / size.x
-				value = (
-					_start_value + (max_value - min_value) * (new_ratio - get_meta("start_ratio"))
-				)
+				ratio = get_meta("start_ratio") + x_delta / size.x
 			else:
 				value = _start_value + x_delta * step
 			# Snap when snap_by_default is true, do the opposite when Control is pressed

--- a/src/UI/ToolsPanel/ToolButtons.gd
+++ b/src/UI/ToolsPanel/ToolButtons.gd
@@ -35,7 +35,7 @@ func _unhandled_input(event: InputEvent) -> void:
 				return
 
 		var quick_tool_shortcut := "quick_" + t.shortcut + "_tool"
-		if InputMap.has_action(quick_tool_shortcut) and not Tools.has_selection_tool():
+		if InputMap.has_action(quick_tool_shortcut) and not Tools.selection_tool_has_selection():
 			if event.is_action_pressed(quick_tool_shortcut, false, true) and not tool_activated:
 				Tools.quick_assign_tool(t.name, MOUSE_BUTTON_LEFT)
 				Tools.quick_assign_tool(t.name, MOUSE_BUTTON_RIGHT)

--- a/src/UI/ToolsPanel/ToolButtons.gd
+++ b/src/UI/ToolsPanel/ToolButtons.gd
@@ -3,7 +3,7 @@ extends FlowContainer
 var pen_inverted := false
 
 
-func _input(event: InputEvent) -> void:
+func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
 		pen_inverted = event.pen_inverted
 		return
@@ -13,11 +13,7 @@ func _input(event: InputEvent) -> void:
 		return
 	if get_tree().current_scene.is_writing_text:
 		return
-	var tool_activated := (
-		Input.is_action_pressed(&"activate_left_tool")
-		or Input.is_action_pressed(&"activate_right_tool")
-		or Tools.active_multi_state_tools > 0
-	)
+	var tool_activated := Tools.active_multi_state_tools > 0
 
 	for tool_name in Tools.tools:  # Handle tool shortcuts
 		if not get_node(tool_name).visible:


### PR DESCRIPTION
## What problem(s) does this PR solve, or what new features does it implement?

Fixes https://github.com/Orama-Interactive/Pixelorama/issues/1581, instead of using `Input.is_action_pressed(&"activate_left_tool")` and `Input.is_action_pressed(&"activate_right_tool")` to see if tool is being used it now only gets called when the shortcut for the quick tool does not conflict with any `shape_perfect, shape_center, shape_displace` shortcuts.

The original method was mainly to prevent color picker getting selected when we were pressing Alt, this new method does the same thing in essence

## Is this PR co-authored by generative AI/LLM?
No