### PR TITLE
integer zoom now zooms exponentially like the normal zoom

### DIFF
--- a/src/UI/Canvas/CanvasCamera.gd
+++ b/src/UI/Canvas/CanvasCamera.gd
@@ -115,7 +115,10 @@ func zoom_camera(dir: float, event_pos := mouse_pos) -> void:
 		var zoom_margin := zoom * dir / 5
 		var new_zoom := zoom + zoom_margin
 		if Global.integer_zoom:
-			new_zoom = (zoom + Vector2.ONE * dir).floor()
+			if dir < 0:
+				new_zoom = new_zoom.floor()
+			else:
+				new_zoom = new_zoom.ceil()
 		if new_zoom < zoom_in_max && new_zoom > zoom_out_max:
 			var new_offset := (
 				offset
@@ -131,10 +134,13 @@ func zoom_camera(dir: float, event_pos := mouse_pos) -> void:
 	else:
 		var prev_zoom := zoom
 		var zoom_margin := zoom * dir / 10
-		if Global.integer_zoom:
-			zoom_margin = (Vector2.ONE * dir).floor()
 		if zoom + zoom_margin <= zoom_in_max:
 			zoom += zoom_margin
+		if Global.integer_zoom:
+			if dir < 0:
+				zoom = zoom.floor()
+			else:
+				zoom = zoom.ceil()
 		if zoom < zoom_out_max:
 			if Global.integer_zoom:
 				zoom = Vector2.ONE


### PR DESCRIPTION
## What problem(s) does this PR solve, or what new features does it implement?
Implements #1592. In current implementation the integer zoom mode appeared to be slower the more you zoomed in, this fixes that issue and the zoom feels more natural.

### Before

https://github.com/user-attachments/assets/ade88c2f-606b-4fe9-8a66-7d1a9f3becf1

### After

https://github.com/user-attachments/assets/e748c2c0-27c9-4f96-b58e-04327c05ca50

## Q&A
### Won't this skip over many zoom values that user might need?
Short answer is no. It does skip values but they are mostly those that users will likely never need. for example user definitely needs zooms like 100% 200% --- 1000%. What they likely never need is zoom like `12400%`, `12500%` `12600%` `12700%` (They all look similar and can be skipped and just show one of them, then move on). Users can still type zoom levels if they want extra precision

## Is this PR co-authored by generative AI/LLM?
No